### PR TITLE
Introduce the clock mock to test block controller

### DIFF
--- a/banyand/tsdb/block.go
+++ b/banyand/tsdb/block.go
@@ -82,7 +82,7 @@ func newBlock(ctx context.Context, opts blockOpts) (b *block, err error) {
 	if err != nil {
 		return nil, err
 	}
-	id := uint16(opts.blockSize.Unit)<<12 | ((uint16(suffixInteger) << 4) >> 4)
+	id := GenerateInternalID(opts.blockSize.Unit, suffixInteger)
 	timeRange := timestamp.NewTimeRange(opts.startTime, opts.blockSize.NextTime(opts.startTime), true, false)
 	encodingMethodObject := ctx.Value(encodingMethodKey)
 	if encodingMethodObject == nil {
@@ -91,13 +91,14 @@ func newBlock(ctx context.Context, opts blockOpts) (b *block, err error) {
 			DecoderPool: encoding.NewPlainDecoderPool(0),
 		}
 	}
+	clock, _ := timestamp.GetClock(ctx)
 	b = &block{
 		segID:          opts.segID,
 		blockID:        id,
 		path:           opts.path,
 		l:              logger.Fetch(ctx, "block"),
 		TimeRange:      timeRange,
-		Reporter:       bucket.NewTimeBasedReporter(timeRange),
+		Reporter:       bucket.NewTimeBasedReporter(timeRange, clock),
 		closed:         atomic.NewBool(true),
 		encodingMethod: encodingMethodObject.(EncodingMethod),
 	}

--- a/banyand/tsdb/bucket/queue.go
+++ b/banyand/tsdb/bucket/queue.go
@@ -29,6 +29,7 @@ type EvictFn func(id interface{})
 type Queue interface {
 	Push(id interface{})
 	Len() int
+	All() []interface{}
 }
 
 const (
@@ -112,6 +113,16 @@ func (q *lruQueue) Len() int {
 	q.lock.RLock()
 	defer q.lock.RUnlock()
 	return q.recent.Len() + q.frequent.Len()
+}
+
+func (q *lruQueue) All() []interface{} {
+	q.lock.RLock()
+	defer q.lock.RUnlock()
+	all := make([]interface{}, q.recent.Len()+q.frequent.Len()+q.recentEvict.Len())
+	copy(all, q.recent.Keys())
+	copy(all[q.recent.Len():], q.frequent.Keys())
+	copy(all[q.recent.Len()+q.frequent.Len():], q.recentEvict.Keys())
+	return all
 }
 
 func (q *lruQueue) ensureSpace(recentEvict bool) {

--- a/banyand/tsdb/bucket/strategy.go
+++ b/banyand/tsdb/bucket/strategy.go
@@ -124,5 +124,6 @@ func (s *Strategy) Run() {
 }
 
 func (s *Strategy) Close() {
+	s.ctrl.OnMove(s.current, nil)
 	close(s.stopCh)
 }

--- a/banyand/tsdb/shard_test.go
+++ b/banyand/tsdb/shard_test.go
@@ -19,9 +19,6 @@ package tsdb_test
 
 import (
 	"context"
-	"errors"
-	"os"
-	"path"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -30,19 +27,21 @@ import (
 	"github.com/apache/skywalking-banyandb/api/common"
 	"github.com/apache/skywalking-banyandb/banyand/tsdb"
 	"github.com/apache/skywalking-banyandb/pkg/test"
+	"github.com/apache/skywalking-banyandb/pkg/timestamp"
 )
-
-var defaultEventallyTimeout = time.Minute
 
 var _ = Describe("Shard", func() {
 	Describe("Generate segments and blocks", func() {
 		var tmp string
 		var deferFn func()
 		var shard tsdb.Shard
+		var clock timestamp.MockClock
 
 		BeforeEach(func() {
 			var err error
 			tmp, deferFn, err = test.NewSpace()
+			Expect(err).NotTo(HaveOccurred())
+			clock = timestamp.NewMockClock()
 			Expect(err).NotTo(HaveOccurred())
 		})
 		AfterEach(func() {
@@ -50,130 +49,337 @@ var _ = Describe("Shard", func() {
 			deferFn()
 		})
 		It("generates several segments and blocks", func() {
+			By("open 4 blocks")
 			var err error
-			shard, err = tsdb.OpenShard(context.TODO(), common.ShardID(0), tmp,
-				tsdb.IntervalRule{
-					Unit: tsdb.MILLISECOND,
-					Num:  3000,
-				},
-				tsdb.IntervalRule{
-					Unit: tsdb.MILLISECOND,
-					Num:  1000,
-				},
-				1<<4,
-			)
-			Expect(err).NotTo(HaveOccurred())
-			segDirectories := make([]string, 3)
-			Eventually(func() int {
-				num := 0
-				err := tsdb.WalkDir(tmp+"/shard-0", "seg-", func(suffix, absolutePath string) error {
-					if num < 3 {
-						segDirectories[num] = absolutePath
-					}
-					num++
-					return nil
-				})
-				Expect(err).NotTo(HaveOccurred())
-				return num
-			}).WithTimeout(defaultEventallyTimeout).Should(BeNumerically(">=", 3))
-			for _, d := range segDirectories {
-				Eventually(func() int {
-					num := 0
-					err := tsdb.WalkDir(d, "block-", func(suffix, absolutePath string) error {
-						num++
-						return nil
-					})
-					Expect(err).NotTo(HaveOccurred())
-					return num
-				}).WithTimeout(defaultEventallyTimeout).Should(BeNumerically(">=", 3))
-			}
-		})
-		It("closes blocks", func() {
-			var err error
-			shard, err = tsdb.OpenShard(context.TODO(), common.ShardID(0), tmp,
+			shard, err = tsdb.OpenShard(timestamp.SetClock(context.Background(), clock), common.ShardID(0), tmp,
 				tsdb.IntervalRule{
 					Unit: tsdb.DAY,
 					Num:  1,
 				},
 				tsdb.IntervalRule{
-					Unit: tsdb.MILLISECOND,
-					Num:  1000,
+					Unit: tsdb.HOUR,
+					Num:  12,
 				},
 				2,
 			)
 			Expect(err).NotTo(HaveOccurred())
-			var segDirectory string
-			Eventually(func() int {
-				num := 0
-				errInternal := tsdb.WalkDir(tmp+"/shard-0", "seg-", func(suffix, absolutePath string) error {
-					if num < 1 {
-						segDirectory = absolutePath
-					}
-					num++
-					return nil
-				})
-				Expect(errInternal).NotTo(HaveOccurred())
-				return num
-			}).WithTimeout(defaultEventallyTimeout).Should(BeNumerically(">=", 1))
-			Eventually(func() int {
-				num := 0
-				errInternal := tsdb.WalkDir(segDirectory, "block-", func(suffix, absolutePath string) error {
-					if _, err := os.Stat(path.Join(absolutePath, "store", "LOCK")); errors.Is(err, os.ErrNotExist) {
-						num++
-					}
-					return nil
-				})
-				Expect(errInternal).NotTo(HaveOccurred())
-				return num
-			}).WithTimeout(defaultEventallyTimeout).Should(BeNumerically(">=", 1))
-		})
-		It("reopens closed blocks", func() {
-			var err error
-			shard, err = tsdb.OpenShard(context.TODO(), common.ShardID(0), tmp,
-				tsdb.IntervalRule{
-					Unit: tsdb.MILLISECOND,
-					Num:  3000,
+			By("1st block is opened")
+			t1 := clock.Now()
+			Eventually(func() []tsdb.BlockState {
+				return shard.State().Blocks
+			}).Should(Equal([]tsdb.BlockState{
+				{
+					ID: tsdb.BlockID{
+						SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700101),
+						BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 00),
+					},
+					TimeRange: timestamp.NewTimeRangeDuration(t1, 12*time.Hour, true, false),
 				},
-				tsdb.IntervalRule{
-					Unit: tsdb.MILLISECOND,
-					Num:  1000,
+			}))
+			By("2nd block is opened")
+			// 01 10:00
+			clock.Add(10 * time.Hour)
+			t2 := clock.Now().Add(2 * time.Hour)
+			Eventually(func() []tsdb.BlockState {
+				return shard.State().Blocks
+			}).Should(Equal([]tsdb.BlockState{
+				{
+					ID: tsdb.BlockID{
+						SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700101),
+						BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 00),
+					},
+					TimeRange: timestamp.NewTimeRangeDuration(t1, 12*time.Hour, true, false),
 				},
-				2,
-			)
-			Expect(err).NotTo(HaveOccurred())
-			Eventually(func() int {
-				num := 0
-				for _, bs := range shard.State().OpenedBlocks {
-					if !bs.Closed {
-						num++
-					}
-				}
-				return num
-			}).WithTimeout(defaultEventallyTimeout).Should(BeNumerically(">=", 2))
-			var closedBlocks []tsdb.BlockState
-			Eventually(func() int {
-				closedBlocks = nil
-				for _, ob := range shard.State().OpenedBlocks {
-					if ob.Closed {
-						closedBlocks = append(closedBlocks, ob)
-					}
-				}
-				return len(closedBlocks)
-			}).WithTimeout(defaultEventallyTimeout).Should(BeNumerically(">=", 1))
+				{
+					ID: tsdb.BlockID{
+						SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700101),
+						BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 12),
+					},
+					TimeRange: timestamp.NewTimeRangeDuration(t2, 12*time.Hour, true, false),
+				},
+			}))
+			Eventually(func() []tsdb.BlockID {
+				return shard.State().OpenBlocks
+			}).Should(Equal([]tsdb.BlockID{}))
+			By("moves to the 2nd block")
+			// 01 13:00
+			clock.Add(3 * time.Hour)
+			Eventually(func() []tsdb.BlockID {
+				return shard.State().OpenBlocks
+			}).Should(Equal([]tsdb.BlockID{
+				{
+					SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700101),
+					BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 00),
+				},
+			}))
+			By("3rd block is opened")
+			// 01 22:00
+			clock.Add(9 * time.Hour)
+			t3 := clock.Now().Add(2 * time.Hour)
+			Eventually(func() []tsdb.BlockState {
+				return shard.State().Blocks
+			}).Should(Equal([]tsdb.BlockState{
+				{
+					ID: tsdb.BlockID{
+						SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700101),
+						BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 00),
+					},
+					TimeRange: timestamp.NewTimeRangeDuration(t1, 12*time.Hour, true, false),
+				},
+				{
+					ID: tsdb.BlockID{
+						SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700101),
+						BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 12),
+					},
+					TimeRange: timestamp.NewTimeRangeDuration(t2, 12*time.Hour, true, false),
+				},
+				{
+					ID: tsdb.BlockID{
+						SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700102),
+						BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 00),
+					},
+					TimeRange: timestamp.NewTimeRangeDuration(t3, 12*time.Hour, true, false),
+				},
+			}))
+			By("moves to 3rd block")
+			// 02 01:00
+			clock.Add(3 * time.Hour)
+			Eventually(func() []tsdb.BlockID {
+				return shard.State().OpenBlocks
+			}).Should(Equal([]tsdb.BlockID{
+				{
+					SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700101),
+					BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 00),
+				},
+				{
+					SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700101),
+					BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 12),
+				},
+			}))
+			By("4th block is opened")
+			// 02 10:00
+			clock.Add(9 * time.Hour)
+			t4 := clock.Now().Add(2 * time.Hour)
+			Eventually(func() []tsdb.BlockState {
+				return shard.State().Blocks
+			}).Should(Equal([]tsdb.BlockState{
+				{
+					ID: tsdb.BlockID{
+						SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700101),
+						BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 00),
+					},
+					TimeRange: timestamp.NewTimeRangeDuration(t1, 12*time.Hour, true, false),
+				},
+				{
+					ID: tsdb.BlockID{
+						SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700101),
+						BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 12),
+					},
+					TimeRange: timestamp.NewTimeRangeDuration(t2, 12*time.Hour, true, false),
+				},
+				{
+					ID: tsdb.BlockID{
+						SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700102),
+						BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 00),
+					},
+					TimeRange: timestamp.NewTimeRangeDuration(t3, 12*time.Hour, true, false),
+				},
+				{
+					ID: tsdb.BlockID{
+						SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700102),
+						BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 12),
+					},
+					TimeRange: timestamp.NewTimeRangeDuration(t4, 12*time.Hour, true, false),
+				},
+			}))
+			By("moves to 4th block")
+			// 02 13:00
+			clock.Add(3 * time.Hour)
+			Eventually(func() []tsdb.BlockID {
+				return shard.State().OpenBlocks
+			}).Should(Equal([]tsdb.BlockID{
+				{
+					SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700101),
+					BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 12),
+				},
+				{
+					SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700102),
+					BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 00),
+				},
+				{
+					SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700101),
+					BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 00),
+				},
+			}))
+			By("5th block is opened")
+			// 02 22:00
+			clock.Add(9 * time.Hour)
+			t5 := clock.Now().Add(2 * time.Hour)
+			Eventually(func() []tsdb.BlockState {
+				return shard.State().Blocks
+			}).Should(Equal([]tsdb.BlockState{
+				{
+					ID: tsdb.BlockID{
+						SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700101),
+						BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 00),
+					},
+					TimeRange: timestamp.NewTimeRangeDuration(t1, 12*time.Hour, true, false),
+				},
+				{
+					ID: tsdb.BlockID{
+						SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700101),
+						BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 12),
+					},
+					TimeRange: timestamp.NewTimeRangeDuration(t2, 12*time.Hour, true, false),
+				},
+				{
+					ID: tsdb.BlockID{
+						SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700102),
+						BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 00),
+					},
+					TimeRange: timestamp.NewTimeRangeDuration(t3, 12*time.Hour, true, false),
+				},
+				{
+					ID: tsdb.BlockID{
+						SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700102),
+						BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 12),
+					},
+					TimeRange: timestamp.NewTimeRangeDuration(t4, 12*time.Hour, true, false),
+				},
+				{
+					ID: tsdb.BlockID{
+						SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700103),
+						BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 00),
+					},
+					TimeRange: timestamp.NewTimeRangeDuration(t5, 12*time.Hour, true, false),
+				},
+			}))
+			By("close 1st block by adding 5th block")
+			// 03 01:00
+			clock.Add(3 * time.Hour)
+			Eventually(func() []tsdb.BlockID {
+				return shard.State().OpenBlocks
+			}).Should(Equal([]tsdb.BlockID{
+				{
+					SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700102),
+					BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 00),
+				},
+				{
+					SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700102),
+					BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 12),
+				},
+				{
+					SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700101),
+					BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 12),
+				},
+			}))
+			Eventually(func() []tsdb.BlockState {
+				return shard.State().Blocks
+			}).Should(Equal([]tsdb.BlockState{
+				{
+					ID: tsdb.BlockID{
+						SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700101),
+						BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 00),
+					},
+					TimeRange: timestamp.NewTimeRangeDuration(t1, 12*time.Hour, true, false),
+					Closed:    true,
+				},
+				{
+					ID: tsdb.BlockID{
+						SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700101),
+						BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 12),
+					},
+					TimeRange: timestamp.NewTimeRangeDuration(t2, 12*time.Hour, true, false),
+				},
+				{
+					ID: tsdb.BlockID{
+						SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700102),
+						BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 00),
+					},
+					TimeRange: timestamp.NewTimeRangeDuration(t3, 12*time.Hour, true, false),
+				},
+				{
+					ID: tsdb.BlockID{
+						SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700102),
+						BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 12),
+					},
+					TimeRange: timestamp.NewTimeRangeDuration(t4, 12*time.Hour, true, false),
+				},
+				{
+					ID: tsdb.BlockID{
+						SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700103),
+						BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 00),
+					},
+					TimeRange: timestamp.NewTimeRangeDuration(t5, 12*time.Hour, true, false),
+				},
+			}))
+			By("reopen 1st block")
 			series, err := shard.Series().GetByID(common.SeriesID(11))
 			Expect(err).NotTo(HaveOccurred())
