### PR TITLE
Process query from liaison

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ release: default  ## Build the release artifacts for all projects, usually the s
 ##@ Test targets
 
 test: TARGET=test
+test: PROJECTS:=$(PROJECTS) pkg
 test: default          ## Run the unit tests in all projects
 
 test-race: TARGET=test-race

--- a/api/event/query.go
+++ b/api/event/query.go
@@ -1,0 +1,14 @@
+package event
+
+import (
+	"github.com/apache/skywalking-banyandb/api/common"
+	"github.com/apache/skywalking-banyandb/pkg/bus"
+)
+
+var (
+	QueryEventKindVersion = common.KindVersion{
+		Version: "v1",
+		Kind:    "event-query",
+	}
+	TopicQueryEvent = bus.UniTopic(QueryEventKindVersion.String())
+)

--- a/api/event/query.go
+++ b/api/event/query.go
@@ -1,3 +1,20 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package event
 
 import (

--- a/api/event/query.go
+++ b/api/event/query.go
@@ -10,5 +10,7 @@ var (
 		Version: "v1",
 		Kind:    "event-query",
 	}
-	TopicQueryEvent = bus.UniTopic(QueryEventKindVersion.String())
+	// TopicQueryEvent is a bidirectional topic for request/response communication
+	// between Liaison and Query module
+	TopicQueryEvent = bus.BiTopic(QueryEventKindVersion.String())
 )

