### PR TITLE
Add load test and inject testing flags

### DIFF
--- a/.github/workflows/load.yml
+++ b/.github/workflows/load.yml
@@ -1,0 +1,57 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Continuous Integration
+
+on:
+  schedule:
+    - cron: '0 20 * * *'
+
+jobs:
+  test:
+    name: Load several days data
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        tz: ["UTC", "Asia/Shanghai", "America/Los_Angeles"]
+    steps:
+      - name: Set timezone
+        run: sudo timedatectl set-timezone ${{ matrix.tz }}
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16.15
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.19
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+      - uses: actions/cache@v3
+        id: cache-go
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Update dependencies 
+        if: steps.cache-go.outputs.cache-hit != 'true'
+        run: GOPROXY=https://proxy.golang.org go mod download
+      - name: Generate mocks
+        run: make generate
+      - name: Test
+        run: TEST_EXTRA_OPTS="--label-filter slow" make -C test test

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,12 @@ test-coverage: default ## Run the unit tests in all projects with coverage analy
 include scripts/build/ginkgo.mk
 
 test-ci: $(GINKGO) ## Run the unit tests in CI
-	$(GINKGO) --race --cover --covermode atomic --coverprofile=coverage.out ./... 
+	$(GINKGO) --race \
+	  -ldflags \
+	  "-X github.com/apache/skywalking-banyandb/pkg/test/flags.eventuallyTimeout=30s -X github.com/apache/skywalking-banyandb/pkg/test/flags.LogLevel=warn" \
+	  --cover --covermode atomic --coverprofile=coverage.out \
+	  --label-filter !slow \
+	  ./... 
 
 ##@ Code quality targets
 

