### PR TITLE
Introduce preparation workflow for tests

### DIFF
--- a/banyand/metadata/schema/etcd.go
+++ b/banyand/metadata/schema/etcd.go
@@ -46,6 +46,8 @@ var (
 	ErrEntityNotFound             = errors.New("entity is not found")
 	ErrUnexpectedNumberOfEntities = errors.New("unexpected number of entities")
 
+	unixDomainSockScheme = "unix"
+
 	GroupsKeyPrefix           = "/groups/"
 	GroupMetadataKey          = "/__meta_group__"
 	StreamKeyPrefix           = "/streams/"
@@ -64,8 +66,8 @@ func RootDir(rootDir string) RegistryOption {
 
 func randomUnixDomainListener() (string, string) {
 	i := rand.Uint64()
-	return fmt.Sprintf("%s://localhost:%d%06d", "unix", os.Getpid(), i),
-		fmt.Sprintf("%s://localhost:%d%06d", "unix", os.Getpid(), i+1)
+	return fmt.Sprintf("%s://localhost:%d%06d", unixDomainSockScheme, os.Getpid(), i),
+		fmt.Sprintf("%s://localhost:%d%06d", unixDomainSockScheme, os.Getpid(), i+1)
 }
 
 func UseRandomListener() RegistryOption {

--- a/banyand/stream/stream_write_test.go
+++ b/banyand/stream/stream_write_test.go
@@ -250,7 +250,7 @@ func setup(t *testing.T) (*stream, test.StopFunc) {
 			}
 		})
 
-	req.NoError(flow.ErrorOrNil())
+	req.NoError(flow.Error())
 
 	return s, flow.Shutdown()
 }

--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,8 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
+	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jonboulle/clockwork v0.2.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/google/go-cmp v0.5.6
 	github.com/google/uuid v1.3.0
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/klauspost/compress v1.13.1
 	github.com/oklog/run v1.1.0
 	github.com/pkg/errors v0.9.1
@@ -49,7 +50,6 @@ require (
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
-	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jonboulle/clockwork v0.2.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/google/go-cmp v0.5.6
 	github.com/google/uuid v1.3.0
-	github.com/hashicorp/go-multierror v1.1.1
 	github.com/klauspost/compress v1.13.1
 	github.com/oklog/run v1.1.0
 	github.com/pkg/errors v0.9.1
@@ -49,7 +48,6 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
-	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jonboulle/clockwork v0.2.2 // indirect
@@ -91,7 +89,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v0.20.0 // indirect
 	go.opentelemetry.io/otel/trace v0.20.0 // indirect
 	go.opentelemetry.io/proto/otlp v0.7.0 // indirect
-	go.uber.org/atomic v1.7.0 // indirect
+	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/zap v1.17.0 // indirect
 	golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0 // indirect
 	golang.org/x/text v0.3.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -243,10 +243,14 @@ github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFb
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
+github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=

--- a/go.sum
+++ b/go.sum
@@ -243,14 +243,10 @@ github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFb
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
-github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
-github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
-github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
@@ -486,8 +482,9 @@ go.opentelemetry.io/otel/trace v0.20.0/go.mod h1:6GjCW8zgDjwGHGa6GkyeB8+/5vjT16g
 go.opentelemetry.io/proto/otlp v0.7.0 h1:rwOQPCuKAKmwGKq2aVNnYIibI6wnV7EvzgfTCzcdGg8=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
-go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
+go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/goleak v1.1.10 h1:z+mqJhf6ss6BSfSM671tgKyZBFPTTJM+HLxnhPC3wu0=
 go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=

--- a/pkg/test/setup.go
+++ b/pkg/test/setup.go
@@ -19,7 +19,6 @@ package test
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
@@ -92,16 +91,15 @@ func (tf *testFlow) Run(ctx context.Context, startFunc StartFunc, stopFunc StopF
 	}()
 
 	donec := make(chan struct{})
+	// start a new goroutine in order to recover from panic
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
-				fmt.Println("====== recover ======")
 				errCh <- errors.Errorf("panic found %v", r)
+				close(donec)
 			}
 		}()
-		fmt.Println("======== start run in loop =======")
 		err := startFunc()
