### PR TITLE
Add a queue to track and close blocks

### DIFF
--- a/banyand/tsdb/bucket/bucket.go
+++ b/banyand/tsdb/bucket/bucket.go
@@ -26,6 +26,7 @@ import (
 type Controller interface {
 	Current() Reporter
 	Next() (Reporter, error)
+	OnMove(prev, next Reporter)
 }
 
 type Status struct {
@@ -38,6 +39,7 @@ type Channel chan Status
 type Reporter interface {
 	Report() Channel
 	Stop()
+	String() string
 }
 
 type timeBasedReporter struct {

--- a/banyand/tsdb/bucket/queue.go
+++ b/banyand/tsdb/bucket/queue.go
@@ -1,0 +1,145 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+package bucket
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/hashicorp/golang-lru/simplelru"
+)
+
+type EvictFn func(id interface{})
+
+type Queue interface {
+	Push(id interface{})
+	Len() int
+}
+
+const (
+	DefaultRecentRatio  = 0.25
+	DefaultGhostEntries = 0.50
+)
+
+var ErrInvalidSize = errors.New("invalid size")
+
+type lruQueue struct {
+	size       int
+	recentSize int
+	evictSize  int
+	evictFn    EvictFn
+
+	recent      simplelru.LRUCache
+	frequent    simplelru.LRUCache
+	recentEvict simplelru.LRUCache
+	lock        sync.RWMutex
+}
+
+func NewQueue(size int, evictFn EvictFn) (Queue, error) {
+	if size <= 0 {
+		return nil, ErrInvalidSize
+	}
+
+	recentSize := int(float64(size) * DefaultRecentRatio)
+	evictSize := int(float64(size) * DefaultGhostEntries)
+
+	recent, err := simplelru.NewLRU(size, nil)
+	if err != nil {
+		return nil, err
+	}
+	frequent, err := simplelru.NewLRU(size, nil)
+	if err != nil {
+		return nil, err
+	}
+	recentEvict, err := simplelru.NewLRU(evictSize, nil)
+	if err != nil {
+		return nil, err
+	}
+	c := &lruQueue{
+		size:        size,
+		recentSize:  recentSize,
+		recent:      recent,
+		frequent:    frequent,
+		recentEvict: recentEvict,
+		evictSize:   evictSize,
+		evictFn:     evictFn,
+	}
+	return c, nil
+}
+
+func (q *lruQueue) Push(id interface{}) {
+	q.lock.Lock()
+	defer q.lock.Unlock()
+
+	if q.frequent.Contains(id) {
+		q.frequent.Add(id, nil)
+		return
+	}
+
+	if q.recent.Contains(id) {
+		q.recent.Remove(id)
+		q.frequent.Add(id, nil)
+		return
+	}
+
+	if q.recentEvict.Contains(id) {
+		q.ensureSpace(true)
+		q.recentEvict.Remove(id)
+		q.frequent.Add(id, nil)
+		return
+	}
+
+	q.ensureSpace(false)
+	q.recent.Add(id, nil)
+}
+
+func (q *lruQueue) Len() int {
+	q.lock.RLock()
+	defer q.lock.RUnlock()
+	return q.recent.Len() + q.frequent.Len()
+}
+
+func (q *lruQueue) ensureSpace(recentEvict bool) {
+	recentLen := q.recent.Len()
+	freqLen := q.frequent.Len()
+	if recentLen+freqLen < q.size {
+		return
+	}
+	if recentLen > 0 && (recentLen > q.recentSize || (recentLen == q.recentSize && !recentEvict)) {
+		k, _, _ := q.recent.RemoveOldest()
+		q.addLst(q.recentEvict, q.evictSize, k)
+		return
+	}
+	q.removeOldest(q.frequent)
+}
+
+func (q *lruQueue) addLst(lst simplelru.LRUCache, size int, id interface{}) {
+	if lst.Len() < size {
+		lst.Add(id, nil)
+		return
+	}
+	q.removeOldest(lst)
+	lst.Add(id, nil)
+}
+
+func (q *lruQueue) removeOldest(lst simplelru.LRUCache) {
+	oldestID, _, ok := lst.RemoveOldest()
+	if ok && q.evictFn != nil {
+		q.evictFn(oldestID)
+	}
+}

--- a/banyand/tsdb/bucket/queue_test.go
+++ b/banyand/tsdb/bucket/queue_test.go
@@ -1,0 +1,56 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+package bucket_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/apache/skywalking-banyandb/banyand/tsdb/bucket"
+)
+
+type queueEntryID struct {
+	first  uint16
+	second uint16
+}
+
+func entryID(id uint16) queueEntryID {
+	return queueEntryID{
+		first:  id,
+		second: id + 1,
+	}
+}
+
+var _ = Describe("Queue", func() {
+	It("pushes data", func() {
+		evictLst := make([]queueEntryID, 0)
+		l, err := bucket.NewQueue(128, func(id interface{}) {
+			evictLst = append(evictLst, id.(queueEntryID))
+		})
+		Expect(err).ShouldNot(HaveOccurred())
+
+		for i := 0; i < 256; i++ {
+			l.Push(entryID(uint16(i)))
+		}
+		Expect(l.Len()).To(Equal(128))
+		Expect(len(evictLst)).To(Equal(64))
+		for i := 0; i < 64; i++ {
+			Expect(evictLst[i]).To(Equal(entryID(uint16(i))))
+		}
+	})
+})

--- a/banyand/tsdb/bucket/strategy.go
+++ b/banyand/tsdb/bucket/strategy.go
@@ -111,6 +111,7 @@ func (s *Strategy) Run() {
 					}
 				}
 				if ratio >= 1.0 {
+					s.ctrl.OnMove(s.current, s.next)
 					s.current = s.next
 					s.next = nil
 					goto bucket

--- a/banyand/tsdb/bucket/strategy_test.go
+++ b/banyand/tsdb/bucket/strategy_test.go
@@ -109,6 +109,9 @@ func (c *controller) Current() bucket.Reporter {
 	return c.reporter
 }
 
+func (c *controller) OnMove(prev bucket.Reporter, next bucket.Reporter) {
+}
+
 func (c *controller) newReporter() {
 	c.reporter = &reporter{step: c.step, capacity: c.capacity}
 }
@@ -141,4 +144,8 @@ func (r *reporter) Report() bucket.Channel {
 }
 
 func (r *reporter) Stop() {
+}
+
+func (r *reporter) String() string {
+	return "default"
 }

--- a/banyand/tsdb/shard_test.go
+++ b/banyand/tsdb/shard_test.go
@@ -123,7 +123,7 @@ var _ = Describe("Shard", func() {
 				})
 				Expect(errInternal).NotTo(HaveOccurred())
 				return num
-			}).WithTimeout(10 * time.Second).Should(BeNumerically(">=", 2))
+			}).WithTimeout(30 * time.Second).Should(BeNumerically(">=", 1))
 		})
 
 	})