--- a/banyand/liaison/grpc/grpc_suite_test.go
+++ b/banyand/liaison/grpc/grpc_suite_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/apache/skywalking-banyandb/pkg/logger"
+	"github.com/apache/skywalking-banyandb/pkg/test/flags"
 )
 
 func TestGrpc(t *testing.T) {
@@ -34,6 +35,6 @@ func TestGrpc(t *testing.T) {
 var _ = BeforeSuite(func() {
 	Expect(logger.Init(logger.Logging{
 		Env:   "dev",
-		Level: "warn",
+		Level: flags.LogLevel,
 	})).Should(Succeed())
 })

--- a/banyand/measure/measure_suite_test.go
+++ b/banyand/measure/measure_suite_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/apache/skywalking-banyandb/banyand/queue"
 	"github.com/apache/skywalking-banyandb/pkg/logger"
 	"github.com/apache/skywalking-banyandb/pkg/test"
+	"github.com/apache/skywalking-banyandb/pkg/test/flags"
 	testmeasure "github.com/apache/skywalking-banyandb/pkg/test/measure"
 )
 
@@ -45,7 +46,7 @@ func TestMeasure(t *testing.T) {
 var _ = ginkgo.BeforeSuite(func() {
 	gomega.Expect(logger.Init(logger.Logging{
 		Env:   "dev",
-		Level: "warn",
+		Level: flags.LogLevel,
 	})).To(gomega.Succeed())
 })
 

--- a/banyand/measure/measure_topn.go
+++ b/banyand/measure/measure_topn.go
@@ -166,7 +166,9 @@ func (t *topNStreamingProcessor) writeData(eventTime time.Time, timeBucket strin
 	if err != nil {
 		return err
 	}
-	span, err := series.Create(eventTime)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	span, err := series.Create(ctx, eventTime)
 	if err != nil {
 		if span != nil {
 			_ = span.Close()

--- a/banyand/measure/measure_write.go
+++ b/banyand/measure/measure_write.go
@@ -19,6 +19,8 @@ package measure
 
 import (
 	"bytes"
+	"context"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -75,7 +77,9 @@ func (s *measure) write(shardID common.ShardID, seriesHashKey []byte, value *mea
 	if err != nil {
 		return err
 	}
-	wp, err := series.Create(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	wp, err := series.Create(ctx, t)
 	if err != nil {
 		if wp != nil {
 			_ = wp.Close()

--- a/banyand/metadata/metadata_test.go
+++ b/banyand/metadata/metadata_test.go
@@ -27,6 +27,7 @@ import (
 	commonv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/common/v1"
 	databasev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
 	"github.com/apache/skywalking-banyandb/pkg/logger"
+	"github.com/apache/skywalking-banyandb/pkg/test/flags"
 	test "github.com/apache/skywalking-banyandb/pkg/test/stream"
 )
 
@@ -37,7 +38,7 @@ func Test_service_RulesBySubject(t *testing.T) {
 	is := assert.New(t)
 	is.NoError(logger.Init(logger.Logging{
 		Env:   "dev",
-		Level: "warn",
+		Level: flags.LogLevel,
 	}))
 	ctx := context.TODO()
 	s, _ := NewService(ctx)

--- a/banyand/metadata/schema/schema_suite_test.go
+++ b/banyand/metadata/schema/schema_suite_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/apache/skywalking-banyandb/pkg/logger"
+	"github.com/apache/skywalking-banyandb/pkg/test/flags"
 )
 
 func TestSchema(t *testing.T) {
@@ -35,6 +36,6 @@ func TestSchema(t *testing.T) {
 var _ = ginkgo.BeforeSuite(func() {
 	Expect(logger.Init(logger.Logging{
 		Env:   "dev",
-		Level: "warn",
+		Level: flags.LogLevel,
 	})).To(Succeed())
 })

--- a/banyand/query/processor_topn.go
+++ b/banyand/query/processor_topn.go
@@ -196,7 +196,9 @@ func familyIdentity(name string, flag []byte) []byte {
 }
 
 func (t *topNQueryProcessor) scanSeries(series tsdb.Series, request *measurev1.TopNRequest) ([]tsdb.Iterator, error) {
-	seriesSpan, err := series.Span(timestamp.NewInclusiveTimeRange(
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	seriesSpan, err := series.Span(ctx, timestamp.NewInclusiveTimeRange(
 		request.GetTimeRange().GetBegin().AsTime(),
 		request.GetTimeRange().GetEnd().AsTime()),
 	)

--- a/banyand/stream/stream_suite_test.go
+++ b/banyand/stream/stream_suite_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/apache/skywalking-banyandb/banyand/queue"
 	"github.com/apache/skywalking-banyandb/pkg/logger"
 	"github.com/apache/skywalking-banyandb/pkg/test"
+	"github.com/apache/skywalking-banyandb/pkg/test/flags"
 	teststream "github.com/apache/skywalking-banyandb/pkg/test/stream"
 )
 
@@ -44,7 +45,7 @@ func TestStream(t *testing.T) {
 var _ = BeforeSuite(func() {
 	Expect(logger.Init(logger.Logging{
 		Env:   "dev",
-		Level: "warn",
+		Level: flags.LogLevel,
 	})).To(Succeed())
 })
 

--- a/banyand/stream/stream_write.go
+++ b/banyand/stream/stream_write.go
@@ -18,6 +18,9 @@
 package stream
 
 import (
+	"context"
+	"time"
+
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -87,7 +90,9 @@ func (s *stream) write(shardID common.ShardID, seriesHashKey []byte, value *stre
 		return err
 	}
 	t := timestamp.MToN(tp)
-	wp, err := series.Create(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	wp, err := series.Create(ctx, t)
 	if err != nil {
 		if wp != nil {
 			_ = wp.Close()

--- a/banyand/tsdb/bucket/queue_test.go
+++ b/banyand/tsdb/bucket/queue_test.go
@@ -17,16 +17,26 @@
 package bucket_test
 
 import (
+	"context"
+	"strconv"
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gleak"
 
 	"github.com/apache/skywalking-banyandb/banyand/tsdb/bucket"
+	"github.com/apache/skywalking-banyandb/pkg/logger"
+	"github.com/apache/skywalking-banyandb/pkg/timestamp"
 )
 
 type queueEntryID struct {
 	first  uint16
 	second uint16
+}
+
+func (q queueEntryID) String() string {
+	return strconv.Itoa(int(q.first))
 }
 
 func entryID(id uint16) queueEntryID {
@@ -37,26 +47,87 @@ func entryID(id uint16) queueEntryID {
 }
 
 var _ = Describe("Queue", func() {
+	var evictLst []queueEntryID
+	var l bucket.Queue
+	var clock timestamp.MockClock
 	BeforeEach(func() {
 		goods := gleak.Goroutines()
 		DeferCleanup(func() {
 			Eventually(gleak.Goroutines).ShouldNot(gleak.HaveLeaked(goods))
 		})
-	})
-	It("pushes data", func() {
-		evictLst := make([]queueEntryID, 0)
-		l, err := bucket.NewQueue(128, func(id interface{}) {
+		evictLst = make([]queueEntryID, 0)
+		clock = timestamp.NewMockClock()
+		clock.Set(time.Date(1970, 0o1, 0o1, 0, 0, 0, 0, time.Local))
+		var err error
+		l, err = bucket.NewQueue(logger.GetLogger("test"), 128, 192, clock, func(_ context.Context, id interface{}) error {
 			evictLst = append(evictLst, id.(queueEntryID))
+			return nil
 		})
 		Expect(err).ShouldNot(HaveOccurred())
-
+		DeferCleanup(func() {
+			evictLst = evictLst[:0]
+			Expect(l.Close()).To(Succeed())
+		})
+	})
+	It("pushes to recent", func() {
+		enRecentSize := 0
 		for i := 0; i < 256; i++ {
-			l.Push(entryID(uint16(i)))
+			Expect(l.Push(context.Background(), entryID(uint16(i)), func() error {
+				enRecentSize++
+				return nil
+			})).To(Succeed())
 		}
+		Expect(enRecentSize).To(Equal(256))
 		Expect(l.Len()).To(Equal(128))
 		Expect(len(evictLst)).To(Equal(64))
 		for i := 0; i < 64; i++ {
 			Expect(evictLst[i]).To(Equal(entryID(uint16(i))))
 		}
+	})
+
+	It("promotes to frequent", func() {
+		enRecentSize := 0
+		for i := 0; i < 128; i++ {
+			Expect(l.Push(context.Background(), entryID(uint16(i)), func() error {
+				enRecentSize++
+				return nil
+			})).To(Succeed())
+		}
+		Expect(enRecentSize).To(Equal(128))
+		Expect(l.Len()).To(Equal(128))
+		Expect(len(evictLst)).To(Equal(0))
+		for i := 0; i < 64; i++ {
+			Expect(l.Touch(entryID(uint16(i)))).To(BeTrue())
+		}
+		enRecentSize = 0
+		for i := 128; i < 256; i++ {
+			Expect(l.Push(context.Background(), entryID(uint16(i)), func() error {
+				enRecentSize++
+				return nil
+			})).To(Succeed())
+		}
+		Expect(enRecentSize).To(Equal(128))
+		Expect(l.Len()).To(Equal(128))
+		Expect(len(evictLst)).To(Equal(64))
+		for i := 0; i < 64; i++ {
+			Expect(evictLst[i]).To(Equal(entryID(uint16(i + 64))))
+		}
+	})
+
+	It("cleans up evict queue", func() {
+		enRecentSize := 0
+
+		for i := 0; i < 192; i++ {
+			Expect(l.Push(context.Background(), entryID(uint16(i)), func() error {
+				enRecentSize++
+				return nil
+			})).To(Succeed())
+		}
+		Expect(enRecentSize).To(Equal(192))
+		Expect(l.Len()).To(Equal(128))
+		Expect(len(evictLst)).To(Equal(0))
+		clock.Add(time.Minute)
+		GinkgoWriter.Printf("evicted size:%d \n", len(evictLst))
+		Expect(len(evictLst)).To(BeNumerically(">", 1))
 	})
 })

--- a/banyand/tsdb/bucket/strategy.go
+++ b/banyand/tsdb/bucket/strategy.go
@@ -117,7 +117,7 @@ func (s *Strategy) observe(c Channel) bool {
 		select {
 		case status, more := <-c:
 			if !more {
-				return true
+				return moreBucket
 			}
 			ratio := Ratio(status.Volume) / Ratio(status.Capacity)
 			atomic.StoreUint64(&s.currentRatio, math.Float64bits(float64(ratio)))
@@ -136,7 +136,7 @@ func (s *Strategy) observe(c Channel) bool {
 				if next != nil {
 					s.current.Store(next)
 				}
-				return true
+				return moreBucket
 			}
 		case <-s.stopCh:
 			return false

--- a/banyand/tsdb/series.go
+++ b/banyand/tsdb/series.go
@@ -75,9 +75,9 @@ func (i *GlobalItemID) UnMarshal(data []byte) error {
 
 type Series interface {
 	ID() common.SeriesID
-	Span(timeRange timestamp.TimeRange) (SeriesSpan, error)
-	Create(t time.Time) (SeriesSpan, error)
-	Get(id GlobalItemID) (Item, io.Closer, error)
+	Span(ctx context.Context, timeRange timestamp.TimeRange) (SeriesSpan, error)
+	Create(ctx context.Context, t time.Time) (SeriesSpan, error)
+	Get(ctx context.Context, id GlobalItemID) (Item, io.Closer, error)
 }
 
 type SeriesSpan interface {
@@ -95,8 +95,8 @@ type series struct {
 	l       *logger.Logger
 }
 
-func (s *series) Get(id GlobalItemID) (Item, io.Closer, error) {
-	b, err := s.blockDB.block(id)
+func (s *series) Get(ctx context.Context, id GlobalItemID) (Item, io.Closer, error) {
+	b, err := s.blockDB.block(ctx, id)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -114,8 +114,8 @@ func (s *series) ID() common.SeriesID {
 	return s.id
 }
 
-func (s *series) Span(timeRange timestamp.TimeRange) (SeriesSpan, error) {
-	blocks, err := s.blockDB.span(timeRange)
+func (s *series) Span(ctx context.Context, timeRange timestamp.TimeRange) (SeriesSpan, error) {
+	blocks, err := s.blockDB.span(ctx, timeRange)
 	if err != nil {
 		return nil, err
 	}
@@ -128,9 +128,9 @@ func (s *series) Span(timeRange timestamp.TimeRange) (SeriesSpan, error) {
 	return newSeriesSpan(context.WithValue(context.Background(), logger.ContextKey, s.l), timeRange, blocks, s.id, s.shardID), nil
 }
 
-func (s *series) Create(t time.Time) (SeriesSpan, error) {
+func (s *series) Create(ctx context.Context, t time.Time) (SeriesSpan, error) {
 	tr := timestamp.NewInclusiveTimeRange(t, t)
-	blocks, err := s.blockDB.span(tr)
+	blocks, err := s.blockDB.span(ctx, tr)
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +140,7 @@ func (s *series) Create(t time.Time) (SeriesSpan, error) {
 			Msg("load a series span")
 		return newSeriesSpan(context.WithValue(context.Background(), logger.ContextKey, s.l), tr, blocks, s.id, s.shardID), nil
 	}
-	b, err := s.blockDB.create(t)
+	b, err := s.blockDB.create(ctx, t)
 	if err != nil {
 		return nil, err
 	}

--- a/banyand/tsdb/seriesdb_test.go
+++ b/banyand/tsdb/seriesdb_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/apache/skywalking-banyandb/pkg/convert"
 	"github.com/apache/skywalking-banyandb/pkg/logger"
 	"github.com/apache/skywalking-banyandb/pkg/test"
+	"github.com/apache/skywalking-banyandb/pkg/test/flags"
 )
 
 func TestEntity(t *testing.T) {
@@ -355,7 +356,7 @@ func Test_SeriesDatabase_Get(t *testing.T) {
 	tester := assert.New(t)
 	tester.NoError(logger.Init(logger.Logging{
 		Env:   "dev",
-		Level: "warn",
+		Level: flags.LogLevel,
 	}))
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -376,7 +377,7 @@ func Test_SeriesDatabase_List(t *testing.T) {
 	tester := assert.New(t)
 	tester.NoError(logger.Init(logger.Logging{
 		Env:   "dev",
-		Level: "warn",
+		Level: flags.LogLevel,
 	}))
 	dir, deferFunc := test.Space(require.New(t))
 	defer deferFunc()

--- a/banyand/tsdb/shard_test.go
+++ b/banyand/tsdb/shard_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/apache/skywalking-banyandb/api/common"
 	"github.com/apache/skywalking-banyandb/banyand/tsdb"
 	"github.com/apache/skywalking-banyandb/pkg/test"
+	"github.com/apache/skywalking-banyandb/pkg/test/flags"
 	"github.com/apache/skywalking-banyandb/pkg/timestamp"
 )
 
@@ -70,13 +71,14 @@ var _ = Describe("Shard", func() {
 					Num:  7,
 				},
 				2,
+				3,
 			)
 			Expect(err).NotTo(HaveOccurred())
 			By("01/01 00:00 1st block is opened")
 			t1 := clock.Now()
 			Eventually(func() []tsdb.BlockState {
 				return shard.State().Blocks
-			}, defaultEventuallyTimeout).Should(Equal([]tsdb.BlockState{
+			}, flags.EventuallyTimeout).Should(Equal([]tsdb.BlockState{
 				{
 					ID: tsdb.BlockID{
 						SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700101),
@@ -93,7 +95,7 @@ var _ = Describe("Shard", func() {
 					GinkgoWriter.Println("01/01 10:00 has been triggered")
 				}
 				return shard.State().Blocks
-			}, defaultEventuallyTimeout).Should(Equal([]tsdb.BlockState{
+			}, flags.EventuallyTimeout).Should(Equal([]tsdb.BlockState{
 				{
 					ID: tsdb.BlockID{
 						SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700101),
@@ -111,7 +113,7 @@ var _ = Describe("Shard", func() {
 			}))
 			Eventually(func() []tsdb.BlockID {
 				return shard.State().OpenBlocks
-			}, defaultEventuallyTimeout).Should(Equal([]tsdb.BlockID{}))
+			}, flags.EventuallyTimeout).Should(Equal([]tsdb.BlockID{}))
 			By("01/01 13:00 moves to the 2nd block")
 			clock.Add(3 * time.Hour)
 			Eventually(func() []tsdb.BlockID {
@@ -119,7 +121,7 @@ var _ = Describe("Shard", func() {
 					GinkgoWriter.Println("01/01 13:00 has been triggered")
 				}
 				return shard.State().OpenBlocks
-			}, defaultEventuallyTimeout).Should(Equal([]tsdb.BlockID{
+			}, flags.EventuallyTimeout).Should(Equal([]tsdb.BlockID{
 				{
 					SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700101),
 					BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 0o0),
@@ -133,7 +135,7 @@ var _ = Describe("Shard", func() {
 					GinkgoWriter.Println("01/01 22:00 has been triggered")
 				}
 				return shard.State().Blocks
-			}, defaultEventuallyTimeout).Should(Equal([]tsdb.BlockState{
+			}, flags.EventuallyTimeout).Should(Equal([]tsdb.BlockState{
 				{
 					ID: tsdb.BlockID{
 						SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700101),
@@ -163,7 +165,7 @@ var _ = Describe("Shard", func() {
 					GinkgoWriter.Println("01/02 01:00 has been triggered")
 				}
 				return shard.State().OpenBlocks
-			}, defaultEventuallyTimeout).Should(Equal([]tsdb.BlockID{
+			}, flags.EventuallyTimeout).Should(Equal([]tsdb.BlockID{
 				{
 					SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700101),
 					BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 0o0),
@@ -181,7 +183,7 @@ var _ = Describe("Shard", func() {
 					GinkgoWriter.Println("01/02 10:00 has been triggered")
 				}
 				return shard.State().Blocks
-			}, defaultEventuallyTimeout).Should(Equal([]tsdb.BlockState{
+			}, flags.EventuallyTimeout).Should(Equal([]tsdb.BlockState{
 				{
 					ID: tsdb.BlockID{
 						SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700101),
@@ -218,7 +220,7 @@ var _ = Describe("Shard", func() {
 					GinkgoWriter.Println("01/02 13:00 has been triggered")
 				}
 				return shard.State().OpenBlocks
-			}, defaultEventuallyTimeout).Should(Equal([]tsdb.BlockID{
+			}, flags.EventuallyTimeout).Should(Equal([]tsdb.BlockID{
 				{
 					SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700101),
 					BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 0o0),
@@ -240,7 +242,7 @@ var _ = Describe("Shard", func() {
 					GinkgoWriter.Println("01/02 22:00 has been triggered")
 				}
 				return shard.State().Blocks
-			}, defaultEventuallyTimeout).Should(Equal([]tsdb.BlockState{
+			}, flags.EventuallyTimeout).Should(Equal([]tsdb.BlockState{
 				{
 					ID: tsdb.BlockID{
 						SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700101),
@@ -284,11 +286,7 @@ var _ = Describe("Shard", func() {
 					GinkgoWriter.Println("01/03 01:00 has been triggered")
 				}
 				return shard.State().OpenBlocks
-			}, defaultEventuallyTimeout).Should(Equal([]tsdb.BlockID{
-				{
-					SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700101),
-					BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 12),
-				},
+			}, flags.EventuallyTimeout).Should(Equal([]tsdb.BlockID{
 				{
 					SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700102),
 					BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 0o0),
@@ -300,7 +298,7 @@ var _ = Describe("Shard", func() {
 			}))
 			Eventually(func() []tsdb.BlockState {
 				return shard.State().Blocks
-			}, defaultEventuallyTimeout).Should(Equal([]tsdb.BlockState{
+			}, flags.EventuallyTimeout).Should(Equal([]tsdb.BlockState{
 				{
 					ID: tsdb.BlockID{
 						SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700101),
@@ -315,6 +313,7 @@ var _ = Describe("Shard", func() {
 						BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 12),
 					},
 					TimeRange: timestamp.NewTimeRangeDuration(t2, 12*time.Hour, true, false),
+					Closed:    true,
 				},
 				{
 					ID: tsdb.BlockID{
@@ -342,7 +341,7 @@ var _ = Describe("Shard", func() {
 			series, err := shard.Series().GetByID(common.SeriesID(11))
 			Expect(err).NotTo(HaveOccurred())
 			t1Range := timestamp.NewInclusiveTimeRangeDuration(t1, 1*time.Hour)
-			span, err := series.Span(t1Range)
+			span, err := series.Span(context.Background(), t1Range)
 			Expect(err).NotTo(HaveOccurred())
 			defer span.Close()
 			writer, err := span.WriterBuilder().Family([]byte("test"), []byte("test")).Time(t1Range.End).Build()
@@ -351,14 +350,14 @@ var _ = Describe("Shard", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Eventually(func() []tsdb.BlockID {
 				return shard.State().OpenBlocks
-			}, defaultEventuallyTimeout).Should(Equal([]tsdb.BlockID{
+			}, flags.EventuallyTimeout).Should(Equal([]tsdb.BlockID{
 				{
 					SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700101),
 					BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 0o0),
 				},
 				{
-					SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700101),
-					BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 12),
+					SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700102),
+					BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 0o0),
 				},
 				{
 					SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700102),
@@ -367,7 +366,7 @@ var _ = Describe("Shard", func() {
 			}))
 			Eventually(func() []tsdb.BlockState {
 				return shard.State().Blocks
-			}, defaultEventuallyTimeout).Should(Equal([]tsdb.BlockState{
+			}, flags.EventuallyTimeout).Should(Equal([]tsdb.BlockState{
 				{
 					ID: tsdb.BlockID{
 						SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700101),
@@ -381,6 +380,7 @@ var _ = Describe("Shard", func() {
 						BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 12),
 					},
 					TimeRange: timestamp.NewTimeRangeDuration(t2, 12*time.Hour, true, false),
+					Closed:    true,
 				},
 				{
 					ID: tsdb.BlockID{
@@ -388,7 +388,6 @@ var _ = Describe("Shard", func() {
 						BlockID: tsdb.GenerateInternalID(tsdb.HOUR, 0o0),
 					},
 					TimeRange: timestamp.NewTimeRangeDuration(t3, 12*time.Hour, true, false),
-					Closed:    true,
 				},
 				{
 					ID: tsdb.BlockID{
@@ -422,6 +421,7 @@ var _ = Describe("Shard", func() {
 					Num:  1,
 				},
 				10,
+				15,
 			)
 			Expect(err).NotTo(HaveOccurred())
 			By("open 4 blocks")
@@ -451,7 +451,7 @@ var _ = Describe("Shard", func() {
 					GinkgoWriter.Println("01/02 13:00 has been triggered")
 				}
 				return shard.State().Blocks
-			}, defaultEventuallyTimeout).Should(Equal([]tsdb.BlockState{
+			}, flags.EventuallyTimeout).Should(Equal([]tsdb.BlockState{
 				{
 					ID: tsdb.BlockID{
 						SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700101),
@@ -497,7 +497,7 @@ var _ = Describe("Shard", func() {
 					GinkgoWriter.Println("01/03 01:00 has been triggered")
 				}
 				return shard.State().Blocks
-			}, defaultEventuallyTimeout).Should(Equal([]tsdb.BlockState{
+			}, flags.EventuallyTimeout).Should(Equal([]tsdb.BlockState{
 				{
 					ID: tsdb.BlockID{
 						SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700102),
@@ -558,13 +558,14 @@ var _ = Describe("Shard", func() {
 					Num:  7,
 				},
 				2,
+				3,
 			)
 			Expect(err).NotTo(HaveOccurred())
 			By("01/01 00:01 1st block is opened")
 			t1 := clock.Now()
 			Eventually(func() []tsdb.BlockState {
 				return shard.State().Blocks
-			}, defaultEventuallyTimeout).Should(Equal([]tsdb.BlockState{
+			}, flags.EventuallyTimeout).Should(Equal([]tsdb.BlockState{
 				{
 					ID: tsdb.BlockID{
 						SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700101),
@@ -581,7 +582,7 @@ var _ = Describe("Shard", func() {
 					GinkgoWriter.Println("01/01 10:00 has been triggered")
 				}
 				return shard.State().Blocks
-			}, defaultEventuallyTimeout).Should(Equal([]tsdb.BlockState{
+			}, flags.EventuallyTimeout).Should(Equal([]tsdb.BlockState{
 				{
 					ID: tsdb.BlockID{
 						SegID:   tsdb.GenerateInternalID(tsdb.DAY, 19700101),
@@ -600,7 +601,7 @@ var _ = Describe("Shard", func() {
 			}))
 			Eventually(func() []tsdb.BlockID {
 				return shard.State().OpenBlocks
-			}, defaultEventuallyTimeout).Should(Equal([]tsdb.BlockID{}))
+			}, flags.EventuallyTimeout).Should(Equal([]tsdb.BlockID{}))
 		})
 	})
 })

--- a/banyand/tsdb/tsdb.go
+++ b/banyand/tsdb/tsdb.go
@@ -107,8 +107,16 @@ type BlockID struct {
 	BlockID uint16
 }
 
+func (b BlockID) String() string {
+	return fmt.Sprintf("BlockID-%d-%d", parseSuffix(b.SegID), parseSuffix(b.BlockID))
+}
+
 func GenerateInternalID(unit IntervalUnit, suffix int) uint16 {
 	return uint16(unit)<<12 | ((uint16(suffix) << 4) >> 4)
+}
+
+func parseSuffix(id uint16) int {
+	return int((id << 12) >> 12)
 }
 
 type BlockState struct {
@@ -211,7 +219,7 @@ func createDatabase(ctx context.Context, db *database, startID int) (Database, e
 	for i := startID; i < int(db.shardNum); i++ {
 		db.logger.Info().Int("shard_id", i).Msg("creating a shard")
 		so, errNewShard := OpenShard(ctx, common.ShardID(i),
-			db.location, db.segmentSize, db.blockSize, db.ttl, defaultBlockQueueSize)
+			db.location, db.segmentSize, db.blockSize, db.ttl, defaultBlockQueueSize, defaultMaxBlockQueueSize)
 		if errNewShard != nil {
 			err = multierr.Append(err, errNewShard)
 			continue
@@ -243,6 +251,7 @@ func loadDatabase(ctx context.Context, db *database) (Database, error) {
 			db.blockSize,
 			db.ttl,
 			defaultBlockQueueSize,
+			defaultMaxBlockQueueSize,
 		)
 		if errOpenShard != nil {
 			return errOpenShard

--- a/banyand/tsdb/tsdb_suite_test.go
+++ b/banyand/tsdb/tsdb_suite_test.go
@@ -18,15 +18,13 @@ package tsdb_test
 
 import (
 	"testing"
-	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/apache/skywalking-banyandb/pkg/logger"
+	"github.com/apache/skywalking-banyandb/pkg/test/flags"
 )
-
-var defaultEventuallyTimeout = 30 * time.Second
 
 func TestTsdb(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -36,6 +34,6 @@ func TestTsdb(t *testing.T) {
 var _ = BeforeSuite(func() {
 	Expect(logger.Init(logger.Logging{
 		Env:   "dev",
-		Level: "warn",
+		Level: flags.LogLevel,
 	})).Should(Succeed())
 })

--- a/banyand/tsdb/tsdb_test.go
+++ b/banyand/tsdb/tsdb_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/apache/skywalking-banyandb/pkg/encoding"
 	"github.com/apache/skywalking-banyandb/pkg/logger"
 	"github.com/apache/skywalking-banyandb/pkg/test"
+	"github.com/apache/skywalking-banyandb/pkg/test/flags"
 	"github.com/apache/skywalking-banyandb/pkg/timestamp"
 )
 
@@ -100,7 +101,7 @@ func verifyDatabaseStructure(tester *assert.Assertions, tempDir string, now time
 func openDatabase(ctx context.Context, t *require.Assertions, path string) (db Database) {
 	t.NoError(logger.Init(logger.Logging{
 		Env:   "dev",
-		Level: "warn",
+		Level: flags.LogLevel,
 	}))
 	db, err := OpenDatabase(
 		context.WithValue(ctx, logger.ContextKey, logger.GetLogger("test")),

--- a/bydbctl/internal/cmd/cmd_suite_test.go
+++ b/bydbctl/internal/cmd/cmd_suite_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/apache/skywalking-banyandb/pkg/logger"
+	"github.com/apache/skywalking-banyandb/pkg/test/flags"
 )
 
 func TestCmd(t *testing.T) {
@@ -34,6 +35,6 @@ func TestCmd(t *testing.T) {
 var _ = BeforeSuite(func() {
 	Expect(logger.Init(logger.Logging{
 		Env:   "dev",
-		Level: "warn",
+		Level: flags.LogLevel,
 	})).To(Succeed())
 })

--- a/docs/crud/measure/query.md
+++ b/docs/crud/measure/query.md
@@ -43,6 +43,7 @@ fieldProjection:
 timeRange:
   begin: 2022-10-15T22:32:48Z
   end: 2022-10-15T23:32:48Z
+EOF
 ```
 
 The below command could query data in the last 30 minutes using relative time duration :
@@ -58,6 +59,7 @@ tagProjection:
     tags: ["id", "entity_id"]
 fieldProjection:
   names: ["total", "value"]
+EOF
 ```
 
 ## API Reference

--- a/docs/crud/stream/query.md
+++ b/docs/crud/stream/query.md
@@ -43,6 +43,7 @@ projection:
 timeRange:
   begin: 2022-10-15T22:32:48+08:00
   end: 2022-10-15T23:32:48+08:00
+EOF
 ```
 
 The below command could query data in the last 30 minutes using relative time duration :
@@ -58,6 +59,7 @@ projection:
     tags: ["trace_id"]
   - name: "data"
     tags: ["data_binary"]
+EOF
 ```
 
 ## API Reference

--- a/pkg/index/inverted/inverted_test.go
+++ b/pkg/index/inverted/inverted_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/apache/skywalking-banyandb/pkg/index/testcases"
 	"github.com/apache/skywalking-banyandb/pkg/logger"
 	"github.com/apache/skywalking-banyandb/pkg/test"
+	"github.com/apache/skywalking-banyandb/pkg/test/flags"
 )
 
 var serviceName = index.FieldKey{
@@ -173,7 +174,7 @@ func TestStore_Iterator(t *testing.T) {
 func setUp(t *require.Assertions) (tempDir string, deferFunc func()) {
 	t.NoError(logger.Init(logger.Logging{
 		Env:   "dev",
-		Level: "warn",
+		Level: flags.LogLevel,
 	}))
 	tempDir, deferFunc = test.Space(t)
 	return tempDir, deferFunc

--- a/pkg/index/lsm/lsm_test.go
+++ b/pkg/index/lsm/lsm_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/apache/skywalking-banyandb/pkg/index/testcases"
 	"github.com/apache/skywalking-banyandb/pkg/logger"
 	"github.com/apache/skywalking-banyandb/pkg/test"
+	"github.com/apache/skywalking-banyandb/pkg/test/flags"
 )
 
 func TestStore_MatchTerm(t *testing.T) {
@@ -63,7 +64,7 @@ func TestStore_Iterator(t *testing.T) {
 func setUp(t *require.Assertions) (tempDir string, deferFunc func()) {
 	t.NoError(logger.Init(logger.Logging{
 		Env:   "dev",
-		Level: "warn",
+		Level: flags.LogLevel,
 	}))
 	tempDir, deferFunc = test.Space(t)
 	return tempDir, deferFunc

--- a/pkg/query/logical/common.go
+++ b/pkg/query/logical/common.go
@@ -19,6 +19,9 @@ package logical
 
 import (
 	"bytes"
+	"context"
+	"io"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -101,16 +104,15 @@ func ProjectItem(ec executor.ExecutionContext, item tsdb.Item, projectionFieldRe
 // This method is used by the underlying tableScan and localIndexScan plans.
 func ExecuteForShard(series tsdb.SeriesList, timeRange timestamp.TimeRange,
 	builders ...SeekerBuilder,
-) ([]tsdb.Iterator, error) {
+) ([]tsdb.Iterator, []io.Closer, error) {
 	var itersInShard []tsdb.Iterator
+	var closers []io.Closer
 	for _, seriesFound := range series {
 		itersInSeries, err := func() ([]tsdb.Iterator, error) {
-			sp, errInner := seriesFound.Span(timeRange)
-			defer func(sp tsdb.SeriesSpan) {
-				if sp != nil {
-					_ = sp.Close()
-				}
-			}(sp)
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			sp, errInner := seriesFound.Span(ctx, timeRange)
+			closers = append(closers, sp)
 			if errInner != nil {
 				return nil, errInner
 			}
@@ -129,16 +131,16 @@ func ExecuteForShard(series tsdb.SeriesList, timeRange timestamp.TimeRange,
 			return iters, nil
 		}()
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		if len(itersInSeries) > 0 {
 			itersInShard = append(itersInShard, itersInSeries...)
 		}
 	}
-	return itersInShard, nil
+	return itersInShard, closers, nil
 }
 
-var DefaultLimit uint32 = 100
+var DefaultLimit uint32 = 20
 
 type Tag struct {
 	familyName, name string

--- a/pkg/query/logical/stream/stream_plan_indexscan_global.go
+++ b/pkg/query/logical/stream/stream_plan_indexscan_global.go
@@ -18,6 +18,7 @@
 package stream
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"time"
@@ -96,7 +97,9 @@ func (t *globalIndexScan) executeForShard(ec executor.StreamExecutionContext, sh
 			return elementsInShard, errors.WithStack(err)
 		}
 		err = func() error {
-			item, closer, errInner := series.Get(itemID)
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			item, closer, errInner := series.Get(ctx, itemID)
 			defer func(closer io.Closer) {
 				if closer != nil {
 					_ = closer.Close()

--- a/pkg/test/flags/flags.go
+++ b/pkg/test/flags/flags.go
@@ -14,25 +14,26 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-package bucket_test
+package flags
 
 import (
-	"testing"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-
-	"github.com/apache/skywalking-banyandb/pkg/logger"
-	"github.com/apache/skywalking-banyandb/pkg/test/flags"
+	"time"
 )
 
-func TestBucket(t *testing.T) {
-	RegisterFailHandler(Fail)
-	BeforeSuite(func() {
-		Expect(logger.Init(logger.Logging{
-			Env:   "dev",
-			Level: flags.LogLevel,
-		})).Should(Succeed())
-	})
-	RunSpecs(t, "Bucket Suite")
+var (
+	eventuallyTimeout string
+	EventuallyTimeout time.Duration
+	LogLevel          = "debug"
+)
+
+func init() {
+	if eventuallyTimeout == "" {
+		EventuallyTimeout = time.Second * 3
+		return
+	}
+	d, err := time.ParseDuration(eventuallyTimeout)
+	if err != nil {
+		panic(err)
+	}
+	EventuallyTimeout = d
 }

--- a/test/integration/cold_query/query_suite_test.go
+++ b/test/integration/cold_query/query_suite_test.go
@@ -27,6 +27,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/apache/skywalking-banyandb/pkg/logger"
+	"github.com/apache/skywalking-banyandb/pkg/test/flags"
 	"github.com/apache/skywalking-banyandb/pkg/test/helpers"
 	"github.com/apache/skywalking-banyandb/pkg/test/setup"
 	"github.com/apache/skywalking-banyandb/pkg/timestamp"
@@ -51,7 +52,7 @@ var (
 var _ = SynchronizedBeforeSuite(func() []byte {
 	Expect(logger.Init(logger.Logging{
 		Env:   "dev",
-		Level: "warn",
+		Level: flags.LogLevel,
 	})).To(Succeed())
 	var addr string
 	addr, _, deferFunc = setup.SetUp()

--- a/test/integration/other/other_suite_test.go
+++ b/test/integration/other/other_suite_test.go
@@ -24,6 +24,7 @@ import (
 	gm "github.com/onsi/gomega"
 
 	"github.com/apache/skywalking-banyandb/pkg/logger"
+	"github.com/apache/skywalking-banyandb/pkg/test/flags"
 )
 
 func TestIntegrationOther(t *testing.T) {
@@ -34,6 +35,6 @@ func TestIntegrationOther(t *testing.T) {
 var _ = g.BeforeSuite(func() {
 	gm.Expect(logger.Init(logger.Logging{
 		Env:   "dev",
-		Level: "warn",
+		Level: flags.LogLevel,
 	})).To(gm.Succeed())
 })


### PR DESCRIPTION
* Add a slow load test case to CI
* Update max opened blocks strategy. A shard could open 64 blocks at most. A cleanup goroutine could collect 10 inactive oldest blocks every minute until there are 4 blocks left in the cache.
* Inject logging level and the timeout of eventually through "ldflags"

Signed-off-by: Gao Hongtao <hanahmily@gmail.com>