### PR TITLE
Add several metrics to measure the compression ratio

### DIFF
--- a/banyand/kv/kv.go
+++ b/banyand/kv/kv.go
@@ -256,6 +256,9 @@ func OpenIndexStore(shardID int, path string, options ...IndexOptions) (IndexSto
 		opt(bdb)
 	}
 	bdb.dbOpts = bdb.dbOpts.WithNumVersionsToKeep(math.MaxUint32)
+	bdb.dbOpts = bdb.dbOpts.WithNumCompactors(2)
+	bdb.dbOpts = bdb.dbOpts.WithMemTableSize(2 << 20)
+	bdb.dbOpts = bdb.dbOpts.WithValueThreshold(1 << 10)
 
 	var err error
 	bdb.db, err = badger.Open(bdb.dbOpts)

--- a/banyand/measure/encode.go
+++ b/banyand/measure/encode.go
@@ -43,10 +43,10 @@ type encoderPool struct {
 	l           *logger.Logger
 }
 
-func newEncoderPool(plainSize, intSize int, l *logger.Logger) encoding.SeriesEncoderPool {
+func newEncoderPool(name string, plainSize, intSize int, l *logger.Logger) encoding.SeriesEncoderPool {
 	return &encoderPool{
-		intPool:     encoding.NewIntEncoderPool(intSize, intervalFn),
-		defaultPool: encoding.NewPlainEncoderPool(plainSize),
+		intPool:     encoding.NewIntEncoderPool(name, intSize, intervalFn),
+		defaultPool: encoding.NewPlainEncoderPool(name, plainSize),
 		l:           l,
 	}
 }
@@ -74,10 +74,10 @@ type decoderPool struct {
 	l           *logger.Logger
 }
 
-func newDecoderPool(plainSize, intSize int, l *logger.Logger) encoding.SeriesDecoderPool {
+func newDecoderPool(name string, plainSize, intSize int, l *logger.Logger) encoding.SeriesDecoderPool {
 	return &decoderPool{
-		intPool:     encoding.NewIntDecoderPool(intSize, intervalFn),
-		defaultPool: encoding.NewPlainDecoderPool(plainSize),
+		intPool:     encoding.NewIntDecoderPool(name, intSize, intervalFn),
+		defaultPool: encoding.NewPlainDecoderPool(name, plainSize),
 		l:           l,
 	}
 }

--- a/banyand/measure/metadata.go
+++ b/banyand/measure/metadata.go
@@ -176,10 +176,6 @@ type supplier struct {
 }
 
 func newSupplier(path string, metadata metadata.Repo, dbOpts tsdb.DatabaseOpts, l *logger.Logger) *supplier {
-	dbOpts.EncodingMethod = tsdb.EncodingMethod{
-		EncoderPool: newEncoderPool(plainChunkSize, intChunkSize, l),
-		DecoderPool: newDecoderPool(plainChunkSize, intChunkSize, l),
-	}
 	return &supplier{
 		path:     path,
 		dbOpts:   dbOpts,
@@ -206,10 +202,15 @@ func (s *supplier) OpenDB(groupSchema *commonv1.Group) (tsdb.Database, error) {
 	opts := s.dbOpts
 	opts.ShardNum = groupSchema.ResourceOpts.ShardNum
 	opts.Location = path.Join(s.path, groupSchema.Metadata.Name)
+	name := groupSchema.Metadata.Name
+	opts.EncodingMethod = tsdb.EncodingMethod{
+		EncoderPool: newEncoderPool(name, plainChunkSize, intChunkSize, s.l),
+		DecoderPool: newDecoderPool(name, plainChunkSize, intChunkSize, s.l),
+	}
 	return tsdb.OpenDatabase(
 		context.WithValue(context.Background(), common.PositionKey, common.Position{
 			Module:   "measure",
-			Database: groupSchema.Metadata.Name,
+			Database: name,
 		}),
 		opts)
 }

--- a/banyand/query/processor.go
+++ b/banyand/query/processor.go
@@ -121,7 +121,7 @@ func (p *measureQueryProcessor) Rev(message bus.Message) (resp bus.Message) {
 		p.queryService.log.Warn().Msg("invalid event data type")
 		return
 	}
-	p.log.Info().Msg("received a query event")
+	p.log.Debug().Msg("received a query event")
 
 	meta := queryCriteria.GetMetadata()
 	ec, err := p.measureService.Measure(meta)

--- a/banyand/tsdb/block.go
+++ b/banyand/tsdb/block.go
@@ -118,10 +118,10 @@ func (b *block) options(ctx context.Context) {
 		options = o.(DatabaseOpts)
 	}
 	if options.EncodingMethod.EncoderPool == nil {
-		options.EncodingMethod.EncoderPool = encoding.NewPlainEncoderPool(0)
+		options.EncodingMethod.EncoderPool = encoding.NewPlainEncoderPool("tsdb", 0)
 	}
 	if options.EncodingMethod.EncoderPool == nil {
-		options.EncodingMethod.DecoderPool = encoding.NewPlainDecoderPool(0)
+		options.EncodingMethod.DecoderPool = encoding.NewPlainDecoderPool("tsdb", 0)
 	}
 	b.encodingMethod = options.EncodingMethod
 	if options.BlockMemSize < 1 {

--- a/banyand/tsdb/tsdb_test.go
+++ b/banyand/tsdb/tsdb_test.go
@@ -76,8 +76,8 @@ func openDatabase(t *require.Assertions, path string) (db Database) {
 			Location: path,
 			ShardNum: 1,
 			EncodingMethod: EncodingMethod{
-				EncoderPool: encoding.NewPlainEncoderPool(0),
-				DecoderPool: encoding.NewPlainDecoderPool(0),
+				EncoderPool: encoding.NewPlainEncoderPool("tsdb", 0),
+				DecoderPool: encoding.NewPlainDecoderPool("tsdb", 0),
 			},
 		})
 	t.NoError(err)

--- a/dist/LICENSE
+++ b/dist/LICENSE
@@ -178,7 +178,7 @@
 Apache-2.0 licenses
 ========================================================================
 
-    github.com/SkyAPM/badger/v3 v3.0.0-20220403004319-fea65bd5e9e4 Apache-2.0
+    github.com/SkyAPM/badger/v3 v3.0.0-20220817114744-b3711444d876 Apache-2.0
     github.com/coreos/go-semver v0.3.0 Apache-2.0
     github.com/coreos/go-systemd/v22 v22.3.2 Apache-2.0
     github.com/dgraph-io/ristretto v0.1.0 Apache-2.0

--- a/go.mod
+++ b/go.mod
@@ -116,5 +116,5 @@ require (
 
 replace (
 	github.com/benbjohnson/clock v1.3.0 => github.com/SkyAPM/clock v1.3.1-0.20220809233656-dc7607c94a97
-	github.com/dgraph-io/badger/v3 v3.2011.1 => github.com/SkyAPM/badger/v3 v3.0.0-20220403004319-fea65bd5e9e4
+	github.com/dgraph-io/badger/v3 v3.2011.1 => github.com/SkyAPM/badger/v3 v3.0.0-20220817114744-b3711444d876
 )

--- a/go.sum
+++ b/go.sum
@@ -48,8 +48,8 @@ github.com/RoaringBitmap/gocroaring v0.4.0/go.mod h1:NieMwz7ZqwU2DD73/vvYwv7r4eW
 github.com/RoaringBitmap/real-roaring-datasets v0.0.0-20190726190000-eb7c87156f76/go.mod h1:oM0MHmQ3nDsq609SS36p+oYbRi16+oVvU2Bw4Ipv0SE=
 github.com/RoaringBitmap/roaring v0.9.1 h1:5PRizBmoN/PfV17nPNQou4dHQ7NcJi8FO/bihdYyCEM=
 github.com/RoaringBitmap/roaring v0.9.1/go.mod h1:h1B7iIUOmnAeb5ytYMvnHJwxMc6LUrwBnzXWRuqTQUc=
-github.com/SkyAPM/badger/v3 v3.0.0-20220403004319-fea65bd5e9e4 h1:iLwRXI6WHBMb2VkWrlYKIFngPKwgs2OnjliXdMB5DY0=
-github.com/SkyAPM/badger/v3 v3.0.0-20220403004319-fea65bd5e9e4/go.mod h1:Q0luV7nB94o3Bl4hYqAPy03+QTtLxs9pWdUEQb0i0K0=
+github.com/SkyAPM/badger/v3 v3.0.0-20220817114744-b3711444d876 h1:zH//2cmDpBla7rL9NzWr+vZ2UskMrvdnUvslz3KYTN0=
+github.com/SkyAPM/badger/v3 v3.0.0-20220817114744-b3711444d876/go.mod h1:TQb+QXS839JUIX5jEySXoAvAIDROfU22HqVHcBr9bRA=
 github.com/SkyAPM/clock v1.3.1-0.20220809233656-dc7607c94a97 h1:FKuhJ+6n/DHspGeLleeNbziWnKr9gHKYN4q7NcoCp4s=
 github.com/SkyAPM/clock v1.3.1-0.20220809233656-dc7607c94a97/go.mod h1:2xGRl9H1pllhxTbEGO1W3gDkip8P9GQaHPni/wpdR44=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -414,9 +414,8 @@ github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/soheilhy/cmux v0.1.5 h1:jjzc5WVemNEDTLwv9tlmemhC73tI08BNOIGwBOo10Js=
 github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
+github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 h1:qLC7fQah7D6K1B0ujays3HV9gkFtllcxhzImRR7ArPQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
-github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
-github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.8.2 h1:xehSyVa0YnHWsJ49JFljMpg1HX19V6NDZ1fkm1Xznbo=
 github.com/spf13/afero v1.8.2/go.mod h1:CtAatgMJh6bJEIs48Ay/FOnkljP3WeGUG0MC1RfAqwo=

--- a/pkg/encoding/encoding.go
+++ b/pkg/encoding/encoding.go
@@ -30,17 +30,17 @@ var (
 		Name:        "banyand_encoding_raw_size",
 		Help:        "The raw size of series",
 		ConstLabels: prometheus.Labels{"model": "encoding"},
-	}, []string{"type"})
+	}, []string{"name", "type"})
 	encodedSize = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name:        "banyand_encoding_encoded_size",
 		Help:        "The encoded size of series",
 		ConstLabels: prometheus.Labels{"model": "encoding"},
-	}, []string{"type"})
+	}, []string{"name", "type"})
 	itemsNum = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name:        "banyand_encoding_items_num",
 		Help:        "The number of items in a encoded series",
 		ConstLabels: prometheus.Labels{"model": "encoding"},
