### PR TITLE
Create group on initialization

### DIFF
--- a/banyand/metadata/metadata.go
+++ b/banyand/metadata/metadata.go
@@ -79,7 +79,12 @@ func (s *service) PreRun() error {
 		return err
 	}
 	<-s.schemaRegistry.ReadyNotify()
-	return nil
+	return s.initializeStorage()
+}
+
+// initializeStorage creates "default" group after the storage layer is ready
+func (s *service) initializeStorage() error {
+	return s.schemaRegistry.CreateGroup(context.TODO(), "default")
 }
 
 func (s *service) Serve() error {

--- a/banyand/metadata/metadata.go
+++ b/banyand/metadata/metadata.go
@@ -79,11 +79,11 @@ func (s *service) PreRun() error {
 		return err
 	}
 	<-s.schemaRegistry.ReadyNotify()
-	return s.initializeStorage()
+	return s.initializeMetadata()
 }
 
-// initializeStorage creates "default" group after the storage layer is ready
-func (s *service) initializeStorage() error {
+// initializeMetadata creates "default" group after the metadata storage layer is ready
+func (s *service) initializeMetadata() error {
 	return s.schemaRegistry.CreateGroup(context.TODO(), "default")
 }
 

--- a/banyand/metadata/schema/etcd.go
+++ b/banyand/metadata/schema/etcd.go
@@ -420,7 +420,7 @@ func (e *etcdSchemaRegistry) listWithPrefix(ctx context.Context, prefix string, 
 	entities := make([]proto.Message, resp.Count)
 	for i := int64(0); i < resp.Count; i++ {
 		message := factory()
-		if err := proto.Unmarshal(resp.Kvs[0].Value, message); err != nil {
+		if err := proto.Unmarshal(resp.Kvs[i].Value, message); err != nil {
 			return nil, err
 		}
 		entities[i] = message

--- a/banyand/query/processor.go
+++ b/banyand/query/processor.go
@@ -44,7 +44,6 @@ var (
 type queryProcessor struct {
 	streamService stream.Service
 	metaService   metadata.Service
-	logger        *logger.Logger
 	log           *logger.Logger
 	serviceRepo   discovery.ServiceRepo
 	pipeline      queue.Queue
@@ -62,31 +61,31 @@ func (q *queryProcessor) Rev(message bus.Message) (resp bus.Message) {
 	meta := queryCriteria.GetMetadata()
 	ec, err := q.streamService.Stream(meta)
 	if err != nil {
-		q.logger.Error().Err(err).Msg("fail to get measure execution context")
+		q.log.Error().Err(err).Msg("fail to get measure execution context")
 		return
 	}
 
 	analyzer, err := logical.CreateAnalyzerFromMetaService(q.metaService)
 	if err != nil {
-		q.logger.Error().Err(err).Msg("fail to build analyzer")
+		q.log.Error().Err(err).Msg("fail to build analyzer")
 		return
 	}
 
 	s, err := analyzer.BuildStreamSchema(context.TODO(), meta)
 	if err != nil {
-		q.logger.Error().Err(err).Msg("fail to build trace schema")
+		q.log.Error().Err(err).Msg("fail to build trace schema")
 		return
 	}
 
 	p, err := analyzer.Analyze(context.TODO(), queryCriteria, meta, s)
 	if err != nil {
-		q.logger.Error().Err(err).Msg("fail to analyze the query request")
+		q.log.Error().Err(err).Msg("fail to analyze the query request")
 		return
 	}
 
 	entities, err := p.Execute(ec)
 	if err != nil {
-		q.logger.Error().Err(err).Msg("fail to execute the query plan")
+		q.log.Error().Err(err).Msg("fail to execute the query plan")
 		return
 	}
 

--- a/pkg/test/measure/etcd.go
+++ b/pkg/test/measure/etcd.go
@@ -44,10 +44,6 @@ var (
 )
 
 func PreloadSchema(e schema.Registry) error {
-	if err := e.CreateGroup(context.TODO(), "default"); err != nil {
-		return err
-	}
-
 	s := &databasev1.Measure{}
 	if err := protojson.Unmarshal([]byte(measureJSON), s); err != nil {
 		return err

--- a/pkg/test/stream/etcd.go
+++ b/pkg/test/stream/etcd.go
@@ -44,10 +44,6 @@ var (
 )
 
 func PreloadSchema(e schema.Registry) error {
-	if err := e.CreateGroup(context.TODO(), "default"); err != nil {
-		return err
-	}
-
 	s := &databasev1.Stream{}
 	if err := protojson.Unmarshal([]byte(streamJSON), s); err != nil {
 		return err


### PR DESCRIPTION
This PR creates `default` group on initialization.

Besides, duplicated `logger` in stream service and subscription typo in metadata response are fixed.