### PR TITLE
Make import order deterministic

### DIFF
--- a/.golangci-format.yml
+++ b/.golangci-format.yml
@@ -27,9 +27,15 @@ run:
 linters:
   disable-all: true
   enable:
-  - goimports
+  - gci
   - gofumpt
   fast: false
+linters-settings:
+  gci:
+    sections:
+      - standard
+      - default
+      - prefix(github.com/apache/skywalking-banyandb/) 
 
 issues:
   max-per-linter: 0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,7 +21,7 @@ linters:
     - gocritic
     - goconst
     - gofumpt
-    - goimports
+    - gci
     - gosimple
     - govet
     - ineffassign
@@ -49,6 +49,11 @@ linters-settings:
     check-exported: false
   unparam:
     check-exported: false
+  gci:
+    sections:
+      - standard
+      - default
+      - prefix(github.com/apache/skywalking-banyandb/) 
   gocritic:
     enabled-checks:
       - appendCombine

--- a/banyand/liaison/grpc/registry_test.go
+++ b/banyand/liaison/grpc/registry_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/apache/skywalking-banyandb/banyand/metadata"
 	"github.com/apache/skywalking-banyandb/banyand/queue"
 	"github.com/apache/skywalking-banyandb/pkg/test"
-
 	teststream "github.com/apache/skywalking-banyandb/pkg/test/stream"
 )
 

--- a/banyand/stream/metadata.go
+++ b/banyand/stream/metadata.go
@@ -32,7 +32,6 @@ import (
 	"github.com/apache/skywalking-banyandb/banyand/tsdb"
 	"github.com/apache/skywalking-banyandb/pkg/encoding"
 	"github.com/apache/skywalking-banyandb/pkg/logger"
-
 	pb_v1 "github.com/apache/skywalking-banyandb/pkg/pb/v1"
 	resourceSchema "github.com/apache/skywalking-banyandb/pkg/schema"
 )

--- a/banyand/tsdb/block.go
+++ b/banyand/tsdb/block.go
@@ -29,6 +29,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/apache/skywalking-banyandb/api/common"
 	"github.com/apache/skywalking-banyandb/banyand/kv"
 	"github.com/apache/skywalking-banyandb/banyand/observability"
@@ -39,7 +41,6 @@ import (
 	"github.com/apache/skywalking-banyandb/pkg/index/lsm"
 	"github.com/apache/skywalking-banyandb/pkg/logger"
 	"github.com/apache/skywalking-banyandb/pkg/timestamp"
-	"github.com/pkg/errors"
 )
 
 const (

--- a/banyand/tsdb/retention.go
+++ b/banyand/tsdb/retention.go
@@ -21,8 +21,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/apache/skywalking-banyandb/pkg/logger"
 	"github.com/robfig/cron/v3"
+
+	"github.com/apache/skywalking-banyandb/pkg/logger"
 )
 
 type retentionController struct {

--- a/banyand/tsdb/segment.go
+++ b/banyand/tsdb/segment.go
@@ -27,13 +27,14 @@ import (
 	"sync"
 	"time"
 
+	"go.uber.org/multierr"
+
 	"github.com/apache/skywalking-banyandb/api/common"
 	"github.com/apache/skywalking-banyandb/banyand/kv"
 	"github.com/apache/skywalking-banyandb/banyand/observability"
 	"github.com/apache/skywalking-banyandb/banyand/tsdb/bucket"
 	"github.com/apache/skywalking-banyandb/pkg/logger"
 	"github.com/apache/skywalking-banyandb/pkg/timestamp"
-	"go.uber.org/multierr"
 )
 
 var ErrEndOfSegment = errors.New("reached the end of the segment")

--- a/bydbctl/internal/cmd/group.go
+++ b/bydbctl/internal/cmd/group.go
@@ -21,13 +21,13 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/apache/skywalking-banyandb/pkg/version"
 	"github.com/go-resty/resty/v2"
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/encoding/protojson"
 
 	common_v1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/common/v1"
 	database_v1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
+	"github.com/apache/skywalking-banyandb/pkg/version"
 )
 
 func newGroupCmd() *cobra.Command {

--- a/bydbctl/internal/cmd/root.go
+++ b/bydbctl/internal/cmd/root.go
@@ -22,9 +22,10 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/apache/skywalking-banyandb/pkg/version"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
+	"github.com/apache/skywalking-banyandb/pkg/version"
 )
 
 var (

--- a/bydbctl/internal/cmd/stream.go
+++ b/bydbctl/internal/cmd/stream.go
@@ -21,13 +21,13 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/apache/skywalking-banyandb/pkg/version"
 	"github.com/go-resty/resty/v2"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"google.golang.org/protobuf/encoding/protojson"
 
 	database_v1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
+	"github.com/apache/skywalking-banyandb/pkg/version"
 )
 
 const streamSchemaPath = "/api/v1/stream/schema"