--- a/banyand/index/index.go
+++ b/banyand/index/index.go
@@ -15,7 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//go:generate mockgen -destination=./index_mock.go -package=index . Repo
 package index
 
 import (
@@ -35,8 +34,9 @@ type Condition struct {
 	Op     apiv1.PairQuery_BinaryOp
 }
 
+//go:generate mockgen -destination=./index_mock.go -package=index . Repo
 type Repo interface {
-	Search(series common.Metadata, shardID uint, startTime, endTime uint64, conditions []Condition) (posting.List, error)
+	Search(seriesMeta common.Metadata, shardID uint, startTime, endTime uint64, indexObjectName string, conditions []Condition) (posting.List, error)
 }
 
 type Builder interface {

--- a/banyand/internal/cmd/standalone.go
+++ b/banyand/internal/cmd/standalone.go
@@ -65,7 +65,7 @@ func newStandaloneCmd() *cobra.Command {
 	if err != nil {
 		l.Fatal().Err(err).Msg("failed to initiate trace series")
 	}
-	q, err := query.NewExecutor(ctx, idx, traceSeries)
+	q, err := query.NewExecutor(ctx, idx, traceSeries, traceSeries)
 	if err != nil {
 		l.Fatal().Err(err).Msg("failed to initiate query executor")
 	}

--- a/banyand/internal/cmd/standalone.go
+++ b/banyand/internal/cmd/standalone.go
@@ -65,7 +65,7 @@ func newStandaloneCmd() *cobra.Command {
 	if err != nil {
 		l.Fatal().Err(err).Msg("failed to initiate trace series")
 	}
-	q, err := query.NewExecutor(ctx, idx, traceSeries, traceSeries)
+	q, err := query.NewExecutor(ctx, repo, idx, traceSeries, traceSeries)
 	if err != nil {
 		l.Fatal().Err(err).Msg("failed to initiate query executor")
 	}

--- a/banyand/query/processor.go
+++ b/banyand/query/processor.go
@@ -1,0 +1,73 @@
+package query
+
+import (
+	"context"
+	"github.com/apache/skywalking-banyandb/pkg/query/executor"
+	"time"
+
+	"github.com/apache/skywalking-banyandb/api/common"
+	"github.com/apache/skywalking-banyandb/api/event"
+	v1 "github.com/apache/skywalking-banyandb/api/fbs/v1"
+	apischema "github.com/apache/skywalking-banyandb/api/schema"
+	"github.com/apache/skywalking-banyandb/pkg/bus"
+	"github.com/apache/skywalking-banyandb/pkg/logger"
+	"github.com/apache/skywalking-banyandb/pkg/query/logical"
+)
+
+const (
+	moduleName = "query-processor"
+)
+
+var _ Executor = (*queryProcessor)(nil)
+var _ bus.MessageListener = (*queryProcessor)(nil)
+
+type queryProcessor struct {
+	executor.ExecutionContext
+	log     *logger.Logger
+	stopCh  chan struct{}
+	liaison bus.Subscriber
+}
+
+func (q *queryProcessor) Rev(message bus.Message) (resp bus.Message) {
+	data, ok := message.Data().([]byte)
+	if !ok {
+		q.log.Warn().Msg("invalid event data type")
+		return
+	}
+	queryCriteria := v1.GetRootAsEntityCriteria(data, 0)
+	q.log.Info().
+		Msg("received a query event")
+	analyzer := logical.DefaultAnalyzer()
+	metadata := &common.Metadata{
+		KindVersion: apischema.SeriesKindVersion,
+		Spec:        queryCriteria.Metadata(nil),
+	}
+	s, err := analyzer.BuildTraceSchema(context.TODO(), *metadata)
+	if err != nil {
+		return
+	}
+
+	p, err := analyzer.Analyze(context.TODO(), queryCriteria, metadata, s)
+	if err != nil {
+		return
+	}
+
+	entities, err := p.Execute(q)
+	if err != nil {
+		return
+	}
+
+	now := time.Now().UnixNano()
+	resp = bus.NewMessage(bus.MessageID(now), entities)
+
+	return
+}
+
+func (q *queryProcessor) Name() string {
+	return moduleName
+}
+
+func (q *queryProcessor) PreRun() error {
+	q.log = logger.GetLogger(moduleName)
+	return q.liaison.Subscribe(event.TopicShardEvent, q)
+}

--- a/banyand/query/processor.go
+++ b/banyand/query/processor.go
@@ -47,6 +47,7 @@ var (
 type queryProcessor struct {
 	index.Repo
 	series.UniModel
+	logger      *logger.Logger
 	schemaRepo  series.SchemaRepo
 	log         *logger.Logger
 	serviceRepo discovery.ServiceRepo
@@ -67,16 +68,19 @@ func (q *queryProcessor) Rev(message bus.Message) (resp bus.Message) {
 	}
 	s, err := analyzer.BuildTraceSchema(context.TODO(), *metadata)
 	if err != nil {
+		q.logger.Error().Err(err).Msg("fail to build trace schema")
 		return
 	}
 
 	p, err := analyzer.Analyze(context.TODO(), queryCriteria, metadata, s)
 	if err != nil {
+		q.logger.Error().Err(err).Msg("fail to analyze the query request")
 		return
 	}
 
 	entities, err := p.Execute(q)
 	if err != nil {
+		q.logger.Error().Err(err).Msg("fail to execute the query plan")
 		return
 	}
 

--- a/banyand/query/processor.go
+++ b/banyand/query/processor.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/apache/skywalking-banyandb/api/common"
 	"github.com/apache/skywalking-banyandb/api/event"
-	v1 "github.com/apache/skywalking-banyandb/api/fbs/v1"
+	v1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/v1"
 	apischema "github.com/apache/skywalking-banyandb/api/schema"
 	"github.com/apache/skywalking-banyandb/banyand/discovery"
 	"github.com/apache/skywalking-banyandb/banyand/index"
@@ -53,17 +53,17 @@ type queryProcessor struct {
 }
 
 func (q *queryProcessor) Rev(message bus.Message) (resp bus.Message) {
-	queryCriteria, ok := message.Data().(*v1.EntityCriteria)
+	queryCriteria, ok := message.Data().(*v1.QueryRequest)
 	if !ok {
 		q.log.Warn().Msg("invalid event data type")
 		return
 	}
 	q.log.Info().
 		Msg("received a query event")
-	analyzer := logical.NewAnalyzer(q.schemaRepo)
+	analyzer := logical.DefaultAnalyzer()
 	metadata := &common.Metadata{
 		KindVersion: apischema.SeriesKindVersion,
-		Spec:        queryCriteria.Metadata(nil),
+		Spec:        queryCriteria.GetMetadata(),
 	}
 	s, err := analyzer.BuildTraceSchema(context.TODO(), *metadata)
 	if err != nil {

--- a/banyand/query/processor.go
+++ b/banyand/query/processor.go
@@ -1,3 +1,20 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package query
 
 import (

--- a/banyand/query/processor_test.go
+++ b/banyand/query/processor_test.go
@@ -62,7 +62,7 @@ func setupServices(tester *require.Assertions) (discovery.ServiceRepo, series.Se
 	tester.NotNil(repo)
 
 	// Init `Database` module
-	db, err := storage.gNewDB(context.TODO(), repo)
+	db, err := storage.NewDB(context.TODO(), repo)
 	tester.NoError(err)
 	uuid, err := googleUUID.NewUUID()
 	tester.NoError(err)

--- a/banyand/query/processor_test.go
+++ b/banyand/query/processor_test.go
@@ -25,13 +25,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/apache/skywalking-banyandb/api/event"
-	v1 "github.com/apache/skywalking-banyandb/api/fbs/v1"
+	v1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/v1"
 	"github.com/apache/skywalking-banyandb/banyand/discovery"
 	"github.com/apache/skywalking-banyandb/banyand/series/trace"
 	"github.com/apache/skywalking-banyandb/banyand/storage"
 	"github.com/apache/skywalking-banyandb/pkg/bus"
-	"github.com/apache/skywalking-banyandb/pkg/fb"
 	"github.com/apache/skywalking-banyandb/pkg/logger"
+	"github.com/apache/skywalking-banyandb/pkg/pb"
 )
 
 func TestQueryProcessor(t *testing.T) {
@@ -76,20 +76,19 @@ func TestQueryProcessor(t *testing.T) {
 		// dataSetup allows to prepare data in advance for testing
 		dataSetup func() error
 		// queryGenerator is used to generate a Query
-		queryGenerator func() *v1.EntityCriteria
+		queryGenerator func() *v1.QueryRequest
 		// wantLen is the length of entities expected to return
 		wantLen int
 	}{
 		{
 			name: "Query Trace ID when no initial data is given",
-			queryGenerator: func() *v1.EntityCriteria {
-				builder := fb.NewCriteriaBuilder()
-				return builder.BuildEntityCriteria(
-					fb.AddLimit(5),
-					fb.AddOffset(10),
-					builder.BuildMetaData("default", "sw"),
-					builder.BuildFields("trace_id", "=", "123"),
-				)
+			queryGenerator: func() *v1.QueryRequest {
+				return pb.NewQueryRequestBuilder().
+					Limit(5).
+					Offset(10).
+					Metadata("default", "sw").
+					Fields("trace_id", "=", "123").
+					Build()
 			},
 			wantLen: 0,
 		},

--- a/banyand/query/processor_test.go
+++ b/banyand/query/processor_test.go
@@ -56,7 +56,7 @@ func TestQueryProcessor(t *testing.T) {
 
 	// Init `Query` module
 	executor, err := NewExecutor(context.TODO(), repo, nil, traceSvc, traceSvc)
-	tester.NotNil(executor)
+	tester.NoError(err)
 
 	// :PreRun:
 	// 1) TraceSeries,

--- a/banyand/query/processor_test.go
+++ b/banyand/query/processor_test.go
@@ -19,16 +19,16 @@ package query
 
 import (
 	"context"
-	"github.com/apache/skywalking-banyandb/api/common"
-	"github.com/apache/skywalking-banyandb/banyand/series"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/apache/skywalking-banyandb/api/common"
 	"github.com/apache/skywalking-banyandb/api/event"
 	v1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/v1"
 	"github.com/apache/skywalking-banyandb/banyand/discovery"
+	"github.com/apache/skywalking-banyandb/banyand/series"
 	"github.com/apache/skywalking-banyandb/banyand/series/trace"
 	"github.com/apache/skywalking-banyandb/banyand/storage"
 	"github.com/apache/skywalking-banyandb/pkg/bus"
@@ -36,10 +36,22 @@ import (
 	"github.com/apache/skywalking-banyandb/pkg/pb"
 )
 
-func setupServices(tester *require.Assertions) (discovery.ServiceRepo, series.Service) {
+var interval = time.Millisecond * 500
+
+type entityValue struct {
+	seriesID   string
+	entityID   string
+	dataBinary []byte
+	ts         time.Time
+	items      []interface{}
+}
+
+func setupServices(tester *require.Assertions) (discovery.ServiceRepo, series.Service, func()) {
 	// Bootstrap logger system
-	err := logger.Bootstrap()
-	tester.NoError(err)
+	tester.NoError(logger.Init(logger.Logging{
+		Env:   "dev",
+		Level: "warn",
+	}))
 
 	// Init `Discovery` module
 	repo, err := discovery.NewServiceRepo(context.Background())
@@ -71,21 +83,176 @@ func setupServices(tester *require.Assertions) (discovery.ServiceRepo, series.Se
 	err = executor.PreRun()
 	tester.NoError(err)
 
-	return repo, traceSvc
+	return repo, traceSvc, db.GracefulStop
+}
+
+func setupData(tester *require.Assertions, baseTs time.Time, svc series.Service) {
+	metadata := common.Metadata{
+		Spec: &v1.Metadata{
+			Name:  "sw",
+			Group: "default",
+		},
+	}
+
+	entityValues := []entityValue{
+		{
+			ts:         baseTs,
+			seriesID:   "webapp_10.0.0.1",
+			entityID:   "1",
+			dataBinary: []byte{11},
+			items: []interface{}{
+				"trace_id-xxfff.111323",
+				0,
+				"webapp_id",
+				"10.0.0.1_id",
+				"/home_id",
+				"webapp",
+				"10.0.0.1",
+				"/home",
+				300,
+				1622933202000000000,
+			},
+		},
+		{
+			ts:         baseTs.Add(interval),
+			seriesID:   "gateway_10.0.0.2",
+			entityID:   "2",
+			dataBinary: []byte{12},
+			items: []interface{}{
+				"trace_id-xxfff.111323a",
+				1,
+			},
+		},
+		{
+			ts:         baseTs.Add(interval * 2),
+			seriesID:   "httpserver_10.0.0.3",
+			entityID:   "3",
+			dataBinary: []byte{13},
+			items: []interface{}{
+				"trace_id-xxfff.111323",
+				1,
+				"httpserver_id",
+				"10.0.0.3_id",
+				"/home_id",
+				"httpserver",
+				"10.0.0.3",
+				"/home",
+				300,
+				1622933202000000000,
+				"GET",
+				"200",
+			},
+		},
+		{
+			ts:         baseTs.Add(interval * 3),
+			seriesID:   "database_10.0.0.4",
+			entityID:   "4",
+			dataBinary: []byte{14},
+			items: []interface{}{
+				"trace_id-xxfff.111323",
+				0,
+				"database_id",
+				"10.0.0.4_id",
+				"/home_id",
+				"database",
+				"10.0.0.4",
+				"/home",
+				300,
+				1622933202000000000,
+				nil,
+				nil,
+				"MySQL",
+				"10.1.1.4",
+			},
+		},
+		{
+			ts:         baseTs.Add(interval * 4),
+			seriesID:   "mq_10.0.0.5",
+			entityID:   "5",
+			dataBinary: []byte{15},
+			items: []interface{}{
+				"trace_id-zzpp.111323",
+				0,
+				"mq_id",
+				"10.0.0.5_id",
+				"/home_id",
+				"mq",
+				"10.0.0.5",
+				"/home",
+				300,
+				1622933202000000000,
+				nil,
+				nil,
+				nil,
+				nil,
+				"test_topic",
+				"10.0.0.5",
+			},
+		},
+		{
+			ts:         baseTs.Add(interval * 5),
+			seriesID:   "database_10.0.0.6",
+			entityID:   "6",
+			dataBinary: []byte{16},
+			items: []interface{}{
+				"trace_id-zzpp.111323",
+				1,
+				"database_id",
+				"10.0.0.6_id",
+				"/home_id",
+				"database",
+				"10.0.0.6",
+				"/home",
+				300,
+				1622933202000000000,
+				nil,
+				nil,
+				"MySQL",
+				"10.1.1.6",
+			},
+		},
+		{
+			ts:         baseTs.Add(interval * 6),
+			seriesID:   "mq_10.0.0.7",
+			entityID:   "7",
+			dataBinary: []byte{17},
+			items: []interface{}{
+				"trace_id-zzpp.111323",
+				0,
+				"nq_id",
+				"10.0.0.7_id",
+				"/home_id",
+				"mq",
+				"10.0.0.7",
+				"/home",
+				300,
+				1622933202000000000,
+				nil,
+				nil,
+				nil,
+				nil,
+				"test_topic",
+				"10.0.0.7",
+			},
+		},
+	}
+
+	for _, ev := range entityValues {
+		ok, err := svc.Write(metadata, ev.ts, ev.seriesID, ev.entityID, ev.dataBinary, ev.items...)
+		tester.True(ok)
+		tester.NoError(err)
+	}
 }
 
 func TestQueryProcessor(t *testing.T) {
 	tester := require.New(t)
 
 	// setup services
-	repo, traceSvc := setupServices(tester)
-	
-	tracesMetadata := common.Metadata{
-		KindVersion: common.KindVersion{},
-		Spec:        ,
-	}
-	now := time.Now()
-	traceSvc.Write()
+	repo, traceSvc, gracefulStop := setupServices(tester)
+	defer gracefulStop()
+
+	baseTs := time.Now()
+	setupData(tester, baseTs, traceSvc)
 
 	tests := []struct {
 		// name of the test case
@@ -96,16 +263,45 @@ func TestQueryProcessor(t *testing.T) {
 		wantLen int
 	}{
 		{
-			name: "Query Trace ID when no initial data is given",
+			name: "query given timeRange is out of the time range of data",
 			queryGenerator: func(baseTs time.Time) *v1.QueryRequest {
 				return pb.NewQueryRequestBuilder().
-					Limit(5).
-					Offset(10).
+					Limit(10).
+					Offset(0).
 					Metadata("default", "sw").
-					Fields("trace_id", "=", "123").
+					TimeRange(time.Unix(0, 0), time.Unix(0, 1)).
+					Projection("trace_id").
 					Build()
 			},
 			wantLen: 0,
+		},
+		{
+			name: "query TraceID given timeRange includes the time range of data",
+			queryGenerator: func(baseTs time.Time) *v1.QueryRequest {
+				return pb.NewQueryRequestBuilder().
+					Limit(10).
+					Offset(0).
+					Metadata("default", "sw").
+					Fields("trace_id", "=", "trace_id-zzpp.111323").
+					TimeRange(baseTs.Add(-1*time.Minute), baseTs.Add(1*time.Minute)).
+					Projection("trace_id").
+					Build()
+			},
+			wantLen: 3,
+		},
+		{
+			name: "query TraceID given timeRange includes the time range of data but limit to 1",
+			queryGenerator: func(baseTs time.Time) *v1.QueryRequest {
+				return pb.NewQueryRequestBuilder().
+					Limit(1).
+					Offset(0).
+					Metadata("default", "sw").
+					Fields("trace_id", "=", "trace_id-zzpp.111323").
+					TimeRange(baseTs.Add(-1*time.Minute), baseTs.Add(1*time.Minute)).
+					Projection("trace_id").
+					Build()
+			},
+			wantLen: 1,
 		},
 	}
 
@@ -113,13 +309,15 @@ func TestQueryProcessor(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			singleTester := require.New(t)
 			now := time.Now()
-			m := bus.NewMessage(bus.MessageID(now.UnixNano()), tt.queryGenerator(now))
+			m := bus.NewMessage(bus.MessageID(now.UnixNano()), tt.queryGenerator(baseTs))
 			f, err := repo.Publish(event.TopicQueryEvent, m)
 			singleTester.NoError(err)
 			singleTester.NotNil(f)
 			msg, err := f.Get()
 			singleTester.NoError(err)
 			singleTester.NotNil(msg)
+			// TODO: better error response
+			singleTester.NotNil(msg.Data())
 			singleTester.Len(msg.Data(), tt.wantLen)
 		})
 	}

--- a/banyand/query/processor_test.go
+++ b/banyand/query/processor_test.go
@@ -1,0 +1,95 @@
+package query
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/apache/skywalking-banyandb/api/event"
+	v1 "github.com/apache/skywalking-banyandb/api/fbs/v1"
+	"github.com/apache/skywalking-banyandb/banyand/discovery"
+	"github.com/apache/skywalking-banyandb/banyand/series/trace"
+	"github.com/apache/skywalking-banyandb/banyand/storage"
+	"github.com/apache/skywalking-banyandb/pkg/bus"
+	"github.com/apache/skywalking-banyandb/pkg/fb"
+	"github.com/apache/skywalking-banyandb/pkg/logger"
+)
+
+func TestQueryProcessor(t *testing.T) {
+	tester := require.New(t)
+	// Bootstrap logger system
+	err := logger.Bootstrap()
+	tester.NoError(err)
+
+	// Init `Discovery` module
+	repo, err := discovery.NewServiceRepo(context.Background())
+	tester.NoError(err)
+	tester.NotNil(repo)
+
+	// Init `Database` module
+	db, err := storage.NewDB(context.TODO(), repo)
+	tester.NoError(err)
+	tester.NoError(db.FlagSet().Parse(nil))
+
+	// Init `Trace` module
+	traceSvc, err := trace.NewService(context.TODO(), db, repo)
+	tester.NoError(err)
+
+	// Init `Query` module
+	executor, err := NewExecutor(context.TODO(), repo, nil, traceSvc, traceSvc)
+	tester.NotNil(executor)
+
+	// :PreRun:
+	// 1) TraceSeries,
+	// 2) Database
+	err = traceSvc.PreRun()
+	tester.NoError(err)
+
+	err = db.PreRun()
+	tester.NoError(err)
+
+	err = executor.PreRun()
+	tester.NoError(err)
+
+	tests := []struct {
+		// name of the test case
+		name string
+		// dataSetup allows to prepare data in advance for testing
+		dataSetup func() error
+		// queryGenerator is used to generate a Query
+		queryGenerator func() *v1.EntityCriteria
+		// wantLen is the length of entities expected to return
+		wantLen int
+	}{
+		{
+			name: "Query Trace ID when no initial data is given",
+			queryGenerator: func() *v1.EntityCriteria {
+				builder := fb.NewCriteriaBuilder()
+				return builder.BuildEntityCriteria(
+					fb.AddLimit(5),
+					fb.AddOffset(10),
+					builder.BuildMetaData("default", "sw"),
+					builder.BuildFields("trace_id", "=", "123"),
+				)
+			},
+			wantLen: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tester := require.New(t)
+			now := time.Now().UnixNano()
+			m := bus.NewMessage(bus.MessageID(now), tt.queryGenerator())
+			f, err := repo.Publish(event.TopicQueryEvent, m)
+			tester.NoError(err)
+			tester.NotNil(f)
+			msg, err := f.Get()
+			tester.NoError(err)
+			tester.NotNil(msg)
+			tester.Len(msg.Data(), tt.wantLen)
+		})
+	}
+}

--- a/banyand/query/processor_test.go
+++ b/banyand/query/processor_test.go
@@ -1,3 +1,20 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package query
 
 import (

--- a/banyand/query/query.go
+++ b/banyand/query/query.go
@@ -20,6 +20,7 @@ package query
 import (
 	"context"
 
+	"github.com/apache/skywalking-banyandb/banyand/discovery"
 	"github.com/apache/skywalking-banyandb/banyand/index"
 	"github.com/apache/skywalking-banyandb/banyand/series"
 	"github.com/apache/skywalking-banyandb/pkg/run"
@@ -29,10 +30,11 @@ type Executor interface {
 	run.PreRunner
 }
 
-func NewExecutor(ctx context.Context, indexRepo index.Repo, uniModel series.UniModel, schemaRepo series.SchemaRepo) (Executor, error) {
+func NewExecutor(_ context.Context, serviceRepo discovery.ServiceRepo, indexRepo index.Repo, uniModel series.UniModel, schemaRepo series.SchemaRepo) (Executor, error) {
 	return &queryProcessor{
-		Repo:       indexRepo,
-		UniModel:   uniModel,
-		schemaRepo: schemaRepo,
+		Repo:        indexRepo,
+		UniModel:    uniModel,
+		schemaRepo:  schemaRepo,
+		serviceRepo: serviceRepo,
 	}, nil
 }

--- a/banyand/query/query.go
+++ b/banyand/query/query.go
@@ -29,6 +29,10 @@ type Executor interface {
 	run.PreRunner
 }
 
-func NewExecutor(ctx context.Context, idx index.Repo, s series.UniModel) (Executor, error) {
-	return nil, nil
+func NewExecutor(ctx context.Context, indexRepo index.Repo, uniModel series.UniModel, schemaRepo series.SchemaRepo) (Executor, error) {
+	return &queryProcessor{
+		Repo:       indexRepo,
+		UniModel:   uniModel,
+		schemaRepo: schemaRepo,
+	}, nil
 }

--- a/banyand/query/query.go
+++ b/banyand/query/query.go
@@ -23,6 +23,7 @@ import (
 	"github.com/apache/skywalking-banyandb/banyand/discovery"
 	"github.com/apache/skywalking-banyandb/banyand/index"
 	"github.com/apache/skywalking-banyandb/banyand/series"
+	"github.com/apache/skywalking-banyandb/pkg/logger"
 	"github.com/apache/skywalking-banyandb/pkg/run"
 )
 
@@ -36,5 +37,6 @@ func NewExecutor(_ context.Context, serviceRepo discovery.ServiceRepo, indexRepo
 		UniModel:    uniModel,
 		schemaRepo:  schemaRepo,
 		serviceRepo: serviceRepo,
+		logger:      logger.GetLogger("query"),
 	}, nil
 }

--- a/banyand/queue/queue.go
+++ b/banyand/queue/queue.go
@@ -21,15 +21,15 @@ import (
 	"context"
 
 	"github.com/apache/skywalking-banyandb/banyand/discovery"
-	bus2 "github.com/apache/skywalking-banyandb/pkg/bus"
+	"github.com/apache/skywalking-banyandb/pkg/bus"
 	"github.com/apache/skywalking-banyandb/pkg/run"
 )
 
 type Queue interface {
 	run.Config
 	run.PreRunner
-	bus2.Subscriber
-	bus2.Publisher
+	bus.Subscriber
+	bus.Publisher
 }
 
 func NewQueue(ctx context.Context, repo discovery.ServiceRepo) (Queue, error) {

--- a/banyand/series/series.go
+++ b/banyand/series/series.go
@@ -20,13 +20,14 @@ package series
 
 import (
 	"context"
+	"time"
+
 	"github.com/apache/skywalking-banyandb/api/common"
 	"github.com/apache/skywalking-banyandb/api/data"
 	v1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/v1"
 	"github.com/apache/skywalking-banyandb/banyand/series/schema"
 	posting2 "github.com/apache/skywalking-banyandb/pkg/posting"
 	"github.com/apache/skywalking-banyandb/pkg/run"
-	"time"
 )
 
 // TraceState represents the State of a traceSeries link
@@ -54,8 +55,8 @@ type TraceRepo interface {
 	FetchEntity(traceSeries common.Metadata, shardID uint, chunkIDs posting2.List, opt ScanOptions) ([]data.Entity, error)
 	//ScanEntity returns data.Entity between a duration by ScanOptions
 	ScanEntity(traceSeries common.Metadata, startTime, endTime uint64, opt ScanOptions) ([]data.Entity, error)
-	// Write writes entity to the given traceSeries
-	Write(traceSeries common.Metadata, ts time.Time, seriesID string, dataBinary []byte, items ...interface{}) (bool, error)
+	// Write entity to the given traceSeries
+	Write(traceSeries common.Metadata, ts time.Time, seriesID, entityID string, dataBinary []byte, items ...interface{}) (bool, error)
 }
 
 //UniModel combines Trace, Metric and Log repositories into a union interface

--- a/banyand/series/series.go
+++ b/banyand/series/series.go
@@ -20,13 +20,13 @@ package series
 
 import (
 	"context"
-
 	"github.com/apache/skywalking-banyandb/api/common"
 	"github.com/apache/skywalking-banyandb/api/data"
 	v1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/v1"
 	"github.com/apache/skywalking-banyandb/banyand/series/schema"
 	posting2 "github.com/apache/skywalking-banyandb/pkg/posting"
 	"github.com/apache/skywalking-banyandb/pkg/run"
+	"time"
 )
 
 // TraceState represents the State of a traceSeries link
@@ -54,6 +54,8 @@ type TraceRepo interface {
 	FetchEntity(traceSeries common.Metadata, shardID uint, chunkIDs posting2.List, opt ScanOptions) ([]data.Entity, error)
 	//ScanEntity returns data.Entity between a duration by ScanOptions
 	ScanEntity(traceSeries common.Metadata, startTime, endTime uint64, opt ScanOptions) ([]data.Entity, error)
+	// Write writes entity to the given traceSeries
+	Write(traceSeries common.Metadata, ts time.Time, seriesID string, dataBinary []byte, items ...interface{}) (bool, error)
 }
 
 //UniModel combines Trace, Metric and Log repositories into a union interface

--- a/banyand/series/trace/common_test.go
+++ b/banyand/series/trace/common_test.go
@@ -55,7 +55,7 @@ func (b ByEntityID) Swap(i, j int) {
 	b[i], b[j] = b[j], b[i]
 }
 
-func setup(t *testing.T) (*traceSeries, func(), string) {
+func setup(t *testing.T) (*traceSeries, func()) {
 	_ = logger.Bootstrap()
 	db, err := storage.NewDB(context.TODO(), nil)
 	assert.NoError(t, err)
@@ -75,7 +75,10 @@ func setup(t *testing.T) (*traceSeries, func(), string) {
 		},
 	})
 	assert.NoError(t, err)
-	return ts, db.GracefulStop, rootPath
+	return ts, func() {
+		db.GracefulStop()
+		_ = os.RemoveAll(rootPath)
+	}
 }
 
 type seriesEntity struct {

--- a/banyand/series/trace/query_test.go
+++ b/banyand/series/trace/query_test.go
@@ -19,7 +19,6 @@ package trace
 
 import (
 	"math"
-	"os"
 	"sort"
 	"testing"
 	"time"
@@ -137,11 +136,8 @@ func Test_traceSeries_FetchEntity(t *testing.T) {
 			wantErr: true,
 		},
 	}
-	ts, stopFunc, dbPath := setup(t)
-	defer func() {
-		stopFunc()
-		_ = os.RemoveAll(dbPath)
-	}()
+	ts, stopFunc := setup(t)
+	defer stopFunc()
 	dataResult := setupTestData(t, ts, testData(time.Now()))
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -209,11 +205,8 @@ func Test_traceSeries_FetchTrace(t *testing.T) {
 			wantErr: true,
 		},
 	}
-	ts, stopFunc, dbPath := setup(t)
-	defer func() {
-		stopFunc()
-		_ = os.RemoveAll(dbPath)
-	}()
+	ts, stopFunc := setup(t)
+	defer stopFunc()
 	setupTestData(t, ts, testData(time.Now()))
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -304,11 +297,8 @@ func Test_traceSeries_ScanEntity(t *testing.T) {
 			args: args{},
 		},
 	}
-	ts, stopFunc, dbPath := setup(t)
-	defer func() {
-		stopFunc()
-		_ = os.RemoveAll(dbPath)
-	}()
+	ts, stopFunc := setup(t)
+	defer stopFunc()
 	setupTestData(t, ts, testData(baseTS))
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/banyand/series/trace/query_test.go
+++ b/banyand/series/trace/query_test.go
@@ -19,6 +19,7 @@ package trace
 
 import (
 	"math"
+	"os"
 	"sort"
 	"testing"
 	"time"
@@ -136,8 +137,11 @@ func Test_traceSeries_FetchEntity(t *testing.T) {
 			wantErr: true,
 		},
 	}
-	ts, stopFunc := setup(t)
-	defer stopFunc()
+	ts, stopFunc, dbPath := setup(t)
+	defer func() {
+		stopFunc()
+		_ = os.RemoveAll(dbPath)
+	}()
 	dataResult := setupTestData(t, ts, testData(time.Now()))
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -205,8 +209,11 @@ func Test_traceSeries_FetchTrace(t *testing.T) {
 			wantErr: true,
 		},
 	}
-	ts, stopFunc := setup(t)
-	defer stopFunc()
+	ts, stopFunc, dbPath := setup(t)
+	defer func() {
+		stopFunc()
+		_ = os.RemoveAll(dbPath)
+	}()
 	setupTestData(t, ts, testData(time.Now()))
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -297,8 +304,11 @@ func Test_traceSeries_ScanEntity(t *testing.T) {
 			args: args{},
 		},
 	}
-	ts, stopFunc := setup(t)
-	defer stopFunc()
+	ts, stopFunc, dbPath := setup(t)
+	defer func() {
+		stopFunc()
+		_ = os.RemoveAll(dbPath)
+	}()
 	setupTestData(t, ts, testData(baseTS))
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/banyand/series/trace/trace.go
+++ b/banyand/series/trace/trace.go
@@ -19,7 +19,6 @@ package trace
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"time"
 
@@ -41,7 +40,6 @@ import (
 )
 
 const (
-	traceSeriesIDTemp = "%s:%s"
 	// KV stores
 	chunkIDMapping = "chunkIDMapping"
 	startTimeIndex = "startTimeIndex"
@@ -111,7 +109,7 @@ func (s *service) PreRun() error {
 			return errTS
 		}
 		s.db.Register(ts)
-		id := fmt.Sprintf(traceSeriesIDTemp, ts.name, ts.group)
+		id := formatTraceSeriesID(ts.name, ts.group)
 		s.schemaMap[id] = ts
 		s.l.Info().Str("id", id).Msg("initialize Trace series")
 	}
@@ -184,7 +182,7 @@ func (s *service) ScanEntity(traceSeries common.Metadata, startTime, endTime uin
 }
 
 func (s *service) getSeries(traceSeries common.Metadata) (*traceSeries, error) {
-	id := getTraceSeriesID(traceSeries)
+	id := formatTraceSeriesID(traceSeries.Spec.GetName(), traceSeries.Spec.GetGroup())
 	s.l.Debug().Str("id", id).Msg("got Trace series")
 	ts, ok := s.schemaMap[id]
 	if !ok {
@@ -193,8 +191,8 @@ func (s *service) getSeries(traceSeries common.Metadata) (*traceSeries, error) {
 	return ts, nil
 }
 
-func getTraceSeriesID(traceSeries common.Metadata) string {
-	return fmt.Sprintf(traceSeriesIDTemp, traceSeries.Spec.GetName(), traceSeries.Spec.GetGroup())
+func formatTraceSeriesID(name, group string) string {
+	return name + ":" + group
 }
 
 type traceSeries struct {

--- a/banyand/series/trace/write_test.go
+++ b/banyand/series/trace/write_test.go
@@ -18,6 +18,7 @@
 package trace
 
 import (
+	"os"
 	"testing"
 	"time"
 
@@ -29,8 +30,11 @@ import (
 )
 
 func Test_traceSeries_Write(t *testing.T) {
-	ts, stopFunc := setup(t)
-	defer stopFunc()
+	ts, stopFunc, dbPath := setup(t)
+	defer func() {
+		stopFunc()
+		_ = os.RemoveAll(dbPath)
+	}()
 
 	tests := []struct {
 		name    string

--- a/banyand/series/trace/write_test.go
+++ b/banyand/series/trace/write_test.go
@@ -18,7 +18,6 @@
 package trace
 
 import (
-	"os"
 	"testing"
 	"time"
 
@@ -30,11 +29,8 @@ import (
 )
 
 func Test_traceSeries_Write(t *testing.T) {
-	ts, stopFunc, dbPath := setup(t)
-	defer func() {
-		stopFunc()
-		_ = os.RemoveAll(dbPath)
-	}()
+	ts, stopFunc := setup(t)
+	defer stopFunc()
 
 	tests := []struct {
 		name    string

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/golang/mock v1.5.0
 	github.com/golang/protobuf v1.5.2
 	github.com/google/go-cmp v0.5.6
+	github.com/google/uuid v1.3.0
 	github.com/klauspost/compress v1.13.1 // indirect
 	github.com/oklog/run v1.1.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -173,6 +173,8 @@ github.com/google/pprof v0.0.0-20210122040257-d980be63207e/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=

--- a/pkg/query/logical/analyzer.go
+++ b/pkg/query/logical/analyzer.go
@@ -101,9 +101,8 @@ func (a *Analyzer) Analyze(_ context.Context, criteria *apiv1.QueryRequest, trac
 			typedPair := pairQuery.GetCondition()
 			switch v := typedPair.GetTyped().(type) {
 			case *apiv1.TypedPair_StrPair:
-				// TODO: use metadata from Plugin?
 				// check special field `trace_id`
-				if v.StrPair.GetKey() == "trace_id" {
+				if v.StrPair.GetKey() == s.TraceIDFieldName() {
 					plan = TraceIDFetch(v.StrPair.GetValues()[0], traceMetadata, projStr...)
 					break
 				}
@@ -112,7 +111,7 @@ func (a *Analyzer) Analyze(_ context.Context, criteria *apiv1.QueryRequest, trac
 				fieldExprs = append(fieldExprs, binaryOpFactory[op](NewFieldRef(v.StrPair.GetKey()), lit))
 			case *apiv1.TypedPair_IntPair:
 				// check special field `state`
-				if v.IntPair.GetKey() == "state" {
+				if v.IntPair.GetKey() == s.TraceStateFieldName() {
 					traceState = series.TraceState(v.IntPair.GetValues()[0])
 					continue
 				}

--- a/pkg/query/logical/analyzer.go
+++ b/pkg/query/logical/analyzer.go
@@ -67,8 +67,9 @@ func (a *Analyzer) BuildTraceSchema(ctx context.Context, metadata common.Metadat
 	}
 
 	s := &schema{
-		indexRule: indexRule,
-		fieldMap:  make(map[string]*fieldSpec),
+		traceSeries: traceSeries.Spec,
+		indexRule:   indexRule,
+		fieldMap:    make(map[string]*fieldSpec),
 	}
 
 	// generate the schema of the fields for the traceSeries

--- a/pkg/query/logical/analyzer_test.go
+++ b/pkg/query/logical/analyzer_test.go
@@ -139,7 +139,8 @@ func TestAnalyzer_TraceIDQuery(t *testing.T) {
 	assert.NoError(err)
 	assert.NotNil(plan)
 
-	correctPlan := logical.TraceIDFetch("123", metadata, schema)
+	correctPlan, err := logical.TraceIDFetch("123", metadata).Analyze(schema)
+	assert.NoError(err)
 	assert.NotNil(correctPlan)
 	cmp.Equal(plan, correctPlan)
 }

--- a/pkg/query/logical/plan_execution_test.go
+++ b/pkg/query/logical/plan_execution_test.go
@@ -156,7 +156,7 @@ func TestPlanExecution_IndexScan(t *testing.T) {
 			unresolvedPlan: logical.IndexScan(st.UnixNano(), et.UnixNano(), m, []logical.Expr{
 				logical.Eq(logical.NewFieldRef("http.method"), logical.Str("GET")),
 			}, series.TraceStateDefault),
-			indexMatchers: []*indexMatcher{newIndexMatcher("http.method", roaring.NewPostingListWithInitialData(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))},
+			indexMatchers: []*indexMatcher{newIndexMatcher("http.method", 0, roaring.NewPostingListWithInitialData(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))},
 			wantLength:    10,
 		},
 		{
@@ -166,8 +166,8 @@ func TestPlanExecution_IndexScan(t *testing.T) {
 				logical.Eq(logical.NewFieldRef("service_id"), logical.Str("app")),
 			}, series.TraceStateDefault),
 			indexMatchers: []*indexMatcher{
-				newIndexMatcher("http.method", roaring.NewPostingListWithInitialData(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)),
-				newIndexMatcher("service_id", roaring.NewPostingListWithInitialData(1, 3, 5, 7, 9)),
+				newIndexMatcher("http.method", 0, roaring.NewPostingListWithInitialData(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)),
+				newIndexMatcher("service_id", 0, roaring.NewPostingListWithInitialData(1, 3, 5, 7, 9)),
 			},
 			wantLength: 5,
 		},
@@ -178,8 +178,8 @@ func TestPlanExecution_IndexScan(t *testing.T) {
 				logical.Eq(logical.NewFieldRef("service_id"), logical.Str("app")),
 			}, series.TraceStateDefault),
 			indexMatchers: []*indexMatcher{
-				newIndexMatcher("http.method", roaring.NewPostingListWithInitialData(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)),
-				newIndexMatcher("service_id", roaring.NewPostingList()),
+				newIndexMatcher("http.method", 0, roaring.NewPostingListWithInitialData(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)),
+				newIndexMatcher("service_id", 0, roaring.NewPostingList()),
 			},
 			wantLength: 0,
 		},

--- a/pkg/query/logical/plan_execution_test.go
+++ b/pkg/query/logical/plan_execution_test.go
@@ -128,7 +128,8 @@ func TestPlanExecution_TraceIDFetch(t *testing.T) {
 
 	traceID := "asdf1234"
 
-	p := logical.TraceIDFetch(traceID, m, s)
+	p, err := logical.TraceIDFetch(traceID, m).Analyze(s)
+	assert.NoError(err)
 	assert.NotNil(p)
 	f := newMockDataFactory(ctrl, m, s, 10)
 	entities, err := p.Execute(f.MockTraceIDFetch(traceID))

--- a/pkg/query/logical/plan_indexscan.go
+++ b/pkg/query/logical/plan_indexscan.go
@@ -108,7 +108,7 @@ type indexScan struct {
 }
 
 func (i *indexScan) Execute(ec executor.ExecutionContext) ([]data.Entity, error) {
-	var dataEntities []data.Entity
+	dataEntities := make([]data.Entity, 0)
 
 	// iterate over shards
 	for shardID := uint32(0); shardID < i.schema.ShardNumber(); shardID++ {
@@ -129,6 +129,10 @@ func (i *indexScan) Execute(ec executor.ExecutionContext) ([]data.Entity, error)
 				// afterwards, it must not be nil
 				_ = chunkSet.Intersect(chunks)
 			}
+		}
+
+		if chunkSet == nil || chunkSet.Len() == 0 {
+			continue
 		}
 
 		// fetch entities with chunkIDs

--- a/pkg/query/logical/plan_indexscan.go
+++ b/pkg/query/logical/plan_indexscan.go
@@ -128,6 +128,10 @@ func (i *indexScan) Execute(ec executor.ExecutionContext) ([]data.Entity, error)
 			} else {
 				// afterwards, it must not be nil
 				_ = chunkSet.Intersect(chunks)
+				// stop loop if chunkSet is empty
+				if chunkSet.Len() == 0 {
+					continue
+				}
 			}
 		}
 

--- a/pkg/query/logical/plan_indexscan.go
+++ b/pkg/query/logical/plan_indexscan.go
@@ -111,6 +111,7 @@ func (i *indexScan) Execute(ec executor.ExecutionContext) ([]data.Entity, error)
 	dataEntities := make([]data.Entity, 0)
 
 	// iterate over shards
+	// TODO: we have to push down Limit and Offset to set a threshold to IndexSearch operations
 	for shardID := uint32(0); shardID < i.schema.ShardNumber(); shardID++ {
 		var chunkSet posting.List
 

--- a/pkg/query/logical/plan_indexscan.go
+++ b/pkg/query/logical/plan_indexscan.go
@@ -19,7 +19,6 @@ package logical
 
 import (
 	"fmt"
-	"github.com/apache/skywalking-banyandb/pkg/posting/roaring"
 	"strings"
 
 	"github.com/google/go-cmp/cmp"
@@ -31,6 +30,7 @@ import (
 	"github.com/apache/skywalking-banyandb/banyand/index"
 	"github.com/apache/skywalking-banyandb/banyand/series"
 	"github.com/apache/skywalking-banyandb/pkg/posting"
+	"github.com/apache/skywalking-banyandb/pkg/posting/roaring"
 	"github.com/apache/skywalking-banyandb/pkg/query/executor"
 )
 

--- a/pkg/query/logical/plan_indexscan.go
+++ b/pkg/query/logical/plan_indexscan.go
@@ -116,9 +116,8 @@ func (i *indexScan) Execute(ec executor.ExecutionContext) ([]data.Entity, error)
 
 		// first collect all chunkIDs via indexes
 		for idxObj, exprs := range i.conditionMap {
-			// TODO: Discuss which metadata should be used!
-			// 1) traceSeries Metadata: indirect mapping
-			// 2) indexRule Metadata: cannot uniquely determine traceSeries
+			// 1) traceSeries Metadata -> IndexObject
+			// 2) IndexObject -> Fields
 			chunks, err := ec.Search(*i.traceMetadata, uint(shardID), uint64(i.startTime), uint64(i.endTime), idxObj.GetName(), convertToConditions(exprs))
 			if err != nil {
 				return nil, err

--- a/pkg/query/logical/plan_indexscan.go
+++ b/pkg/query/logical/plan_indexscan.go
@@ -115,11 +115,11 @@ func (i *indexScan) Execute(ec executor.ExecutionContext) ([]data.Entity, error)
 		var chunkSet posting.List
 
 		// first collect all chunkIDs via indexes
-		for _, exprs := range i.conditionMap {
+		for idxObj, exprs := range i.conditionMap {
 			// TODO: Discuss which metadata should be used!
 			// 1) traceSeries Metadata: indirect mapping
 			// 2) indexRule Metadata: cannot uniquely determine traceSeries
-			chunks, err := ec.Search(*i.traceMetadata, uint(shardID), uint64(i.startTime), uint64(i.endTime), convertToConditions(exprs))
+			chunks, err := ec.Search(*i.traceMetadata, uint(shardID), uint64(i.startTime), uint64(i.endTime), idxObj.GetName(), convertToConditions(exprs))
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/query/logical/plan_tablescan.go
+++ b/pkg/query/logical/plan_tablescan.go
@@ -47,11 +47,10 @@ func (u *unresolvedTableScan) Type() PlanType {
 func (u *unresolvedTableScan) Analyze(schema Schema) (Plan, error) {
 	if u.projectionFields == nil || len(u.projectionFields) == 0 {
 		return &tableScan{
-			startTime:           u.startTime,
-			endTime:             u.endTime,
-			projectionFieldRefs: nil,
-			schema:              schema,
-			traceMetadata:       u.traceMetadata,
+			startTime:     u.startTime,
+			endTime:       u.endTime,
+			schema:        schema,
+			traceMetadata: u.traceMetadata,
 		}, nil
 	}
 

--- a/pkg/query/logical/schema.go
+++ b/pkg/query/logical/schema.go
@@ -31,6 +31,7 @@ type Schema interface {
 	CreateRef(names ...string) ([]*FieldRef, error)
 	Map(refs ...*FieldRef) Schema
 	Equal(Schema) bool
+	ShardNumber() uint32
 }
 
 type fieldSpec struct {
@@ -45,8 +46,9 @@ func (fs *fieldSpec) Equal(other *fieldSpec) bool {
 var _ Schema = (*schema)(nil)
 
 type schema struct {
-	indexRule apischema.IndexRule
-	fieldMap  map[string]*fieldSpec
+	traceSeries *apiv1.TraceSeries
+	indexRule   apischema.IndexRule
+	fieldMap    map[string]*fieldSpec
 }
 
 // IndexDefined checks whether the field given is indexed
@@ -100,11 +102,16 @@ func (s *schema) Map(refs ...*FieldRef) Schema {
 		return nil
 	}
 	newS := &schema{
-		indexRule: s.indexRule,
-		fieldMap:  make(map[string]*fieldSpec),
+		traceSeries: s.traceSeries,
+		indexRule:   s.indexRule,
+		fieldMap:    make(map[string]*fieldSpec),
 	}
 	for _, ref := range refs {
 		newS.fieldMap[ref.name] = ref.spec
 	}
 	return newS
+}
+
+func (s *schema) ShardNumber() uint32 {
+	return s.traceSeries.Shard.Number
 }

--- a/pkg/query/logical/schema.go
+++ b/pkg/query/logical/schema.go
@@ -32,6 +32,8 @@ type Schema interface {
 	Map(refs ...*FieldRef) Schema
 	Equal(Schema) bool
 	ShardNumber() uint32
+	TraceIDFieldName() string
+	TraceStateFieldName() string
 }
 
 type fieldSpec struct {
@@ -49,6 +51,14 @@ type schema struct {
 	traceSeries *apiv1.TraceSeries
 	indexRule   apischema.IndexRule
 	fieldMap    map[string]*fieldSpec
+}
+
+func (s *schema) TraceIDFieldName() string {
+	return s.traceSeries.GetReservedFieldsMap().GetTraceId()
+}
+
+func (s *schema) TraceStateFieldName() string {
+	return s.traceSeries.GetReservedFieldsMap().GetState().GetField()
 }
 
 // IndexDefined checks whether the field given is indexed


### PR DESCRIPTION
A `Write` API is added to support writing entities when running tests.

- [x] TraceIDFetch Test
- [x] TableScan Test