### PR TITLE
Fix docker CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           go-version: 1.16
       - name: install goimports
-        run: GO111MODULE=off go get golang.org/x/tools/cmd/goimports
+        run: go install golang.org/x/tools/cmd/goimports
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
       - name: Check License Header

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           go-version: 1.16
       - name: install goimports
-        run: go install golang.org/x/tools/cmd/goimports
+        run: go install golang.org/x/tools/cmd/goimports@latest
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
       - name: Check License Header

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.16
-      - name: install goimports
+      - name: Install goimports
         run: go install golang.org/x/tools/cmd/goimports@latest
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -17,6 +17,7 @@
 name: publish-docker
 
 on:
+  pull_request:
   push:
     branches:
       - main
@@ -41,6 +42,8 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.16
+      - name: install goimports
+        run: GO111MODULE=off go get golang.org/x/tools/cmd/goimports
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
       - name: Update dependencies 
@@ -49,11 +52,13 @@ jobs:
         run: make generate
       - name: Log in to the Container registry
         uses: docker/login-action@v1.10.0
+        if: github.ref == 'refs/heads/main'
         with:
           registry: ${{ env.HUB }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build docker image
+        if: github.ref == 'refs/heads/main'
         run: |
           make docker || make docker
           make docker.push || make docker.push

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -50,6 +50,9 @@ jobs:
         run: GOPROXY=https://proxy.golang.org go mod download
       - name: Generate codes
         run: make generate
+      - name: Build docker image
+        run: |
+          make docker || make docker
       - name: Log in to the Container registry
         uses: docker/login-action@v1.10.0
         if: github.ref == 'refs/heads/main'
@@ -57,8 +60,7 @@ jobs:
           registry: ${{ env.HUB }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build docker image
+      - name: Push docker image
         if: github.ref == 'refs/heads/main'
         run: |
-          make docker || make docker
           make docker.push || make docker.push

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           go-version: 1.16
       - name: install goimports
-        run: go install golang.org/x/tools/cmd/goimports
+        run: go install golang.org/x/tools/cmd/goimports@latest
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
       - name: Update dependencies 

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.16
-      - name: install goimports
+      - name: Install goimports
         run: go install golang.org/x/tools/cmd/goimports@latest
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
@@ -50,6 +50,8 @@ jobs:
         run: GOPROXY=https://proxy.golang.org go mod download
       - name: Generate codes
         run: make generate
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
       - name: Build docker image
         run: |
           make docker || make docker

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           go-version: 1.16
       - name: install goimports
-        run: GO111MODULE=off go get golang.org/x/tools/cmd/goimports
+        run: go install golang.org/x/tools/cmd/goimports
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
       - name: Update dependencies 

--- a/banyand/liaison/grpc/trace_test.go
+++ b/banyand/liaison/grpc/trace_test.go
@@ -162,9 +162,6 @@ func TestTraceService(t *testing.T) {
 						"webapp_id",
 						"10.0.0.1_id",
 						"/home_id",
-						"webapp",
-						"10.0.0.1",
-						"/home",
 						300,
 						1622933202000000000).
 					Timestamp(time.Now()).
@@ -204,9 +201,6 @@ func TestTraceService(t *testing.T) {
 						"webapp_id",
 						"10.0.0.1_id",
 						"/home_id",
-						"webapp",
-						"10.0.0.1",
-						"/home",
 						300,
 						1622933202000000000).
 					Timestamp(time.Now()).

--- a/scripts/build/docker.mk
+++ b/scripts/build/docker.mk
@@ -34,9 +34,9 @@ BUILD_ARGS := $(BUILD_ARGS) --build-arg CERT_IMAGE=alpine:edge --build-arg BASE_
 .PHONY: docker
 docker:
 	@echo "Build Skywalking/BanyanDB Docker Image"
-	@docker buildx build $(BUILD_ARGS) -t $(HUB):$(TAG) -f Dockerfile ..
+	@time docker buildx build $(BUILD_ARGS) -t $(HUB):$(TAG) -f Dockerfile ..
 
 .PHONY: docker.push
 docker.push:
 	@echo "Push Skywalking/BanyanDB Docker Image"
-	@docker push $(HUB):$(TAG)
+	@time docker push $(HUB):$(TAG)

--- a/scripts/build/docker.mk
+++ b/scripts/build/docker.mk
@@ -34,9 +34,9 @@ BUILD_ARGS := $(BUILD_ARGS) --build-arg CERT_IMAGE=alpine:edge --build-arg BASE_
 .PHONY: docker
 docker:
 	@echo "Build Skywalking/BanyanDB Docker Image"
-	@time (docker buildx build $(BUILD_ARGS) -t $(HUB):$(TAG) -f Dockerfile ..)
+	@docker buildx build $(BUILD_ARGS) -t $(HUB):$(TAG) -f Dockerfile ..
 
 .PHONY: docker.push
 docker.push:
 	@echo "Push Skywalking/BanyanDB Docker Image"
-	@time (docker push $(HUB):$(TAG))
+	@docker push $(HUB):$(TAG)

--- a/scripts/build/docker.mk
+++ b/scripts/build/docker.mk
@@ -39,4 +39,4 @@ docker:
 .PHONY: docker.push
 docker.push:
 	@echo "Push Skywalking/BanyanDB Docker Image"
-	time (docker push $(HUB):$(TAG))
+	@time (docker push $(HUB):$(TAG))


### PR DESCRIPTION
Signed-off-by: Megrez Lu <lujiajing1126@gmail.com>

1. Run docker build for both PR and main branch
2. Skip docker push for PR
3. Use `go install` instead of `go get` to install goimports due to [the recent change](https://blog.golang.org/go116-module-changes#TOC_4.) in go 1.1.6