--- a/banyand/tsdb/shard_test.go
+++ b/banyand/tsdb/shard_test.go
@@ -19,6 +19,9 @@ package tsdb_test
 
 import (
 	"context"
+	"errors"
+	"os"
+	"path"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -55,6 +58,7 @@ var _ = Describe("Shard", func() {
 					Unit: tsdb.MILLISECOND,
 					Num:  1000,
 				},
+				1<<4,
 			)
 			Expect(err).NotTo(HaveOccurred())
 			segDirectories := make([]string, 3)
@@ -81,6 +85,45 @@ var _ = Describe("Shard", func() {
 					return num
 				}).WithTimeout(10 * time.Second).Should(BeNumerically(">=", 3))
 			}
+		})
+		It("closes blocks", func() {
+			var err error
+			shard, err = tsdb.OpenShard(context.TODO(), common.ShardID(0), tmp,
+				tsdb.IntervalRule{
+					Unit: tsdb.DAY,
+					Num:  1,
+				},
+				tsdb.IntervalRule{
+					Unit: tsdb.MILLISECOND,
+					Num:  1000,
+				},
+				2,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			var segDirectory string
+			Eventually(func() int {
+				num := 0
+				errInternal := tsdb.WalkDir(tmp+"/shard-0", "seg-", func(suffix, absolutePath string) error {
+					if num < 1 {
+						segDirectory = absolutePath
+					}
+					num++
+					return nil
+				})
+				Expect(errInternal).NotTo(HaveOccurred())
+				return num
+			}).WithTimeout(10 * time.Second).Should(BeNumerically(">=", 1))
+			Eventually(func() int {
+				num := 0
+				errInternal := tsdb.WalkDir(segDirectory, "block-", func(suffix, absolutePath string) error {
+					if _, err := os.Stat(path.Join(absolutePath, "store", "LOCK")); errors.Is(err, os.ErrNotExist) {
+						num++
+					}
+					return nil
+				})
+				Expect(errInternal).NotTo(HaveOccurred())
+				return num
+			}).WithTimeout(10 * time.Second).Should(BeNumerically(">=", 2))
 		})
 
 	})

