### PR TITLE
Append group name to the end of tsdb's path

### DIFF
--- a/banyand/measure/metadata.go
+++ b/banyand/measure/metadata.go
@@ -19,6 +19,7 @@ package measure
 
 import (
 	"context"
+	"path"
 	"time"
 
 	"github.com/apache/skywalking-banyandb/api/common"
@@ -201,7 +202,7 @@ func (s *supplier) OpenDB(groupSchema *commonv1.Group) (tsdb.Database, error) {
 			Database: groupSchema.Metadata.Name,
 		}),
 		tsdb.DatabaseOpts{
-			Location: s.path,
+			Location: path.Join(s.path, groupSchema.Metadata.Name),
 			ShardNum: groupSchema.ResourceOpts.ShardNum,
 			EncodingMethod: tsdb.EncodingMethod{
 				EncoderPool: encoding.NewPlainEncoderPool(chunkSize),

--- a/banyand/stream/metadata.go
+++ b/banyand/stream/metadata.go
@@ -19,6 +19,7 @@ package stream
 
 import (
 	"context"
+	"path"
 	"time"
 
 	"github.com/apache/skywalking-banyandb/api/common"
@@ -201,7 +202,7 @@ func (s *supplier) OpenDB(groupSchema *commonv1.Group) (tsdb.Database, error) {
 			Database: groupSchema.Metadata.Name,
 		}),
 		tsdb.DatabaseOpts{
-			Location: s.path,
+			Location: path.Join(s.path, groupSchema.Metadata.Name),
 			ShardNum: groupSchema.ResourceOpts.ShardNum,
 			EncodingMethod: tsdb.EncodingMethod{
 				EncoderPool: encoding.NewPlainEncoderPool(chunkSize),

--- a/pkg/schema/metadata.go
+++ b/pkg/schema/metadata.go
@@ -175,7 +175,7 @@ func (sr *schemaRepo) Watcher() {
 					break
 				}
 				time.Sleep(time.Second)
-				sr.l.Err(err).Interface("event", evt).Msg("fail to handle the metadata event. retry...")
+				sr.l.Err(err).Interface("event", evt).Int("round", i).Msg("fail to handle the metadata event. retry...")
 			}
 		case <-sr.workerStopCh:
 			return


### PR DESCRIPTION
This will cause multiple groups are trying to open the same tsdb, and conflict with each other.

Signed-off-by: Gao Hongtao <hanahmily@gmail.com>