-			writeFn := func(bs tsdb.BlockState) {
-				span, err := series.Span(bs.TimeRange)
-				Expect(err).NotTo(HaveOccurred())
-				defer span.Close()
-				writer, err := span.WriterBuilder().Family([]byte("test"), []byte("test")).Time(bs.TimeRange.Start).Build()
-				Expect(err).NotTo(HaveOccurred())
-				_, err = writer.Write()
-				Expect(err).NotTo(HaveOccurred())
-			}
-			for _, bs := range closedBlocks {
-				writeFn(bs)
-			}
+			t1Range := timestamp.NewInclusiveTimeRangeDuration(t1, 1*time.Hour)
+			span, err := series.Span(t1Range)
+			Expect(err).NotTo(HaveOccurred())
+			defer span.Close()
+			writer, err := span.WriterBuilder().Family([]byte("test"), []byte("test")).Time(t1Range.End).Build()
+			Expect(err).NotTo(HaveOccurred())
+			_, err = writer.Write()
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(func() []tsdb.BlockID {
+				return shard.State().OpenBlocks
+			}).Should(Equal([]tsdb.BlockID{
+				{
+					SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700102),
+					BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 12),
+				},
+				{
+					SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700101),
+					BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 00),
+				},
+				{
+					SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700102),
+					BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 00),
+				},
+			}))
+			Eventually(func() []tsdb.BlockState {
+				return shard.State().Blocks
+			}).Should(Equal([]tsdb.BlockState{
+				{
+					ID: tsdb.BlockID{
+						SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700101),
+						BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 00),
+					},
+					TimeRange: timestamp.NewTimeRangeDuration(t1, 12*time.Hour, true, false),
+				},
+				{
+					ID: tsdb.BlockID{
+						SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700101),
+						BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 12),
+					},
+					TimeRange: timestamp.NewTimeRangeDuration(t2, 12*time.Hour, true, false),
+					Closed:    true,
+				},
+				{
+					ID: tsdb.BlockID{
+						SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700102),
+						BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 00),
+					},
+					TimeRange: timestamp.NewTimeRangeDuration(t3, 12*time.Hour, true, false),
+				},
+				{
+					ID: tsdb.BlockID{
+						SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700102),
+						BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 12),
+					},
+					TimeRange: timestamp.NewTimeRangeDuration(t4, 12*time.Hour, true, false),
+				},
+				{
+					ID: tsdb.BlockID{
+						SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700103),
+						BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 00),
+					},
+					TimeRange: timestamp.NewTimeRangeDuration(t5, 12*time.Hour, true, false),
+				},
+			}))
 		})
 	})
 })