-	}, []string{"type"})
+	}, []string{"name", "type"})
 )
 
 type SeriesEncoderPool interface {

--- a/pkg/encoding/int_test.go
+++ b/pkg/encoding/int_test.go
@@ -86,8 +86,8 @@ func TestNewIntEncoderAndDecoder(t *testing.T) {
 		assert.Equal(t, key, k)
 		return 1 * time.Minute
 	}
-	encoderPool := NewIntEncoderPool(3, fn)
-	decoderPool := NewIntDecoderPool(3, fn)
+	encoderPool := NewIntEncoderPool("minute", 3, fn)
+	decoderPool := NewIntDecoderPool("minute", 3, fn)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/index/inverted/inverted.go
+++ b/pkg/index/inverted/inverted.go
@@ -68,6 +68,8 @@ func (s *store) Close() error {
 }
 
 func (s *store) Write(field index.Field, chunkID common.ItemID) error {
+	s.rwMutex.Lock()
+	defer s.rwMutex.Unlock()
 	return s.memTable.Write(field, chunkID)
 }
 

--- a/test/stress/docker-compose.yaml
+++ b/test/stress/docker-compose.yaml
@@ -24,9 +24,12 @@ services:
       target: ${TARGET}
     volumes:
     - ../..:/app:rw,delegated
+    # Uncomment below line to mount an external volume
+    # - /tmp:/tmp:rw,delgated
     ports:
     - 17913:17913
     - 6060:6060
+    - 2121:2121
     networks:
       - test
       - monitoring


### PR DESCRIPTION
The compression ratio of stream resources is around 90%

## Raw data

```
banyand_encoding_raw_size{instance="banyandb:2121", job="banyandb", model="encoding", name="stream-log", type="plain"}
7281680
banyand_encoding_raw_size{instance="banyandb:2121", job="banyandb", model="encoding", name="stream-segment", type="plain"}
14717062
```

## Encoded data

```
banyand_encoding_encoded_size{instance="banyandb:2121", job="banyandb", model="encoding", name="stream-log", type="plain"} 
956638
banyand_encoding_encoded_size{instance="banyandb:2121", job="banyandb", model="encoding", name="stream-segment", type="plain"} 
1404901
```

## Compression Ratio

Expression: `(banyand_encoding_raw_size-banyand_encoding_encoded_size)*100/banyand_encoding_raw_size`

```
{instance="banyandb:2121", job="banyandb", model="encoding", name="stream-log", type="plain"}
86.8454943844342
{instance="banyandb:2121", job="banyandb", model="encoding", name="stream-segment", type="plain"}
90.37276793305686

```

Related to https://github.com/apache/skywalking/issues/9452

Signed-off-by: Gao Hongtao <hanahmily@gmail.com>