### PR TITLE
Introduce bytebuffer pool

### DIFF
--- a/banyand/series/trace/common_test.go
+++ b/banyand/series/trace/common_test.go
@@ -53,8 +53,11 @@ func (b ByEntityID) Swap(i, j int) {
 	b[i], b[j] = b[j], b[i]
 }
 
-func setup(t *testing.T) (*traceSeries, func()) {
-	_ = logger.Bootstrap()
+func setup(t testing.TB) (*traceSeries, func()) {
+	_ = logger.Init(logger.Logging{
+		Env:   "test",
+		Level: "warn",
+	})
 	db, err := storage.NewDB(context.TODO(), nil)
 	assert.NoError(t, err)
 	assert.NoError(t, db.FlagSet().Parse(nil))
@@ -241,7 +244,7 @@ func getEntityWithTS(id string, binary []byte, ts uint64, items ...interface{}) 
 	}
 }
 
-func setUpTestData(t *testing.T, ts *traceSeries, seriesEntities []seriesEntity) (chunkIDs []common.ChunkID) {
+func setUpTestData(t testing.TB, ts *traceSeries, seriesEntities []seriesEntity) (chunkIDs []common.ChunkID) {
 	chunkIDs = make([]common.ChunkID, 0, len(seriesEntities))
 	for _, se := range seriesEntities {
 		seriesID := []byte(se.seriesID)

--- a/banyand/series/trace/query_benchmark_test.go
+++ b/banyand/series/trace/query_benchmark_test.go
@@ -1,0 +1,33 @@
+package trace
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/apache/skywalking-banyandb/banyand/series"
+)
+
+// Commit: 01c28bc0b8cccc927780a2e1cad7293cf71f9276
+// go test -bench=. -benchtime=60s -benchmem ./banyand/series/trace/...
+// goos: darwin
+// goarch: amd64
+// pkg: github.com/apache/skywalking-banyandb/banyand/series/trace
+// cpu: Intel(R) Core(TM) i7-6700HQ CPU @ 2.60GHz
+// Benchmark_Query_ScanEntity-8   	 1982455	     35238 ns/op	   14166 B/op	     333 allocs/op
+// PASS
+// Benchmark_Query_ScanEntity-8   	 2146119	     32553 ns/op	   12923 B/op	     288 allocs/op
+func Benchmark_Query_ScanEntity(b *testing.B) {
+	baseTS := uint64((time.Now().UnixNano() / 1e6) * 1e6)
+	ts, stopFunc := setup(b)
+	defer stopFunc()
+	setUpTestData(b, ts, testData(baseTS))
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = ts.ScanEntity(0, math.MaxUint64, series.ScanOptions{
+			Projection: []string{"data_binary", "trace_id"},
+			State:      series.TraceStateDefault,
+		})
+	}
+}

--- a/banyand/series/trace/query_benchmark_test.go
+++ b/banyand/series/trace/query_benchmark_test.go
@@ -1,3 +1,20 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package trace
 
 import (

--- a/banyand/series/trace/query_benchmark_test.go
+++ b/banyand/series/trace/query_benchmark_test.go
@@ -16,6 +16,7 @@ import (
 // cpu: Intel(R) Core(TM) i7-6700HQ CPU @ 2.60GHz
 // Benchmark_Query_ScanEntity-8   	 1982455	     35238 ns/op	   14166 B/op	     333 allocs/op
 // PASS
+// Current commit:
 // Benchmark_Query_ScanEntity-8   	 2146119	     32553 ns/op	   12923 B/op	     288 allocs/op
 func Benchmark_Query_ScanEntity(b *testing.B) {
 	baseTS := uint64((time.Now().UnixNano() / 1e6) * 1e6)
@@ -29,5 +30,28 @@ func Benchmark_Query_ScanEntity(b *testing.B) {
 			Projection: []string{"data_binary", "trace_id"},
 			State:      series.TraceStateDefault,
 		})
+	}
+}
+
+// Commit: 01c28bc0b8cccc927780a2e1cad7293cf71f9276
+// go test -bench=Benchmark_Query_FetchTrace -run=^a -benchtime=60s -benchmem ./banyand/series/trace/...
+// goos: darwin
+// goarch: amd64
+// pkg: github.com/apache/skywalking-banyandb/banyand/series/trace
+// cpu: Intel(R) Core(TM) i7-6700HQ CPU @ 2.60GHz
+// Benchmark_Query_FetchTrace-8   	 4519570	     16007 ns/op	    6279 B/op	     149 allocs/op
+// PASS
+// ok  	github.com/apache/skywalking-banyandb/banyand/series/trace	153.538s
+func Benchmark_Query_FetchTrace(b *testing.B) {
+	baseTS := uint64((time.Now().UnixNano() / 1e6) * 1e6)
+	ts, stopFunc := setup(b)
+	defer stopFunc()
+	setUpTestData(b, ts, testData(baseTS))
+
+	traceID := "trace_id-xxfff.111323"
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = ts.FetchTrace(traceID, series.ScanOptions{Projection: []string{"data_binary", "trace_id"}})
 	}
 }