--- a/banyand/tsdb/tsdb.go
+++ b/banyand/tsdb/tsdb.go
@@ -49,11 +49,10 @@ const (
 	blockTemplate       = rootPrefix + blockPathPrefix + "-%s"
 	globalIndexTemplate = rootPrefix + "index"
 
-	segHourFormat     = "2006010215"
-	segDayFormat      = "20060102"
-	millisecondFormat = "20060102150405000"
-	blockHourFormat   = "15"
-	blockDayFormat    = "0102"
+	segHourFormat   = "2006010215"
+	segDayFormat    = "20060102"
+	blockHourFormat = "15"
+	blockDayFormat  = "0102"
 
 	dirPerm = 0700
 )
@@ -104,13 +103,18 @@ type BlockID struct {
 	BlockID uint16
 }
 
+func GenerateInternalID(unit IntervalUnit, suffix int) uint16 {
+	return uint16(unit)<<12 | ((uint16(suffix) << 4) >> 4)
+}
+
 type BlockState struct {
 	ID        BlockID
 	TimeRange timestamp.TimeRange
 	Closed    bool
 }
 type ShardState struct {
-	OpenedBlocks []BlockState
+	Blocks     []BlockState
+	OpenBlocks []BlockID
 }
 
 type database struct {
@@ -154,14 +158,14 @@ func OpenDatabase(ctx context.Context, opts DatabaseOpts) (Database, error) {
 		return nil, err
 	}
 	segmentSize := opts.SegmentSize
-	if segmentSize.Unit == MILLISECOND {
+	if segmentSize.Num == 0 {
 		segmentSize = IntervalRule{
 			Unit: DAY,
 			Num:  1,
 		}
 	}
 	blockSize := opts.BlockSize
-	if blockSize.Unit == MILLISECOND {
+	if blockSize.Num == 0 {
 		blockSize = IntervalRule{
 			Unit: HOUR,
 			Num:  2,

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.17
 
 require (
 	github.com/RoaringBitmap/roaring v0.9.1
+	github.com/benbjohnson/clock v1.3.0
 	github.com/cespare/xxhash v1.1.0
 	github.com/dgraph-io/badger/v3 v3.2011.1
 	github.com/dgraph-io/ristretto v0.1.0
@@ -107,4 +108,7 @@ require (
 	sigs.k8s.io/yaml v1.2.0 // indirect
 )
 
-replace github.com/dgraph-io/badger/v3 v3.2011.1 => github.com/SkyAPM/badger/v3 v3.0.0-20220403004319-fea65bd5e9e4
+replace (
+	github.com/benbjohnson/clock v1.3.0 => github.com/SkyAPM/clock v1.3.1-0.20220416123716-97dcb111a8d8
+	github.com/dgraph-io/badger/v3 v3.2011.1 => github.com/SkyAPM/badger/v3 v3.0.0-20220403004319-fea65bd5e9e4
+)

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/RoaringBitmap/roaring v0.9.1 h1:5PRizBmoN/PfV17nPNQou4dHQ7NcJi8FO/bih
 github.com/RoaringBitmap/roaring v0.9.1/go.mod h1:h1B7iIUOmnAeb5ytYMvnHJwxMc6LUrwBnzXWRuqTQUc=
 github.com/SkyAPM/badger/v3 v3.0.0-20220403004319-fea65bd5e9e4 h1:iLwRXI6WHBMb2VkWrlYKIFngPKwgs2OnjliXdMB5DY0=
 github.com/SkyAPM/badger/v3 v3.0.0-20220403004319-fea65bd5e9e4/go.mod h1:Q0luV7nB94o3Bl4hYqAPy03+QTtLxs9pWdUEQb0i0K0=
+github.com/SkyAPM/clock v1.3.1-0.20220416123716-97dcb111a8d8 h1:TK3KN7H7ROhT0/sfY8JWWa5xHOo5jUqW7Stc/VxNJyA=
+github.com/SkyAPM/clock v1.3.1-0.20220416123716-97dcb111a8d8/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -59,7 +61,6 @@ github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hC
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/benbjohnson/clock v1.0.3 h1:vkLuvpK4fmtSCuo60+yC63p7y0BmQ8gm5ZXGuBCJyXg=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=

--- a/pkg/timestamp/clock.go
+++ b/pkg/timestamp/clock.go
@@ -1,0 +1,67 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+package timestamp
+
+import (
+	"context"
+	"time"
+
+	"github.com/benbjohnson/clock"
+)
+
+// Clock represents an interface contains all functions in the standard library time.
+type Clock interface {
+	clock.Clock
+}
+
+type MockClock interface {
+	clock.Clock
+	// Add moves the current time of the mock clock forward by the specified duration.
+	Add(d time.Duration)
+}
+
+// NewClock returns an instance of a real-time clock.
+func NewClock() Clock {
+	return clock.New()
+}
+
+// NewMockClock returns an instance of a mock clock.
+func NewMockClock() MockClock {
+	return clock.NewMock()
+}
+
+var clockKey = contextClockKey{}
+
+type contextClockKey struct{}
+
+// GetClock returns a Clock from the context. If the context doesn't contains
+// a Clock, a real-time one will be created and returned with a child context
+// which contains the new one.
+func GetClock(ctx context.Context) (Clock, context.Context) {
+	c := ctx.Value(clockKey)
+	if c == nil {
+		realClock := NewClock()
+		return realClock, SetClock(ctx, realClock)
+	}
+	return c.(Clock), ctx
+}
+
+// SetContext returns a sub context with the passed Clock
+func SetClock(ctx context.Context, clock Clock) context.Context {
+	return context.WithValue(ctx, clockKey, clock)
+}


### PR DESCRIPTION
This tends to introduce a clock mock to convince the tsdb block controller testing.

  * Add a mock clock to mock `time` package.
  * Remove the  `millisecond` interval time unit which is only for testing.

fixes https://github.com/apache/skywalking/issues/8844

Signed-off-by: Gao Hongtao <hanahmily@gmail.com>