### PR TITLE
Bump up api plugins

### DIFF
--- a/api/proto/buf.lock
+++ b/api/proto/buf.lock
@@ -4,12 +4,12 @@ deps:
   - remote: buf.build
     owner: envoyproxy
     repository: protoc-gen-validate
-    commit: dc09a417d27241f7b069feae2cd74a0e
+    commit: 45685e052c7e406b9fbd441fc7a568a5
   - remote: buf.build
     owner: googleapis
     repository: googleapis
-    commit: b2ce3a783bb9432c86e4ff84bea45f27
+    commit: 8d7204855ec14631a499bd7393ce1970
   - remote: buf.build
     owner: grpc-ecosystem
     repository: grpc-gateway
-    commit: 00116f302b12478b85deb33b734e026c
+    commit: bc28b723cd774c32b6fbc77621518765

--- a/api/proto/buf.yaml
+++ b/api/proto/buf.yaml
@@ -19,8 +19,8 @@
 
 version: v1
 deps:
-  - buf.build/grpc-ecosystem/grpc-gateway:3849b8a0cf8a66fe2799ff9dc1857f0097d13411
-  - buf.build/googleapis/googleapis:49e6a7ed565e4318817623413ca6b791d35085c8
+  - buf.build/grpc-ecosystem/grpc-gateway
+  - buf.build/googleapis/googleapis:b174c584f7d3349f48ed2703476573d372d24878
   - buf.build/envoyproxy/protoc-gen-validate
 lint:
   use:


### PR DESCRIPTION
The plugin's previous tag is removed, which will cause CI failure. 

Signed-off-by: Gao Hongtao <hanahmily@gmail.com>