### PR TITLE
Fix timezone issue

### DIFF
--- a/banyand/tsdb/segment.go
+++ b/banyand/tsdb/segment.go
@@ -192,10 +192,10 @@ func (bc *blockController) startTime(suffix string) (time.Time, error) {
 	switch bc.blockSize.Unit {
 	case HOUR:
 		return time.Date(startTime.Year(), startTime.Month(),
-			startTime.Day(), t.Hour(), 0, 0, 0, time.UTC), nil
+			startTime.Day(), t.Hour(), 0, 0, 0, startTime.Location()), nil
 	case DAY:
 		return time.Date(startTime.Year(), startTime.Month(),
-			t.Day(), t.Hour(), 0, 0, 0, time.UTC), nil
+			t.Day(), t.Hour(), 0, 0, 0, startTime.Location()), nil
 	case MILLISECOND:
 		return time.Parse(millisecondFormat, suffix)
 	}

--- a/banyand/tsdb/shard.go
+++ b/banyand/tsdb/shard.go
@@ -237,11 +237,11 @@ func (sc *segmentController) Format(tm time.Time) string {
 func (sc *segmentController) Parse(value string) (time.Time, error) {
 	switch sc.segmentSize.Unit {
 	case HOUR:
-		return time.Parse(segHourFormat, value)
+		return time.ParseInLocation(segHourFormat, value, time.Local)
 	case DAY:
-		return time.Parse(segDayFormat, value)
+		return time.ParseInLocation(segDayFormat, value, time.Local)
 	case MILLISECOND:
-		return time.Parse(millisecondFormat, value)
+		return time.ParseInLocation(millisecondFormat, value, time.Local)
 	}
 	panic("invalid interval unit")
 }


### PR DESCRIPTION
This PR fixes timezone issue introduced in PR #73 

Currently the `time.Local` is used to ensure consistency.

But I am curious why liaison test passed. @hanahmily 