--- a/banyand/tsdb/tsdb.go
+++ b/banyand/tsdb/tsdb.go
@@ -186,7 +186,7 @@ func createDatabase(ctx context.Context, db *database, startID int) (Database, e
 	for i := startID; i < int(db.shardNum); i++ {
 		db.logger.Info().Int("shard_id", i).Msg("creating a shard")
 		so, errNewShard := OpenShard(ctx, common.ShardID(i),
-			db.location, db.segmentSize, db.blockSize)
+			db.location, db.segmentSize, db.blockSize, defaultBlockQueueSize)
 		if errNewShard != nil {
 			err = multierr.Append(err, errNewShard)
 			continue
@@ -216,6 +216,7 @@ func loadDatabase(ctx context.Context, db *database) (Database, error) {
 			db.location,
 			db.segmentSize,
 			db.blockSize,
+			defaultBlockQueueSize,
 		)
 		if errOpenShard != nil {
 			return errOpenShard

--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
+	github.com/hashicorp/golang-lru v0.5.4
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jonboulle/clockwork v0.2.2 // indirect
@@ -93,7 +94,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v0.20.0 // indirect
 	go.opentelemetry.io/otel/trace v0.20.0 // indirect
 	go.opentelemetry.io/proto/otlp v0.7.0 // indirect
-	go.uber.org/atomic v1.9.0 // indirect
+	go.uber.org/atomic v1.9.0
 	go.uber.org/zap v1.17.0 // indirect
 	golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0 // indirect
 	golang.org/x/text v0.3.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -258,6 +258,8 @@ github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
+github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=

--- a/pkg/timestamp/range.go
+++ b/pkg/timestamp/range.go
@@ -53,6 +53,24 @@ func (t TimeRange) Duration() time.Duration {
 	return t.End.Sub(t.Start)
 }
 
+func (t TimeRange) String() string {
+	var buf []byte
+	if t.IncludeStart {
+		buf = []byte("[")
+	} else {
+		buf = []byte("(")
+	}
+	buf = append(buf, t.Start.String()...)
+	buf = append(buf, ", "...)
+	buf = append(buf, t.End.String()...)
+	if t.IncludeEnd {
+		buf = append(buf, "]"...)
+	} else {
+		buf = append(buf, ")"...)
+	}
+	return string(buf)
+}
+
 func NewInclusiveTimeRange(start, end time.Time) TimeRange {
 	return TimeRange{
 		Start:        start,


### PR DESCRIPTION
These changes tend to introduce an LRU queue to track blocks both frequently and recently. When it's not the hot block, the block is moved to the queue and gets closed on evicted from the queue. The default size of a queue in a shard is 16, which means that up to 24(16+8) blocks could keep open. The extra 8 blocks belong to a survived list containing evicted blocks added recently.

Caveat: the hot block in the current writing window is not tracked by the queue.


Signed-off-by: Gao Hongtao <hanahmily@gmail.com>