### PR TITLE
Fix the index iterator overflow

### DIFF
--- a/banyand/stream/stream_write.go
+++ b/banyand/stream/stream_write.go
@@ -111,6 +111,7 @@ func (s *stream) write(shardID common.ShardID, seriesHashKey []byte, value *stre
 			Int("ts_nano", t.Nanosecond()).
 			Interface("data", value).
 			Uint64("series_id", uint64(series.ID())).
+			Uint64("item_id", uint64(writer.ItemID().ID)).
 			Int("shard_id", int(shardID)).
 			Str("stream", sm.Metadata.GetName()).
 			Msg("write stream")

--- a/banyand/tsdb/segment.go
+++ b/banyand/tsdb/segment.go
@@ -217,11 +217,15 @@ func (bc *blockController) blocks() []*block {
 }
 
 func (bc *blockController) search(matcher func(*block) bool) (bb []*block) {
-	bc.RLock()
-	defer bc.RUnlock()
-	last := len(bc.lst) - 1
-	for i := range bc.lst {
-		b := bc.lst[last-i]
+	snapshotLst := func() []*block {
+		bc.RLock()
+		defer bc.RUnlock()
+		return bc.lst
+	}
+	lst := snapshotLst()
+	last := len(lst) - 1
+	for i := range lst {
+		b := lst[last-i]
 		if matcher(b) {
 			bb = append(bb, b)
 		}

--- a/banyand/tsdb/series_write.go
+++ b/banyand/tsdb/series_write.go
@@ -19,6 +19,7 @@ package tsdb
 
 import (
 	"bytes"
+	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -39,6 +40,7 @@ type Writer interface {
 	IndexWriter
 	Write() (GlobalItemID, error)
 	ItemID() GlobalItemID
+	String() string
 }
 
 var _ WriterBuilder = (*writerBuilder)(nil)
@@ -149,6 +151,17 @@ func (w *writer) WriteLSMIndex(field index.Field) error {
 func (w *writer) WriteInvertedIndex(field index.Field) error {
 	field.Key.SeriesID = w.itemID.SeriesID
 	return w.block.writeInvertedIndex(field, w.itemID.ID)
+}
+
+func (w *writer) String() string {
+	var buf []byte
+	buf = append(buf, "block:"...)
+	buf = append(buf, w.block.String()...)
+	buf = append(buf, ",column:"...)
+	buf = append(buf, fmt.Sprintf("%+v", w.columns)...)
+	buf = append(buf, ",ts:"...)
+	buf = append(buf, w.ts.String()...)
+	return string(buf)
 }
 
 type dataBucket struct {

--- a/banyand/tsdb/seriesdb.go
+++ b/banyand/tsdb/seriesdb.go
@@ -191,7 +191,7 @@ func (s *seriesDB) List(path Path) (SeriesList, error) {
 			s.l.Debug().
 				Hex("path", path.prefix).
 				Uint64("series_id", uint64(seriesID)).
-				Msg("got a series")
+				Msg("got a series with a full path")
 			return []Series{newSeries(s.context(), seriesID, s)}, nil
 		}
 		s.l.Debug().Hex("path", path.prefix).Msg("doesn't get any series")

--- a/banyand/tsdb/shard.go
+++ b/banyand/tsdb/shard.go
@@ -209,11 +209,10 @@ func newSegmentController(location string, segmentSize, blockSize IntervalRule, 
 }
 
 func (sc *segmentController) get(segID uint16) *segment {
-	sc.RLock()
-	defer sc.RUnlock()
-	last := len(sc.lst) - 1
-	for i := range sc.lst {
-		s := sc.lst[last-i]
+	lst := sc.snapshotLst()
+	last := len(lst) - 1
+	for i := range lst {
+		s := lst[last-i]
 		if s.id == segID {
 			return s
 		}
@@ -222,16 +221,21 @@ func (sc *segmentController) get(segID uint16) *segment {
 }
 
 func (sc *segmentController) span(timeRange timestamp.TimeRange) (ss []*segment) {
-	sc.RLock()
-	defer sc.RUnlock()
-	last := len(sc.lst) - 1
-	for i := range sc.lst {
-		s := sc.lst[last-i]
+	lst := sc.snapshotLst()
+	last := len(lst) - 1
+	for i := range lst {
+		s := lst[last-i]
 		if s.Overlapping(timeRange) {
 			ss = append(ss, s)
 		}
 	}
 	return ss
+}
+
+func (sc *segmentController) snapshotLst() []*segment {
+	sc.RLock()
+	defer sc.RUnlock()
+	return sc.lst
 }
 
 func (sc *segmentController) segments() (ss []*segment) {

--- a/go.mod
+++ b/go.mod
@@ -94,7 +94,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v0.20.0 // indirect
 	go.opentelemetry.io/otel/trace v0.20.0 // indirect
 	go.opentelemetry.io/proto/otlp v0.7.0 // indirect
-	go.uber.org/atomic v1.9.0 // indirect
+	go.uber.org/atomic v1.9.0
 	go.uber.org/zap v1.17.0 // indirect
 	golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0 // indirect
 	golang.org/x/text v0.3.6 // indirect

--- a/pkg/index/inverted/inverted.go
+++ b/pkg/index/inverted/inverted.go
@@ -42,6 +42,8 @@ type store struct {
 	memTable          *memTable
 	immutableMemTable *memTable
 	rwMutex           sync.RWMutex
+
+	l *logger.Logger
 }
 
 type StoreOpts struct {
@@ -65,6 +67,7 @@ func NewStore(opts StoreOpts) (index.Store, error) {
 		memTable:     newMemTable(),
 		diskTable:    diskTable,
 		termMetadata: md,
+		l:            opts.Logger,
 	}, nil
 }
 
@@ -166,7 +169,7 @@ func (s *store) Iterator(fieldKey index.FieldKey, termRange index.RangeOpts,
 		}
 		iters = append(iters, it)
 	}
-	it, err := index.NewFieldIteratorTemplate(fieldKey, termRange, order, s.diskTable, s.termMetadata,
+	it, err := index.NewFieldIteratorTemplate(s.l, fieldKey, termRange, order, s.diskTable, s.termMetadata,
 		func(term, val []byte, delegated kv.Iterator) (*index.PostingValue, error) {
 			list := roaring.NewPostingList()
 			err := list.Unmarshall(val)

--- a/pkg/index/lsm/lsm.go
+++ b/pkg/index/lsm/lsm.go
@@ -33,6 +33,7 @@ var _ index.Store = (*store)(nil)
 type store struct {
 	lsm          kv.Store
 	termMetadata metadata.Term
+	l            *logger.Logger
 }
 
 func (s *store) Close() error {
@@ -69,5 +70,6 @@ func NewStore(opts StoreOpts) (index.Store, error) {
 	return &store{
 		lsm:          lsm,
 		termMetadata: md,
+		l:            opts.Logger,
 	}, nil
 }

--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/oklog/run"
+	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 	"go.uber.org/multierr"
 
@@ -231,7 +232,7 @@ func (g *Group) RunConfig() (interrupted bool, err error) {
 
 	// Load config from env and file
 	if err = config.Load(g.f.Name, g.f.FlagSet); err != nil {
-		return false, err
+		return false, errors.Wrapf(err, "%s fails to load config", g.f.Name)
 	}
 
 	// bail early on help or version requests


### PR DESCRIPTION
The index iterator would overflow when the index module stores several streams' indices. 

Signed-off-by: Gao Hongtao <hanahmily@gmail.com>