### PR TITLE
Install golangci-lint by go install

### DIFF
--- a/scripts/build/base.mk
+++ b/scripts/build/base.mk
@@ -37,6 +37,10 @@ endif
 
 GO_LINK_VERSION := -X ${VERSION_PATH}.build=${VERSION_STRING}-${GIT_BRANCH_NAME}
 
+LINTER := $(tool_bin)/golangci-lint
+$(LINTER):
+	@GOBIN=$(tool_bin) go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.2
+
 .PHONY: clean
 clean:
 	git clean -Xdf

--- a/scripts/build/lint-api.mk
+++ b/scripts/build/lint-api.mk
@@ -16,15 +16,9 @@
 # under the License.
 #
 
-GOLANGCI_VERSION := v1.46.2
-
 LINT_OPTS ?= --timeout 1m0s
 
 ##@ Code quality targets
-
-LINTER := $(tool_bin)/golangci-lint
-$(LINTER):
-	@wget -O - -q https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(root_dir)/bin $(GOLANGCI_VERSION)
 
 .PHONY: lint
 lint: $(LINTER)

--- a/scripts/build/lint-deprecated.mk
+++ b/scripts/build/lint-deprecated.mk
@@ -16,15 +16,9 @@
 # under the License.
 #
 
-GOLANGCI_VERSION := v1.46.2
-
 LINT_OPTS ?= --timeout 1m0s
 
 ##@ Code quality targets
-
-LINTER := $(tool_bin)/golangci-lint
-$(LINTER):
-	@wget -O - -q https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(root_dir)/bin $(GOLANGCI_VERSION)
 
 .PHONY: lint
 lint: $(LINTER)

--- a/scripts/build/lint.mk
+++ b/scripts/build/lint.mk
@@ -16,15 +16,7 @@
 # under the License.
 #
 
-GOLANGCI_VERSION := v1.46.2
-
-LINT_OPTS ?= --timeout 1m0s
-
 ##@ Code quality targets
-
-LINTER := $(tool_bin)/golangci-lint
-$(LINTER):
-	@wget -O - -q https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(root_dir)/bin $(GOLANGCI_VERSION)
 
 REVIVE := $(tool_bin)/revive
 $(REVIVE):


### PR DESCRIPTION
Install golangci-lint through `go install` to tackle the issue that `wget` might fail silently. 

@WuChuSheng1 Please test this patch on your local VM. 

Signed-off-by: Gao Hongtao <hanahmily@gmail.com>