--- a/pkg/bytes/buffer.go
+++ b/pkg/bytes/buffer.go
@@ -1,0 +1,39 @@
+package bytes
+
+type ByteBuf struct {
+	b []byte
+}
+
+func (b *ByteBuf) Len() int {
+	return len(b.b)
+}
+
+func (b *ByteBuf) Bytes() []byte {
+	return b.b
+}
+
+func (b *ByteBuf) Append(raw []byte) (int, error) {
+	b.b = append(b.b, raw...)
+	return len(raw), nil
+}
+
+func (b *ByteBuf) AppendByte(ch byte) (int, error) {
+	b.b = append(b.b, ch)
+	return 1, nil
+}
+
+func (b *ByteBuf) AppendString(s string) (int, error) {
+	b.b = append(b.b, s...)
+	return len(s), nil
+}
+
+// AppendUInt64 appends uint64 with BigEndianness
+func (b *ByteBuf) AppendUInt64(v uint64) (int, error) {
+	b.b = append(b.b, byte(v>>56), byte(v>>48), byte(v>>40), byte(v>>32), byte(v>>24), byte(v>>16), byte(v>>8), byte(v))
+	return 8, nil
+}
+
+// Reset the underlying slice while keeping the capacity
+func (b *ByteBuf) Reset() {
+	b.b = b.b[:0]
+}

--- a/pkg/bytes/buffer.go
+++ b/pkg/bytes/buffer.go
@@ -1,3 +1,20 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package bytes
 
 type ByteBuf struct {

--- a/pkg/bytes/pool.go
+++ b/pkg/bytes/pool.go
@@ -1,0 +1,34 @@
+package bytes
+
+import (
+	"sync"
+)
+
+var defaultPool Pool
+
+type Pool struct {
+	p sync.Pool
+}
+
+func Borrow() *ByteBuf {
+	return defaultPool.Borrow()
+}
+
+func (p *Pool) Borrow() *ByteBuf {
+	v := p.p.Get()
+	if v != nil {
+		return v.(*ByteBuf)
+	}
+	return &ByteBuf{
+		b: make([]byte, 0),
+	}
+}
+
+func Return(buf *ByteBuf) {
+	buf.Reset()
+	defaultPool.Return(buf)
+}
+
+func (p *Pool) Return(buf *ByteBuf) {
+	p.p.Put(buf)
+}

--- a/pkg/bytes/pool.go
+++ b/pkg/bytes/pool.go
@@ -1,3 +1,20 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package bytes
 
 import (


### PR DESCRIPTION
In this PR, I've introduced a very simple bytebuffer to optimize byte manipulation.

The benchmark of query path has been added, the result shows approx. ~10% less allocation.