-		fmt.Println("======== end run in loop =======")
 
 		if err != nil {
 			errCh <- err

--- a/pkg/test/setup.go
+++ b/pkg/test/setup.go
@@ -1,0 +1,129 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/pkg/errors"
+)
+
+type StartFunc func() error
+type StopFunc func()
+
+type Flow interface {
+	// PushErrorHandler only pushes a stopFunc
+	PushErrorHandler(StopFunc) Flow
+
+	// Run calls the startFunc and expects no error returned.
+	// If a non-nil error is returned or panic, shutdown must be called at once.
+	// The error will be stored and thus could be checked by the caller later.
+	Run(context.Context, StartFunc, StopFunc) Flow
+
+	// RunWithoutSideEffect calls the startFunc and does not expect any side effects from it.
+	// If a non-nil error is returned or panic, shutdown must be called at once.
+	// The error will be stored and thus could be checked by the caller later.
+	RunWithoutSideEffect(context.Context, StartFunc) Flow
+
+	// Shutdown does not actually shutdown the flow,
+	// but only returns a function containing all stopFunc(s) to be executed.
+	// The timing to do the real shutdown can be determined by users.
+	Shutdown() StopFunc
+
+	ErrorOrNil() error
+}
+
+type testFlow struct {
+	err       *multierror.Error
+	stopFuncs []StopFunc
+}
+
+// NewTestFlow creates a flow ready to prepare services/components to be used for testing.
+func NewTestFlow() Flow {
+	return &testFlow{
+		err:       &multierror.Error{},
+		stopFuncs: make([]StopFunc, 0),
+	}
+}
+
+// Shutdown does not actually call the shutdown functions but only return a composition of all
+// stop functions given by the user thus it allows the user to determine the timing.
+func (tf *testFlow) Shutdown() StopFunc {
+	return func() {
+		for idx := len(tf.stopFuncs) - 1; idx >= 0; idx-- {
+			tf.stopFuncs[idx]()
+		}
+	}
+}
+
+func (tf *testFlow) RunWithoutSideEffect(ctx context.Context, startFunc StartFunc) Flow {
+	return tf.Run(ctx, startFunc, nil)
+}
+
+func (tf *testFlow) Run(ctx context.Context, startFunc StartFunc, stopFunc StopFunc) Flow {
+	if tf.err.ErrorOrNil() != nil {
+		return tf
+	}
+
+	if stopFunc != nil {
+		tf.stopFuncs = append(tf.stopFuncs, stopFunc)
+	}
+
+	errCh := make(chan error)
+	defer func() {
+		close(errCh)
+	}()
+
+	donec := make(chan struct{})
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				fmt.Println("====== recover ======")
+				errCh <- errors.Errorf("panic found %v", r)
+			}
+		}()
+		fmt.Println("======== start run in loop =======")
+		err := startFunc()
+		fmt.Println("======== end run in loop =======")
+
+		if err != nil {
+			errCh <- err
+		}
+		close(donec)
+	}()
+	select {
+	case <-donec:
+	case err := <-errCh:
+		tf.err = multierror.Append(tf.err, err)
+		tf.Shutdown()()
+		return tf
+	}
+
+	return tf
+}
+
+func (tf *testFlow) PushErrorHandler(stopFunc StopFunc) Flow {
+	tf.stopFuncs = append(tf.stopFuncs, stopFunc)
+	return tf
+}
+
+func (tf *testFlow) ErrorOrNil() error {
+	return tf.err.ErrorOrNil()
+}

--- a/pkg/test/setup_test.go
+++ b/pkg/test/setup_test.go
@@ -1,0 +1,107 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Setup_Single_Error(t *testing.T) {
+	require := require.New(t)
+	wg := sync.WaitGroup{}
+	flow := NewTestFlow().
+		Run(context.TODO(), func() error {
+			wg.Add(1)
+			return errors.New("normal error")
+		}, func() {
+			wg.Done()
+		})
+
+	wg.Wait()
+
+	require.Error(flow.ErrorOrNil())
+}
+
+func Test_Setup_Multiple_ErrorHandlers(t *testing.T) {
+	require := require.New(t)
+	wg := sync.WaitGroup{}
+	flow := NewTestFlow().
+		Run(context.TODO(), func() error {
+			wg.Add(1)
+			return nil
+		}, func() {
+			wg.Done()
+		}).
+		Run(context.TODO(), func() error {
+			wg.Add(1)
+			return errors.New("normal error")
+		}, func() {
+			wg.Done()
+		})
+
+	wg.Wait()
+
+	require.Error(flow.ErrorOrNil())
+}
+
+func Test_Setup_Panic(t *testing.T) {
+	require := require.New(t)
+	wg := sync.WaitGroup{}
+	flow := NewTestFlow().
+		Run(context.TODO(), func() error {
+			wg.Add(1)
+			panic("oops...")
+		}, func() {
+			wg.Done()
+		})
+
+	wg.Wait()
+
+	require.Error(flow.ErrorOrNil())
+}
+
+func Test_Setup_Shutdown(t *testing.T) {
+	require := require.New(t)
+	wg := sync.WaitGroup{}
+	flow := NewTestFlow().
+		Run(context.TODO(), func() error {
+			wg.Add(1)
+			return nil
+		}, func() {
+			wg.Done()
+		}).
+		Run(context.TODO(), func() error {
+			wg.Add(1)
+			return nil
+		}, func() {
+			wg.Done()
+		})
+
+	go func() {
+		flow.Shutdown()()
+	}()
+
+	wg.Wait()
+
+	require.NoError(flow.ErrorOrNil())
+}

