### PR TITLE
Change operator structure

### DIFF
--- a/api/fbs/v1/query.fbs
+++ b/api/fbs/v1/query.fbs
@@ -19,8 +19,11 @@ include "database.fbs";
 
 namespace banyandb.v1;
 
-// BinaryOp specify the operation imposed to the given query condition
-enum BinaryOp: byte {
+// BinaryOp specifies the operation imposed to the given query condition
+// For EQ, NE, LT, GT, LE and GE, only one operand should be given, i.e. one-to-one relationship.
+// HAVING and NOT_HAVING allow multi-value to be the operand such as array/vector, i.e. one-to-many relationship.
+// For example, "keyA" contains "valueA" **and** "valueB"
+enum BinaryOp : byte {
     EQ,
     NE,
     LT,
@@ -29,11 +32,6 @@ enum BinaryOp: byte {
     GE,
     HAVING,
     NOT_HAVING
-}
-
-// BinaryOps is an array of binary operators.
-table BinaryOps {
-    ops: [BinaryOp];
 }
 
 // IntPair in a typed pair with an array of int64 as values
@@ -59,9 +57,11 @@ table Pair {
     pair: TypedPair;
 }
 
-// PairQuery consists of the query condition with a binary operator to be imposed
+// PairQuery consists of the query condition with a single binary operator to be imposed
+// For 1:1 BinaryOp, values in condition must be an array with length = 1,
+// while for 1:N BinaryOp, values can be an array with length >= 1.
 table PairQuery {
-    ops: BinaryOps;
+    op: BinaryOp;
     condition: Pair;
 }
 

--- a/api/fbs/v1/query_generated.go
+++ b/api/fbs/v1/query_generated.go
@@ -118,72 +118,6 @@ func (v Sort) String() string {
 	return "Sort(" + strconv.FormatInt(int64(v), 10) + ")"
 }
 
-type BinaryOps struct {
-	_tab flatbuffers.Table
-}
-
-func GetRootAsBinaryOps(buf []byte, offset flatbuffers.UOffsetT) *BinaryOps {
-	n := flatbuffers.GetUOffsetT(buf[offset:])
-	x := &BinaryOps{}
-	x.Init(buf, n+offset)
-	return x
-}
-
-func GetSizePrefixedRootAsBinaryOps(buf []byte, offset flatbuffers.UOffsetT) *BinaryOps {
-	n := flatbuffers.GetUOffsetT(buf[offset+flatbuffers.SizeUint32:])
-	x := &BinaryOps{}
-	x.Init(buf, n+offset+flatbuffers.SizeUint32)
-	return x
-}
-
-func (rcv *BinaryOps) Init(buf []byte, i flatbuffers.UOffsetT) {
-	rcv._tab.Bytes = buf
-	rcv._tab.Pos = i
-}
-
-func (rcv *BinaryOps) Table() flatbuffers.Table {
-	return rcv._tab
-}
-
-func (rcv *BinaryOps) Ops(j int) BinaryOp {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
-	if o != 0 {
-		a := rcv._tab.Vector(o)
-		return BinaryOp(rcv._tab.GetInt8(a + flatbuffers.UOffsetT(j*1)))
-	}
-	return 0
-}
-
-func (rcv *BinaryOps) OpsLength() int {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
-	if o != 0 {
-		return rcv._tab.VectorLen(o)
-	}
-	return 0
-}
-
-func (rcv *BinaryOps) MutateOps(j int, n BinaryOp) bool {
-	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
-	if o != 0 {
-		a := rcv._tab.Vector(o)
-		return rcv._tab.MutateInt8(a+flatbuffers.UOffsetT(j*1), int8(n))
-	}
-	return false
-}
-
-func BinaryOpsStart(builder *flatbuffers.Builder) {
-	builder.StartObject(1)
-}
-func BinaryOpsAddOps(builder *flatbuffers.Builder, ops flatbuffers.UOffsetT) {
-	builder.PrependUOffsetTSlot(0, flatbuffers.UOffsetT(ops), 0)
-}
-func BinaryOpsStartOpsVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
-	return builder.StartVector(1, numElems, 1)
-}
-func BinaryOpsEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
-	return builder.EndObject()
-}
-
 type IntPair struct {
 	_tab flatbuffers.Table
 }
@@ -417,17 +351,16 @@ func (rcv *PairQuery) Table() flatbuffers.Table {
 	return rcv._tab
 }
 
-func (rcv *PairQuery) Ops(obj *BinaryOps) *BinaryOps {
+func (rcv *PairQuery) Op() BinaryOp {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
 	if o != 0 {
-		x := rcv._tab.Indirect(o + rcv._tab.Pos)
-		if obj == nil {
-			obj = new(BinaryOps)
-		}
-		obj.Init(rcv._tab.Bytes, x)
-		return obj
+		return BinaryOp(rcv._tab.GetInt8(o + rcv._tab.Pos))
 	}
-	return nil
+	return 0
+}
+
+func (rcv *PairQuery) MutateOp(n BinaryOp) bool {
+	return rcv._tab.MutateInt8Slot(4, int8(n))
 }
 
 func (rcv *PairQuery) Condition(obj *Pair) *Pair {
@@ -446,8 +379,8 @@ func (rcv *PairQuery) Condition(obj *Pair) *Pair {
 func PairQueryStart(builder *flatbuffers.Builder) {
 	builder.StartObject(2)
 }
-func PairQueryAddOps(builder *flatbuffers.Builder, ops flatbuffers.UOffsetT) {
-	builder.PrependUOffsetTSlot(0, flatbuffers.UOffsetT(ops), 0)
+func PairQueryAddOp(builder *flatbuffers.Builder, op BinaryOp) {
+	builder.PrependInt8Slot(0, int8(op), 0)
 }
 func PairQueryAddCondition(builder *flatbuffers.Builder, condition flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(1, flatbuffers.UOffsetT(condition), 0)


### PR DESCRIPTION
## Motivation

As we've discussed this morning, in order to eliminate ambiguity of relationship between key and values in `PairQuery`, I would like to change the structure of `PairQuery` to only allow a single operator in `PairQuery`.

## Design

Rather than put multiple operators and values in one `PairQuery`, we may use the following methodology to compose conditional query,

- Range operation can be implemented by submitting two conditions, i.e. `[{key: duration, op: GT, values: [minValue]}, {key: duration, op: LE, values: [maxValue]}]`
- Having: a single condition `{key: peer.services, op: HAVING, values: [1,2,3]}`
- Composite indexes: For example, in order to make composite index “colA-colB-colC-colD” work, all four columns should be required, i.e. colA, colB and colC must not be skipped and only the condition for the rightmost column may not be EQUAL. `[{key: colA, op: EQ, values: [valA]}, {key: colB, op: EQ, values: [valB]}], {key: colC, op: EQ, values: [valC], {key: colD, op: EQ, values: [valD]}}`

Following the idea, the Query module should be able to 
1. merge operations for the same key, 
2. decide whether any composite index can be made use of and then choose the most suitable and restrictive one to improve performance.

In the future, we may also support HINT to force the query module to use some indexes.

## Alternatives

Use `Union of Enums`, but it is not supported by FlatBuffers. See issue https://github.com/google/flatbuffers/issues/5791
