### PR TITLE
Update go 1.19

### DIFF
--- a/.github/workflows/e2e.storage.yml
+++ b/.github/workflows/e2e.storage.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.19
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.19
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
       - name: Check License Header
@@ -66,7 +66,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.19
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
       - uses: actions/cache@v3

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.19
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
       - uses: actions/cache@v3

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18
+          go-version: 1.19
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
       - name: Update dependencies 

--- a/api/proto/banyandb/measure/v1/topn.pb.go
+++ b/api/proto/banyandb/measure/v1/topn.pb.go
@@ -41,7 +41,7 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-//TopNList contains a series of topN items
+// TopNList contains a series of topN items
 type TopNList struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/api/proto/banyandb/measure/v1/write.pb.go
+++ b/api/proto/banyandb/measure/v1/write.pb.go
@@ -41,7 +41,7 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-//DataPointValue is the data point for writing. It only contains values.
+// DataPointValue is the data point for writing. It only contains values.
 type DataPointValue struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/api/proto/banyandb/model/v1/common.pb.go
+++ b/api/proto/banyandb/model/v1/common.pb.go
@@ -337,6 +337,7 @@ type TagValue struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Value:
+	//
 	//	*TagValue_Null
 	//	*TagValue_Str
 	//	*TagValue_StrArray
@@ -534,6 +535,7 @@ type FieldValue struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Value:
+	//
 	//	*FieldValue_Null
 	//	*FieldValue_Str
 	//	*FieldValue_Int

--- a/banyand/Dockerfile
+++ b/banyand/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.18 AS dev
+FROM golang:1.19 AS dev
 WORKDIR /app
 ENV GOOS="linux"
 ENV CGO_ENABLED=0
@@ -27,7 +27,7 @@ EXPOSE 2345
 
 ENTRYPOINT ["air"]
 
-FROM golang:1.18 AS base
+FROM golang:1.19 AS base
 
 ENV GOPATH "/go"
 ENV GO111MODULE "on"

