### PR TITLE
Correct the behaviour of group by

### DIFF
--- a/banyand/query/processor.go
+++ b/banyand/query/processor.go
@@ -165,7 +165,10 @@ func (p *measureQueryProcessor) Rev(message bus.Message) (resp bus.Message) {
 	}()
 	result := make([]*measurev1.DataPoint, 0)
 	for mIterator.Next() {
-		result = append(result, mIterator.Current()...)
+		current := mIterator.Current()
+		if len(current) > 0 {
+			result = append(result, current[0])
+		}
 	}
 	now := time.Now().UnixNano()
 	resp = bus.NewMessage(bus.MessageID(now), result)


### PR DESCRIPTION
The grouping operation should remove duplicated data points, but it fails. This change tends to fix the incorrect behavior.

Signed-off-by: Gao Hongtao <hanahmily@gmail.com>