### PR TITLE
Change String to Str to avoid class name conflicts

### DIFF
--- a/api/fbs/Makefile
+++ b/api/fbs/Makefile
@@ -18,7 +18,16 @@
 
 VERSION ?= v1
 fbs := $(wildcard $(VERSION)/*.fbs)
+GO_FLAGS := --go-namespace $(VERSION) --gen-onefile
+JAVA_FLAGS := --gen-generated
 
 .PHONY: generate
-generate: $(fbs)
-	flatc --go --gen-onefile --grpc --go-namespace $(VERSION) -o $(VERSION) $^
+generate: generate-go
+
+.PHONY: generate-go
+generate-go: $(fbs)
+	flatc --go --grpc $(GO_FLAGS) -o $(VERSION) $^
+
+.PHONY: generate-java
+generate-java: $(fbs)
+	flatc --java --grpc $(JAVA_FLAGS) -o $(VERSION) $^

--- a/api/fbs/v1/write.fbs
+++ b/api/fbs/v1/write.fbs
@@ -19,7 +19,7 @@ include "database.fbs";
 
 namespace banyandb.v1;
 
-table String {
+table Str {
     value: string;
 }
 
@@ -27,7 +27,7 @@ table Int {
     value: int64;
 }
 
-table StringArray {
+table StrArray {
     value: [string];
 }
 
@@ -36,8 +36,8 @@ table IntArray {
 }
 
 union ValueType {
-    String,
-    StringArray,
+    Str,
+    StrArray,
     Int,
     IntArray
 }

--- a/api/fbs/v1/write_generated.go
+++ b/api/fbs/v1/write_generated.go
@@ -11,27 +11,27 @@ import (
 type ValueType byte
 
 const (
-	ValueTypeNONE        ValueType = 0
-	ValueTypeString      ValueType = 1
-	ValueTypeStringArray ValueType = 2
-	ValueTypeInt         ValueType = 3
-	ValueTypeIntArray    ValueType = 4
+	ValueTypeNONE     ValueType = 0
+	ValueTypeStr      ValueType = 1
+	ValueTypeStrArray ValueType = 2
+	ValueTypeInt      ValueType = 3
+	ValueTypeIntArray ValueType = 4
 )
 
 var EnumNamesValueType = map[ValueType]string{
-	ValueTypeNONE:        "NONE",
-	ValueTypeString:      "String",
-	ValueTypeStringArray: "StringArray",
-	ValueTypeInt:         "Int",
-	ValueTypeIntArray:    "IntArray",
+	ValueTypeNONE:     "NONE",
+	ValueTypeStr:      "Str",
+	ValueTypeStrArray: "StrArray",
+	ValueTypeInt:      "Int",
+	ValueTypeIntArray: "IntArray",
 }
 
 var EnumValuesValueType = map[string]ValueType{
-	"NONE":        ValueTypeNONE,
-	"String":      ValueTypeString,
-	"StringArray": ValueTypeStringArray,
-	"Int":         ValueTypeInt,
-	"IntArray":    ValueTypeIntArray,
+	"NONE":     ValueTypeNONE,
+	"Str":      ValueTypeStr,
+	"StrArray": ValueTypeStrArray,
+	"Int":      ValueTypeInt,
+	"IntArray": ValueTypeIntArray,
 }
 
 func (v ValueType) String() string {
@@ -41,34 +41,34 @@ func (v ValueType) String() string {
 	return "ValueType(" + strconv.FormatInt(int64(v), 10) + ")"
 }
 
-type String struct {
+type Str struct {
 	_tab flatbuffers.Table
 }
 
-func GetRootAsString(buf []byte, offset flatbuffers.UOffsetT) *String {
+func GetRootAsStr(buf []byte, offset flatbuffers.UOffsetT) *Str {
 	n := flatbuffers.GetUOffsetT(buf[offset:])
-	x := &String{}
+	x := &Str{}
 	x.Init(buf, n+offset)
 	return x
 }
 
-func GetSizePrefixedRootAsString(buf []byte, offset flatbuffers.UOffsetT) *String {
+func GetSizePrefixedRootAsStr(buf []byte, offset flatbuffers.UOffsetT) *Str {
 	n := flatbuffers.GetUOffsetT(buf[offset+flatbuffers.SizeUint32:])
-	x := &String{}
+	x := &Str{}
 	x.Init(buf, n+offset+flatbuffers.SizeUint32)
 	return x
 }
 
-func (rcv *String) Init(buf []byte, i flatbuffers.UOffsetT) {
+func (rcv *Str) Init(buf []byte, i flatbuffers.UOffsetT) {
 	rcv._tab.Bytes = buf
 	rcv._tab.Pos = i
 }
 
-func (rcv *String) Table() flatbuffers.Table {
+func (rcv *Str) Table() flatbuffers.Table {
 	return rcv._tab
 }
 
-func (rcv *String) Value() []byte {
+func (rcv *Str) Value() []byte {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
 	if o != 0 {
 		return rcv._tab.ByteVector(o + rcv._tab.Pos)
@@ -76,13 +76,13 @@ func (rcv *String) Value() []byte {
 	return nil
 }
 
-func StringStart(builder *flatbuffers.Builder) {
+func StrStart(builder *flatbuffers.Builder) {
 	builder.StartObject(1)
 }
-func StringAddValue(builder *flatbuffers.Builder, value flatbuffers.UOffsetT) {
+func StrAddValue(builder *flatbuffers.Builder, value flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(0, flatbuffers.UOffsetT(value), 0)
 }
-func StringEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+func StrEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
 
@@ -135,34 +135,34 @@ func IntEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
 
-type StringArray struct {
+type StrArray struct {
 	_tab flatbuffers.Table
 }
 
-func GetRootAsStringArray(buf []byte, offset flatbuffers.UOffsetT) *StringArray {
+func GetRootAsStrArray(buf []byte, offset flatbuffers.UOffsetT) *StrArray {
 	n := flatbuffers.GetUOffsetT(buf[offset:])
-	x := &StringArray{}
+	x := &StrArray{}
 	x.Init(buf, n+offset)
 	return x
 }
 
-func GetSizePrefixedRootAsStringArray(buf []byte, offset flatbuffers.UOffsetT) *StringArray {
+func GetSizePrefixedRootAsStrArray(buf []byte, offset flatbuffers.UOffsetT) *StrArray {
 	n := flatbuffers.GetUOffsetT(buf[offset+flatbuffers.SizeUint32:])
-	x := &StringArray{}
+	x := &StrArray{}
 	x.Init(buf, n+offset+flatbuffers.SizeUint32)
 	return x
 }
 
-func (rcv *StringArray) Init(buf []byte, i flatbuffers.UOffsetT) {
+func (rcv *StrArray) Init(buf []byte, i flatbuffers.UOffsetT) {
 	rcv._tab.Bytes = buf
 	rcv._tab.Pos = i
 }
 
-func (rcv *StringArray) Table() flatbuffers.Table {
+func (rcv *StrArray) Table() flatbuffers.Table {
 	return rcv._tab
 }
 
-func (rcv *StringArray) Value(j int) []byte {
+func (rcv *StrArray) Value(j int) []byte {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
 	if o != 0 {
 		a := rcv._tab.Vector(o)
@@ -171,7 +171,7 @@ func (rcv *StringArray) Value(j int) []byte {
 	return nil
 }
 
-func (rcv *StringArray) ValueLength() int {
+func (rcv *StrArray) ValueLength() int {
 	o := flatbuffers.UOffsetT(rcv._tab.Offset(4))
 	if o != 0 {
 		return rcv._tab.VectorLen(o)
@@ -179,16 +179,16 @@ func (rcv *StringArray) ValueLength() int {
 	return 0
 }
 
-func StringArrayStart(builder *flatbuffers.Builder) {
+func StrArrayStart(builder *flatbuffers.Builder) {
 	builder.StartObject(1)
 }
-func StringArrayAddValue(builder *flatbuffers.Builder, value flatbuffers.UOffsetT) {
+func StrArrayAddValue(builder *flatbuffers.Builder, value flatbuffers.UOffsetT) {
 	builder.PrependUOffsetTSlot(0, flatbuffers.UOffsetT(value), 0)
 }
-func StringArrayStartValueVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
+func StrArrayStartValueVector(builder *flatbuffers.Builder, numElems int) flatbuffers.UOffsetT {
 	return builder.StartVector(4, numElems, 4)
 }
-func StringArrayEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
+func StrArrayEnd(builder *flatbuffers.Builder) flatbuffers.UOffsetT {
 	return builder.EndObject()
 }
 

--- a/banyand/series/trace/trace.go
+++ b/banyand/series/trace/trace.go
@@ -345,12 +345,12 @@ func (t *traceSeries) getTraceID(entityValue *v1.EntityValue) ([]byte, error) {
 	if !entityValue.Fields(f, int(t.traceIDIndex)) {
 		return nil, errors.Wrapf(ErrFieldNotFound, "trace_id index :%d", t.traceIDIndex)
 	}
-	if f.ValueType() != v1.ValueTypeString {
+	if f.ValueType() != v1.ValueTypeStr {
 		return nil, errors.Wrapf(ErrUnsupportedFieldType, "type:%s, supported type: String", f.ValueType().String())
 	}
 	unionTable := new(flatbuffers.Table)
 	f.Value(unionTable)
-	stringValue := new(v1.String)
+	stringValue := new(v1.Str)
 	stringValue.Init(unionTable.Bytes, unionTable.Pos)
 	return stringValue.Value(), nil
 }
@@ -381,14 +381,14 @@ func (t *traceSeries) getState(entityValue *v1.EntityValue) (state State, fieldS
 				intValue.Value(), t.intStateSuccessVal, t.intStateErrorVal)
 			return
 		}
-	case v1.ValueTypeString:
+	case v1.ValueTypeStr:
 		if t.stateFieldType != v1.FieldTypeString {
 			err = errors.Wrapf(ErrUnsupportedFieldType, "type:%s, supported type: String", f.ValueType().String())
 			return
 		}
 		unionTable := new(flatbuffers.Table)
 		f.Value(unionTable)
-		stringValue := new(v1.String)
+		stringValue := new(v1.Str)
 		stringValue.Init(unionTable.Bytes, unionTable.Pos)
 		switch string(stringValue.Value()) {
 		case t.strStateSuccessVal:

--- a/pkg/fb/api.go
+++ b/pkg/fb/api.go
@@ -101,10 +101,10 @@ func (b *WriteEntityBuilder) buildField(val interface{}) flatbuffers.UOffsetT {
 		valType = v1.ValueTypeIntArray
 	case string:
 		valueTypeOffset = b.buildStrValueType(v)
-		valType = v1.ValueTypeString
+		valType = v1.ValueTypeStr
 	case []string:
 		valueTypeOffset = b.buildStrValueType(v...)
-		valType = v1.ValueTypeStringArray
+		valType = v1.ValueTypeStrArray
 	default:
 		panic("not supported value")
 	}
@@ -121,18 +121,18 @@ func (b *WriteEntityBuilder) buildStrValueType(values ...string) flatbuffers.UOf
 		strOffsets = append(strOffsets, b.CreateString(values[i]))
 	}
 	if len(values) == 1 {
-		v1.StringStart(b.Builder)
-		v1.StringAddValue(b.Builder, strOffsets[0])
-		return v1.StringEnd(b.Builder)
+		v1.StrStart(b.Builder)
+		v1.StrAddValue(b.Builder, strOffsets[0])
+		return v1.StrEnd(b.Builder)
 	}
-	v1.StringArrayStartValueVector(b.Builder, len(values))
+	v1.StrArrayStartValueVector(b.Builder, len(values))
 	for i := len(strOffsets) - 1; i >= 0; i-- {
 		b.Builder.PrependUOffsetT(strOffsets[i])
 	}
 	int64Arr := b.Builder.EndVector(len(values))
-	v1.StringArrayStart(b.Builder)
-	v1.StringArrayAddValue(b.Builder, int64Arr)
-	return v1.StringArrayEnd(b.Builder)
+	v1.StrArrayStart(b.Builder)
+	v1.StrArrayAddValue(b.Builder, int64Arr)
+	return v1.StrArrayEnd(b.Builder)
 }
 
 func (b *WriteEntityBuilder) buildInt(values ...int64) flatbuffers.UOffsetT {

--- a/pkg/fb/util.go
+++ b/pkg/fb/util.go
@@ -35,15 +35,15 @@ func Transform(entityValue *v1.EntityValue, fieldsIndices []FieldEntry, builder 
 		case v1.ValueTypeNONE:
 			typedPair = v1.TypedPairNONE
 			pairOffset = 0
-		case v1.ValueTypeString, v1.ValueTypeStringArray:
+		case v1.ValueTypeStr, v1.ValueTypeStrArray:
 			typedPair = v1.TypedPairStrPair
-			stringValue, isStr := value.(*v1.String)
+			stringValue, isStr := value.(*v1.Str)
 			var l int
-			var stringArrayValue *v1.StringArray
+			var stringArrayValue *v1.StrArray
 			if isStr {
 				l = 1
 			} else {
-				stringArrayValue = value.(*v1.StringArray)
+				stringArrayValue = value.(*v1.StrArray)
 				l = stringArrayValue.ValueLength()
 			}
 			strPos := make([]flatbuffers.UOffsetT, 0, l)
@@ -56,7 +56,7 @@ func Transform(entityValue *v1.EntityValue, fieldsIndices []FieldEntry, builder 
 				}
 				strPos = append(strPos, o)
 			}
-			v1.StringArrayStartValueVector(builder, l)
+			v1.StrArrayStartValueVector(builder, l)
 			for j := l - 1; j >= 0; j-- {
 				builder.PrependUOffsetT(strPos[j])
 			}
@@ -119,21 +119,21 @@ func CopyFields(entityValue *v1.EntityValue, builder *flatbuffers.Builder) flatb
 		switch valueType {
 		case v1.ValueTypeNONE:
 			valueOffset = 0
-		case v1.ValueTypeString:
-			stringValue := value.(*v1.String)
+		case v1.ValueTypeStr:
+			stringValue := value.(*v1.Str)
 			pos := builder.CreateByteString(stringValue.Value())
-			v1.StringStart(builder)
-			v1.StringAddValue(builder, pos)
-			valueOffset = v1.StringEnd(builder)
+			v1.StrStart(builder)
+			v1.StrAddValue(builder, pos)
+			valueOffset = v1.StrEnd(builder)
 		case v1.ValueTypeInt:
 			intValue := value.(*v1.Int)
 			v1.IntStart(builder)
 			v1.IntAddValue(builder, intValue.Value())
 			valueOffset = v1.IntEnd(builder)
-		case v1.ValueTypeStringArray:
-			stringArrayValue := value.(*v1.StringArray)
+		case v1.ValueTypeStrArray:
+			stringArrayValue := value.(*v1.StrArray)
 			l := stringArrayValue.ValueLength()
-			v1.StringArrayStartValueVector(builder, l)
+			v1.StrArrayStartValueVector(builder, l)
 			strPos := make([]flatbuffers.UOffsetT, 0, l)
 			for j := 0; j < l; j++ {
 				strPos = append(strPos, builder.CreateByteString(stringArrayValue.Value(j)))
@@ -202,16 +202,16 @@ func VisitFields(entityValue *v1.EntityValue, fieldsIndices []FieldEntry, visit 
 		switch f.ValueType() {
 		case v1.ValueTypeNONE:
 			visit(key, f.ValueType(), nil)
-		case v1.ValueTypeString:
-			stringValue := new(v1.String)
+		case v1.ValueTypeStr:
+			stringValue := new(v1.Str)
 			stringValue.Init(unionTable.Bytes, unionTable.Pos)
 			visit(key, f.ValueType(), stringValue)
 		case v1.ValueTypeInt:
 			intValue := new(v1.Int)
 			intValue.Init(unionTable.Bytes, unionTable.Pos)
 			visit(key, f.ValueType(), intValue)
-		case v1.ValueTypeStringArray:
-			stringArrayValue := new(v1.StringArray)
+		case v1.ValueTypeStrArray:
+			stringArrayValue := new(v1.StrArray)
 			stringArrayValue.Init(unionTable.Bytes, unionTable.Pos)
 			visit(key, f.ValueType(), stringArrayValue)
 		case v1.ValueTypeIntArray:


### PR DESCRIPTION
Signed-off-by: Megrez Lu <lujiajing1126@gmail.com>

Since we use fbs in Java, I am going to run a benchmark for fb/pb in Java.

If we still use `String`, there will be conflicts between `banyandb.v1.String` and `java.lang.String` since `flatc` cannot generate fully-qualified names.

For example, the following `String` will be `banyandb.v1.String` in the same package rather than the native `java.lang.String`.

```java
// automatically generated by the FlatBuffers compiler, do not modify

package banyandb.v1;

public final class Action {
  private Action() { }
  public static final byte Put = 0;
  public static final byte Delete = 1;

  public static final String[] names = { "Put", "Delete", };

  public static String name(int e) { return names[e]; }
}
```