--- a/banyand/internal/cmd/root.go
+++ b/banyand/internal/cmd/root.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// Package cmd is an internal package defining cli commands for BanyanDB
 package cmd
 
 import (

--- a/banyand/measure/encode.go
+++ b/banyand/measure/encode.go
@@ -6,7 +6,7 @@
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
@@ -14,7 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-//
 package measure
 
 import (

--- a/banyand/measure/field_flag_test.go
+++ b/banyand/measure/field_flag_test.go
@@ -6,7 +6,7 @@
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
@@ -14,7 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-//
 package measure
 
 import (

--- a/banyand/measure/measure_write_test.go
+++ b/banyand/measure/measure_write_test.go
@@ -132,10 +132,9 @@ func writeDataWithBaseTime(baseTime time.Time, dataFile string, measure measure.
 		rawDataPointValue, errMarshal := json.Marshal(template)
 		Expect(errMarshal).ShouldNot(HaveOccurred())
 		dataPointValue := &measurev1.DataPointValue{}
-		dataPointValue.Timestamp = timestamppb.New(baseTime.Add(time.Duration(i) * time.Minute))
 		Expect(protojson.Unmarshal(rawDataPointValue, dataPointValue)).ShouldNot(HaveOccurred())
-		errInner := measure.Write(dataPointValue)
-		Expect(errInner).ShouldNot(HaveOccurred())
+		dataPointValue.Timestamp = timestamppb.New(baseTime.Add(time.Duration(i) * time.Minute))
+		Expect(measure.Write(dataPointValue)).Should(Succeed())
 	}
 	return baseTime
 }

--- a/banyand/measure/measure_write_test.go
+++ b/banyand/measure/measure_write_test.go
@@ -22,9 +22,9 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/golang/protobuf/jsonpb"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	commonv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/common/v1"
@@ -133,7 +133,7 @@ func writeDataWithBaseTime(baseTime time.Time, dataFile string, measure measure.
 		Expect(errMarshal).ShouldNot(HaveOccurred())
 		dataPointValue := &measurev1.DataPointValue{}
 		dataPointValue.Timestamp = timestamppb.New(baseTime.Add(time.Duration(i) * time.Minute))
-		Expect(jsonpb.UnmarshalString(string(rawDataPointValue), dataPointValue)).ShouldNot(HaveOccurred())
+		Expect(protojson.Unmarshal(rawDataPointValue, dataPointValue)).ShouldNot(HaveOccurred())
 		errInner := measure.Write(dataPointValue)
 		Expect(errInner).ShouldNot(HaveOccurred())
 	}

--- a/banyand/measure/metadata.go
+++ b/banyand/measure/metadata.go
@@ -6,7 +6,7 @@
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
@@ -14,7 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-//
 package measure
 
 import (

--- a/banyand/observability/metric.go
+++ b/banyand/observability/metric.go
@@ -6,7 +6,7 @@
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
@@ -14,7 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-//
 package observability
 
 import (

--- a/banyand/observability/type.go
+++ b/banyand/observability/type.go
@@ -6,7 +6,7 @@
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
@@ -14,7 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-//
 package observability
 
 type Statistics struct {

--- a/banyand/query/processor_test.go
+++ b/banyand/query/processor_test.go
@@ -26,9 +26,9 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/golang/protobuf/jsonpb"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/apache/skywalking-banyandb/api/data"
@@ -158,7 +158,7 @@ func setUpStreamQueryData(dataFile string, stream stream.Stream) (baseTime time.
 		rawSearchTagFamily, errMarshal := json.Marshal(template)
 		Expect(errMarshal).ShouldNot(HaveOccurred())
 		searchTagFamily := &modelv1.TagFamilyForWrite{}
-		Expect(jsonpb.UnmarshalString(string(rawSearchTagFamily), searchTagFamily)).Should(Succeed())
+		Expect(protojson.Unmarshal(rawSearchTagFamily, searchTagFamily)).Should(Succeed())
 		e := &streamv1.ElementValue{
 			ElementId: strconv.Itoa(i),
 			Timestamp: timestamppb.New(baseTime.Add(500 * time.Millisecond * time.Duration(i))),

--- a/banyand/query/query_suite_test.go
+++ b/banyand/query/query_suite_test.go
@@ -6,7 +6,7 @@
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
@@ -14,7 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-//
 package query_test
 
 import (

--- a/banyand/stream/stream_query_test.go
+++ b/banyand/stream/stream_query_test.go
@@ -28,10 +28,10 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/golang/protobuf/jsonpb"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/apache/skywalking-banyandb/api/common"
@@ -990,7 +990,7 @@ func setupQueryData(dataFile string, stream *stream) (baseTime time.Time) {
 		rawSearchTagFamily, errMarshal := json.Marshal(template)
 		Expect(errMarshal).ShouldNot(HaveOccurred())
 		searchTagFamily := &modelv1.TagFamilyForWrite{}
-		Expect(jsonpb.UnmarshalString(string(rawSearchTagFamily), searchTagFamily)).ShouldNot(HaveOccurred())
+		Expect(protojson.Unmarshal(rawSearchTagFamily, searchTagFamily)).ShouldNot(HaveOccurred())
 		e := &streamv1.ElementValue{
 			ElementId: strconv.Itoa(i),
 			Timestamp: timestamppb.New(baseTime.Add(500 * time.Millisecond * time.Duration(i))),

--- a/banyand/tsdb/bucket/bucket_suite_test.go
+++ b/banyand/tsdb/bucket/bucket_suite_test.go
@@ -6,7 +6,7 @@
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
@@ -14,7 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-//
 package bucket_test
 
 import (

--- a/banyand/tsdb/bucket/queue.go
+++ b/banyand/tsdb/bucket/queue.go
@@ -6,7 +6,7 @@
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
@@ -14,7 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-//
 package bucket
 
 import (

--- a/banyand/tsdb/bucket/queue_test.go
+++ b/banyand/tsdb/bucket/queue_test.go
@@ -6,7 +6,7 @@
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
@@ -14,7 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-//
 package bucket_test
 
 import (

--- a/banyand/tsdb/bucket/strategy_test.go
+++ b/banyand/tsdb/bucket/strategy_test.go
@@ -6,7 +6,7 @@
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
@@ -14,7 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-//
 package bucket_test
 
 import (

--- a/banyand/tsdb/metric.go
+++ b/banyand/tsdb/metric.go
@@ -6,7 +6,7 @@
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
@@ -14,7 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-//
 package tsdb
 
 import (

--- a/banyand/tsdb/scope.go
+++ b/banyand/tsdb/scope.go
@@ -6,7 +6,7 @@
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
@@ -14,7 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-//
 package tsdb
 
 import (

--- a/banyand/tsdb/series_test.go
+++ b/banyand/tsdb/series_test.go
@@ -6,7 +6,7 @@
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
@@ -14,7 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-//
 package tsdb_test
 
 import (

--- a/banyand/tsdb/shard_test.go
+++ b/banyand/tsdb/shard_test.go
@@ -6,7 +6,7 @@
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
@@ -14,7 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-//
 package tsdb_test
 
 import (

--- a/banyand/tsdb/tsdb.go
+++ b/banyand/tsdb/tsdb.go
@@ -21,8 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/fs"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -182,9 +180,9 @@ func OpenDatabase(ctx context.Context, opts DatabaseOpts) (Database, error) {
 		blockSize:   blockSize,
 	}
 	db.logger.Info().Str("path", opts.Location).Msg("initialized")
-	var entries []fs.FileInfo
+	var entries []os.DirEntry
 	var err error
-	if entries, err = ioutil.ReadDir(opts.Location); err != nil {
+	if entries, err = os.ReadDir(opts.Location); err != nil {
 		return nil, errors.Wrap(err, "failed to read directory contents failed")
 	}
 	thisContext := context.WithValue(ctx, logger.ContextKey, db.logger)
@@ -262,7 +260,7 @@ func loadDatabase(ctx context.Context, db *database) (Database, error) {
 type WalkFn func(suffix, absolutePath string) error
 
 func WalkDir(root, prefix string, walkFn WalkFn) error {
-	files, err := ioutil.ReadDir(root)
+	files, err := os.ReadDir(root)
 	if err != nil {
 		return errors.Wrapf(err, "failed to walk the database path: %s", root)
 	}

--- a/banyand/tsdb/tsdb_suite_test.go
+++ b/banyand/tsdb/tsdb_suite_test.go
@@ -6,7 +6,7 @@
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
@@ -14,7 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-//
 package tsdb_test
 
 import (

--- a/bydbctl/Dockerfile
+++ b/bydbctl/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.18 AS base
+FROM golang:1.19 AS base
 
 ENV GOPATH "/go"
 ENV GO111MODULE "on"

--- a/bydbctl/cmd/bydbctl/main.go
+++ b/bydbctl/cmd/bydbctl/main.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// Package main provides main entry for the command-line toolkit, i.e. bydbctl
 package main
 
 import (

--- a/bydbctl/internal/cmd/root.go
+++ b/bydbctl/internal/cmd/root.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// Package cmd is an internal package defining cli commands for bydbctl
 package cmd
 
 import (

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/apache/skywalking-banyandb
 
-go 1.18
+go 1.19
 
 require (
 	github.com/RoaringBitmap/roaring v0.9.1

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/dgraph-io/badger/v3 v3.2011.1
 	github.com/dgraph-io/ristretto v0.1.0
 	github.com/golang/mock v1.6.0
-	github.com/golang/protobuf v1.5.2
+	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-cmp v0.5.8
 	github.com/google/uuid v1.3.0
 	github.com/klauspost/compress v1.15.6

--- a/pkg/grpchelper/client.go
+++ b/pkg/grpchelper/client.go
@@ -6,7 +6,7 @@
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
@@ -14,7 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-//
 package grpchelper
 
 import (

--- a/pkg/query/aggregation/aggregation.go
+++ b/pkg/query/aggregation/aggregation.go
@@ -6,7 +6,7 @@
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
@@ -14,7 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-//
 package aggregation
 
 import (

--- a/pkg/query/aggregation/function.go
+++ b/pkg/query/aggregation/function.go
@@ -6,7 +6,7 @@
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
@@ -14,7 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-//
 package aggregation
 
 import "math"

--- a/pkg/query/logical/common_test.go
+++ b/pkg/query/logical/common_test.go
@@ -27,9 +27,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/protobuf/jsonpb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	commonv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/common/v1"
@@ -63,7 +63,7 @@ func setupQueryData(testing *testing.T, dataFile string, stream stream.Stream) (
 		rawSearchTagFamily, errMarshal := json.Marshal(template)
 		t.NoError(errMarshal)
 		searchTagFamily := &modelv1.TagFamilyForWrite{}
-		t.NoError(jsonpb.UnmarshalString(string(rawSearchTagFamily), searchTagFamily))
+		t.NoError(protojson.Unmarshal(rawSearchTagFamily, searchTagFamily))
 		e := &streamv1.ElementValue{
 			ElementId: strconv.Itoa(i),
 			Timestamp: timestamppb.New(baseTime.Add(500 * time.Millisecond * time.Duration(i))),
@@ -216,7 +216,7 @@ func setupMeasureQueryData(testing *testing.T, dataFile string, measure measure.
 		if dataPointValue.Timestamp == nil {
 			dataPointValue.Timestamp = timestamppb.New(baseTime.Add(time.Duration(i) * time.Minute))
 		}
-		t.NoError(jsonpb.UnmarshalString(string(rawDataPointValue), dataPointValue))
+		t.NoError(protojson.Unmarshal(rawDataPointValue, dataPointValue))
 		errInner := measure.Write(dataPointValue)
 		t.NoError(errInner)
 	}

--- a/pkg/query/logical/common_test.go
+++ b/pkg/query/logical/common_test.go
@@ -213,10 +213,10 @@ func setupMeasureQueryData(testing *testing.T, dataFile string, measure measure.
 		rawDataPointValue, errMarshal := json.Marshal(template)
 		t.NoError(errMarshal)
 		dataPointValue := &measurev1.DataPointValue{}
+		t.NoError(protojson.Unmarshal(rawDataPointValue, dataPointValue))
 		if dataPointValue.Timestamp == nil {
 			dataPointValue.Timestamp = timestamppb.New(baseTime.Add(time.Duration(i) * time.Minute))
 		}
-		t.NoError(protojson.Unmarshal(rawDataPointValue, dataPointValue))
 		errInner := measure.Write(dataPointValue)
 		t.NoError(errInner)
 	}

--- a/pkg/query/logical/iter.go
+++ b/pkg/query/logical/iter.go
@@ -94,9 +94,12 @@ func (it *itemIter) init() {
 // pushIterator pushes the given iterator into the underlying deque.
 // Status will be immediately checked if the Iterator has a next value.
 // 1 - If not, it will be close at once and will not be added to the slice,
-//     which means inactive iterator does not exist in the deq.
+//
+//	which means inactive iterator does not exist in the deq.
+//
 // 2 - If so, it will be wrapped into a container and push to the deq.
-//     Then we call SliceStable sort to sort the deq.
+//
+//	Then we call SliceStable sort to sort the deq.
 func (it *itemIter) pushIterator(iter tsdb.Iterator) {
 	if !iter.Next() {
 		_ = iter.Close()

--- a/pkg/query/logical/measure_plan_aggregation.go
+++ b/pkg/query/logical/measure_plan_aggregation.go
@@ -6,7 +6,7 @@
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
@@ -14,7 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-//
 package logical
 
 import (

--- a/pkg/query/logical/measure_plan_groupby.go
+++ b/pkg/query/logical/measure_plan_groupby.go
@@ -6,7 +6,7 @@
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
@@ -14,7 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-//
 package logical
 
 import (

--- a/pkg/query/logical/measure_plan_top.go
+++ b/pkg/query/logical/measure_plan_top.go
@@ -6,7 +6,7 @@
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
@@ -14,7 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-//
 package logical
 
 import (

--- a/pkg/query/logical/measure_top.go
+++ b/pkg/query/logical/measure_top.go
@@ -6,7 +6,7 @@
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
@@ -14,7 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-//
 package logical
 
 import (

--- a/pkg/query/logical/measure_top_test.go
+++ b/pkg/query/logical/measure_top_test.go
@@ -6,7 +6,7 @@
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
@@ -14,7 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-//
 package logical_test
 
 import (

--- a/pkg/query/logical/stream_analyzer.go
+++ b/pkg/query/logical/stream_analyzer.go
@@ -140,8 +140,9 @@ func (a *StreamAnalyzer) Analyze(_ context.Context, criteria *streamv1.QueryRequ
 // Basically,
 // 1 - If no criteria is given, we can only scan all shards
 // 2 - If criteria is given, but all of those fields exist in the "entity" definition,
-//     i.e. they are top-level sharding keys. For example, for the current skywalking's streamSchema,
-//     we use service_id + service_instance_id + state as the compound sharding keys.
+//
+//	i.e. they are top-level sharding keys. For example, for the current skywalking's streamSchema,
+//	we use service_id + service_instance_id + state as the compound sharding keys.
 func parseStreamFields(criteria *streamv1.QueryRequest, metadata *commonv1.Metadata, s Schema) (UnresolvedPlan, error) {
 	timeRange := criteria.GetTimeRange()
 

--- a/pkg/run/run.go
+++ b/pkg/run/run.go
@@ -282,24 +282,23 @@ func (g *Group) RunConfig() (interrupted bool, err error) {
 //
 // The following phases are executed in the following sequence:
 //
-//   Config phase (serially, in order of Unit registration)
-//     - FlagSet()        Get & register all FlagSets from Config Units.
-//     - Flag Parsing     Using the provided args (os.Args if empty)
-//     - Validate()       Validate Config Units. Exit on first error.
+//	Config phase (serially, in order of Unit registration)
+//	  - FlagSet()        Get & register all FlagSets from Config Units.
+//	  - Flag Parsing     Using the provided args (os.Args if empty)
+//	  - Validate()       Validate Config Units. Exit on first error.
 //
-//   PreRunner phase (serially, in order of Unit registration)
-//     - PreRun()         Execute PreRunner Units. Exit on first error.
+//	PreRunner phase (serially, in order of Unit registration)
+//	  - PreRun()         Execute PreRunner Units. Exit on first error.
 //
-//   Service phase (concurrently)
-//     - Serve()          Execute all Service Units in separate Go routines.
-//     - Wait             Block until one of the Serve() methods returns
-//     - GracefulStop()   Call interrupt handlers of all Service Units.
+//	Service phase (concurrently)
+//	  - Serve()          Execute all Service Units in separate Go routines.
+//	  - Wait             Block until one of the Serve() methods returns
+//	  - GracefulStop()   Call interrupt handlers of all Service Units.
 //
-//   Run will return with the originating error on:
-//   - first Config.Validate()  returning an error
-//   - first PreRunner.PreRun() returning an error
-//   - first Service.Serve()    returning (error or nil)
-//
+//	Run will return with the originating error on:
+//	- first Config.Validate()  returning an error
+//	- first PreRunner.PreRun() returning an error
+//	- first Service.Serve()    returning (error or nil)
 func (g *Group) Run() (err error) {
 	// run config registration and flag parsing stages
 	if interrupted, errRun := g.RunConfig(); interrupted || errRun != nil {

--- a/pkg/test/helpers/fail_interceptor.go
+++ b/pkg/test/helpers/fail_interceptor.go
@@ -6,7 +6,7 @@
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
@@ -14,7 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-//
 package helpers
 
 import (

--- a/pkg/test/helpers/grpc_health.go
+++ b/pkg/test/helpers/grpc_health.go
@@ -6,7 +6,7 @@
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
@@ -14,7 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-//
 package helpers
 
 import (

--- a/pkg/test/matcher.go
+++ b/pkg/test/matcher.go
@@ -6,7 +6,7 @@
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
@@ -14,7 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-//
 package test
 
 import (

--- a/pkg/test/measure/traffic/traffic.go
+++ b/pkg/test/measure/traffic/traffic.go
@@ -6,7 +6,7 @@
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
@@ -14,7 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-//
 package traffic
 
 import (

--- a/pkg/test/measure/traffic/traffic.go
+++ b/pkg/test/measure/traffic/traffic.go
@@ -14,6 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+
 package traffic
 
 import (

--- a/pkg/test/space.go
+++ b/pkg/test/space.go
@@ -19,7 +19,6 @@ package test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/stretchr/testify/require"
@@ -27,7 +26,7 @@ import (
 
 func Space(t *require.Assertions) (tempDir string, deferFunc func()) {
 	var tempDirErr error
-	tempDir, tempDirErr = ioutil.TempDir("", "banyandb-test-*")
+	tempDir, tempDirErr = os.MkdirTemp("", "banyandb-test-*")
 	t.Nil(tempDirErr)
 	return tempDir, func() {
 		if err := os.RemoveAll(tempDir); err != nil {
@@ -37,7 +36,7 @@ func Space(t *require.Assertions) (tempDir string, deferFunc func()) {
 }
 
 func NewSpace() (tempDir string, deferFunc func(), err error) {
-	tempDir, err = ioutil.TempDir("", "banyandb-test-*")
+	tempDir, err = os.MkdirTemp("", "banyandb-test-*")
 	return tempDir, func() {
 		if err = os.RemoveAll(tempDir); err != nil {
 			_, _ = fmt.Fprintf(os.Stderr, "Error while removing dir: %v\n", err)

--- a/pkg/test/stream/traffic/traffic.go
+++ b/pkg/test/stream/traffic/traffic.go
@@ -6,7 +6,7 @@
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
@@ -14,7 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-//
 package traffic
 
 import (

--- a/pkg/test/stream/traffic/traffic.go
+++ b/pkg/test/stream/traffic/traffic.go
@@ -14,6 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+
 package traffic
 
 import (
@@ -30,7 +31,7 @@ import (
 	"time"
 
 	"github.com/dgraph-io/ristretto/z"
-	"github.com/golang/protobuf/jsonpb"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -44,7 +45,7 @@ import (
 
 var (
 	//go:embed searchable_template.json
-	content string
+	content []byte
 	l       = logger.GetLogger("test_stream_traffic")
 )
 
@@ -56,7 +57,7 @@ type TestCase struct {
 
 func SendWrites(ts TestCase) (*z.Closer, error) {
 	searchTagFamily := &modelv1.TagFamilyForWrite{}
-	err := jsonpb.UnmarshalString(content, searchTagFamily)
+	err := protojson.Unmarshal(content, searchTagFamily)
 	if err != nil {
 		l.Err(err).Msg("unmarshal template")
 		return nil, err

--- a/pkg/timestamp/clock.go
+++ b/pkg/timestamp/clock.go
@@ -6,7 +6,7 @@
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
@@ -14,7 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-//
 package timestamp
 
 import (

--- a/pkg/timestamp/duration.go
+++ b/pkg/timestamp/duration.go
@@ -6,7 +6,7 @@
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
@@ -14,7 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-//
 package timestamp
 
 import (

--- a/pkg/timestamp/duration_test.go
+++ b/pkg/timestamp/duration_test.go
@@ -6,7 +6,7 @@
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
@@ -14,7 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-//
 package timestamp
 
 import (

--- a/pkg/timestamp/nano.go
+++ b/pkg/timestamp/nano.go
@@ -6,7 +6,7 @@
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
@@ -14,7 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-//
 package timestamp
 
 import (
@@ -36,6 +35,7 @@ var (
 )
 
 // FastRandN is a fast thread local random function.
+//
 //go:linkname fastRandN runtime.fastrandn
 func fastRandN(n uint32) uint32
 

--- a/pkg/timestamp/nano_test.go
+++ b/pkg/timestamp/nano_test.go
@@ -6,7 +6,7 @@
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
@@ -14,7 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-//
 package timestamp_test
 
 import (

--- a/pkg/timestamp/range.go
+++ b/pkg/timestamp/range.go
@@ -6,7 +6,7 @@
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
@@ -14,7 +14,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-//
 package timestamp
 
 import (

--- a/scripts/build/lint-bin.mk
+++ b/scripts/build/lint-bin.mk
@@ -1,4 +1,4 @@
 
 LINTER := $(tool_bin)/golangci-lint
 $(LINTER):
-	@GOBIN=$(tool_bin) go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.2
+	@GOBIN=$(tool_bin) go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.48.0

--- a/ui/embed.go
+++ b/ui/embed.go
@@ -20,5 +20,6 @@ package ui
 import "embed"
 
 // DistContent contains ui distributed pages
+//
 //go:embed dist
 var DistContent embed.FS

--- a/ui/embed.go
+++ b/ui/embed.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// Package ui provides Web based UI for BanyanDB
 package ui
 
 import "embed"


### PR DESCRIPTION
## Lint issues

Several lint errors occur after upgrading to go 1.19

- Package comments missing: https://tip.golang.org/doc/go1.19#go-doc
- Migrate `github.com/golang/protobuf/jsonpb` -> `google.golang.org/protobuf/encoding/protojson`
- fully deprecate `io/ioutil`