--- a/pkg/test/setup_test.go
+++ b/pkg/test/setup_test.go
@@ -39,7 +39,7 @@ func Test_Setup_Single_Error(t *testing.T) {
 
 	wg.Wait()
 
-	require.Error(flow.ErrorOrNil())
+	require.Error(flow.Error())
 }
 
 func Test_Setup_Multiple_ErrorHandlers(t *testing.T) {
@@ -61,7 +61,7 @@ func Test_Setup_Multiple_ErrorHandlers(t *testing.T) {
 
 	wg.Wait()
 
-	require.Error(flow.ErrorOrNil())
+	require.Error(flow.Error())
 }
 
 func Test_Setup_Panic(t *testing.T) {
@@ -77,7 +77,7 @@ func Test_Setup_Panic(t *testing.T) {
 
 	wg.Wait()
 
-	require.Error(flow.ErrorOrNil())
+	require.Error(flow.Error())
 }
 
 func Test_Setup_Shutdown(t *testing.T) {
@@ -103,5 +103,5 @@ func Test_Setup_Shutdown(t *testing.T) {
 
 	wg.Wait()
 
-	require.NoError(flow.ErrorOrNil())
+	require.NoError(flow.Error())
 }

--- a/pkg/test/stream/etcd.go
+++ b/pkg/test/stream/etcd.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"embed"
 	"fmt"
-	"math/rand"
 	"os"
 	"path"
 
@@ -87,10 +86,4 @@ func PreloadSchema(e schema.Registry) error {
 
 func RandomTempDir() string {
 	return path.Join(os.TempDir(), fmt.Sprintf("banyandb-embed-etcd-%s", uuid.New().String()))
-}
-
-func RandomUnixDomainListener() (string, string) {
-	i := rand.Uint64()
-	return fmt.Sprintf("%s://localhost:%d%06d", "unix", os.Getpid(), i),
-		fmt.Sprintf("%s://localhost:%d%06d", "unix", os.Getpid(), i+1)
 }


### PR DESCRIPTION
Previously, we setup all components and services which are necessary for tests manually, which may lead to resource leakages if an error is returned. And in some cases, we are using `testify.Require` package which calls `FailNow` at once after assertion failures.

This PR intends to introduce a workflow to prepare components/services before tests, and it could properly handle errors and  even `panic` by calling all registered `stopFunc` by previous steps.

There are still known issues:

1. `fcntl` cases

```
--- FAIL: Test_Stream_Write (5.89s)
    stream_write_test.go:253:
        	Error Trace:	stream_write_test.go:253
        	            				stream_write_test.go:42
        	Error:      	Received unexpected error:
        	            	1 error occurred:
        	            		* failed to open normal store: while opening memtables error: Unable to open mem dir.. Path=/var/folders/p0/8chn4dqn0w1c_yd0dw5byljc0000gn/T/banyandb-test-2643493976/shard-1/seg-20220105/block-1549/lsm/lsm. Error=open /var/folders/p0/8chn4dqn0w1c_yd0dw5byljc0000gn/T/banyandb-test-2643493976/shard-1/seg-20220105/block-1549/lsm/lsm: too many open files

        	Test:       	Test_Stream_Write
FAIL
FAIL	github.com/apache/skywalking-banyandb/banyand/stream	24.626s
```

We have no chance to handle `fcntl` failures while either running `startFunc` (e.g. `createDatabase`) or `stopFunc` (e.g. calling `os.RemoveAll`).

2. `os.Exit`

if someone call `os.Exit` in the middle of the program, the program may exit unexpectedly. A possible compensation may be listen to some well-known signals...