--- a/bydbctl/internal/cmd/stream_test.go
+++ b/bydbctl/internal/cmd/stream_test.go
@@ -22,6 +22,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ghodss/yaml"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+	"github.com/zenizh/go-capturer"
+
+	database_v1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
 	"github.com/apache/skywalking-banyandb/banyand/discovery"
 	"github.com/apache/skywalking-banyandb/banyand/liaison/grpc"
 	"github.com/apache/skywalking-banyandb/banyand/liaison/http"
@@ -33,13 +40,6 @@ import (
 	"github.com/apache/skywalking-banyandb/bydbctl/internal/cmd"
 	"github.com/apache/skywalking-banyandb/pkg/test"
 	"github.com/apache/skywalking-banyandb/pkg/test/helpers"
-	"github.com/ghodss/yaml"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"github.com/spf13/cobra"
-	"github.com/zenizh/go-capturer"
-
-	database_v1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
 )
 
 var _ = Describe("Stream", func() {

--- a/bydbctl/internal/cmd/use.go
+++ b/bydbctl/internal/cmd/use.go
@@ -20,9 +20,10 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/apache/skywalking-banyandb/pkg/version"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
+	"github.com/apache/skywalking-banyandb/pkg/version"
 )
 
 func newUserCmd() *cobra.Command {

--- a/deprecated-golangci.yml
+++ b/deprecated-golangci.yml
@@ -26,7 +26,7 @@ linters:
     - unconvert
     - varcheck
     - govet
-    - goimports
+    - gci
     - prealloc
     - unused
     - staticcheck
@@ -41,6 +41,11 @@ linters-settings:
     min-occurrences: 4
   govet:
     check-shadowing: true
+  gci:
+    sections:
+      - standard
+      - default
+      - prefix(github.com/apache/skywalking-banyandb/) 
 run:
   deadline: 10m
   skip-files:

--- a/pkg/index/lsm/lsm.go
+++ b/pkg/index/lsm/lsm.go
@@ -18,13 +18,14 @@
 package lsm
 
 import (
+	"go.uber.org/multierr"
+
 	"github.com/apache/skywalking-banyandb/api/common"
 	"github.com/apache/skywalking-banyandb/banyand/kv"
 	"github.com/apache/skywalking-banyandb/banyand/observability"
 	"github.com/apache/skywalking-banyandb/pkg/convert"
 	"github.com/apache/skywalking-banyandb/pkg/index"
 	"github.com/apache/skywalking-banyandb/pkg/logger"
-	"go.uber.org/multierr"
 )
 
 var _ index.Store = (*store)(nil)

--- a/pkg/query/logical/index_filter.go
+++ b/pkg/query/logical/index_filter.go
@@ -23,6 +23,8 @@ import (
 	"encoding/json"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/apache/skywalking-banyandb/api/common"
 	database_v1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
 	model_v1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/model/v1"
@@ -30,7 +32,6 @@ import (
 	"github.com/apache/skywalking-banyandb/pkg/convert"
 	"github.com/apache/skywalking-banyandb/pkg/index"
 	"github.com/apache/skywalking-banyandb/pkg/index/posting"
-	"github.com/pkg/errors"
 )
 
 var (

--- a/pkg/query/logical/measure/schema.go
+++ b/pkg/query/logical/measure/schema.go
@@ -18,12 +18,12 @@
 package measure
 
 import (
-	databasev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
-
-	"github.com/apache/skywalking-banyandb/banyand/tsdb"
-	"github.com/apache/skywalking-banyandb/pkg/query/logical"
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
+
+	databasev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
+	"github.com/apache/skywalking-banyandb/banyand/tsdb"
+	"github.com/apache/skywalking-banyandb/pkg/query/logical"
 )
 
 type schema struct {

--- a/pkg/query/logical/tag_filter.go
+++ b/pkg/query/logical/tag_filter.go
@@ -22,8 +22,9 @@ import (
 	"fmt"
 	"strings"
 
-	model_v1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/model/v1"
 	"github.com/pkg/errors"
+
+	model_v1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/model/v1"
 )
 
 var ErrUnsupportedLogicalOperation = errors.New("unsupported logical operation")

--- a/pkg/signal/handler.go
+++ b/pkg/signal/handler.go
@@ -28,8 +28,10 @@ import (
 )
 
 // ErrSignal is returned when a termination signal is received.
-var ErrSignal = errors.New("signal received")
-var _ run.Service = (*Handler)(nil)
+var (
+	ErrSignal             = errors.New("signal received")
+	_         run.Service = (*Handler)(nil)
+)
 
 // Handler implements a unix signal handler as run.GroupService.
 type Handler struct {

--- a/pkg/test/setup/setup.go
+++ b/pkg/test/setup/setup.go
@@ -21,6 +21,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/onsi/gomega"
+
 	"github.com/apache/skywalking-banyandb/banyand/discovery"
 	"github.com/apache/skywalking-banyandb/banyand/liaison/grpc"
 	"github.com/apache/skywalking-banyandb/banyand/measure"
@@ -31,8 +33,6 @@ import (
 	"github.com/apache/skywalking-banyandb/pkg/test"
 	test_measure "github.com/apache/skywalking-banyandb/pkg/test/measure"
 	test_stream "github.com/apache/skywalking-banyandb/pkg/test/stream"
-
-	"github.com/onsi/gomega"
 )
 
 const host = "127.0.0.1"

--- a/pkg/test/stream/traffic/traffic.go
+++ b/pkg/test/stream/traffic/traffic.go
@@ -20,7 +20,6 @@ package traffic
 import (
 	"context"
 	"crypto/rand"
-
 	// Load some tag templates
 	_ "embed"
 	"encoding/base64"

--- a/pkg/timestamp/nano.go
+++ b/pkg/timestamp/nano.go
@@ -19,7 +19,6 @@ package timestamp
 import (
 	"math"
 	"time"
-
 	// link runtime pkg fastrand
 	_ "unsafe"
 

--- a/scripts/build/lint-bin.mk
+++ b/scripts/build/lint-bin.mk
@@ -1,4 +1,4 @@
 
 LINTER := $(tool_bin)/golangci-lint
 $(LINTER):
-	@GOBIN=$(tool_bin) go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.48.0
+	@GOBIN=$(tool_bin) go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.0

--- a/test/integration/other/property_test.go
+++ b/test/integration/other/property_test.go
@@ -20,7 +20,6 @@ package integration_other_test
 import (
 	"context"
 
-	"github.com/apache/skywalking-banyandb/pkg/test/setup"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	grpclib "google.golang.org/grpc"
@@ -29,6 +28,7 @@ import (
 	common_v1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/common/v1"
 	model_v1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/model/v1"
 	property_v1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/property/v1"
+	"github.com/apache/skywalking-banyandb/pkg/test/setup"
 )
 
 var _ = Describe("Property application", func() {


### PR DESCRIPTION
Use `gci` in place of `goimports` to split all import blocks into three sections:

- standard: Golang official imports, like "fmt"
- default: All rest of import blocks
- banyandb: Use a prefix match: `github.com/apache/skywalking-banyandb`