### PR TITLE
Only run the `result` job after all needed jobs succeeded

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -31,7 +31,6 @@ github:
   protected_branches:
     main:
       required_status_checks:
-        strict: true
         contexts:
           - Continuous Integration
       required_pull_request_reviews:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -76,6 +76,7 @@ jobs:
       - name: Test
         run: make test
   result:
+    if: ${{ success() }}
     name: Continuous Integration
     runs-on: ubuntu-20.04
     needs: [check, build, test]


### PR DESCRIPTION
@wu-sheng this makes the logical job only run after all needed jobs succeeded, otherwise the logical job won't run and thus the CI will be pending