### PR TITLE
Add health checker to test cases

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -81,6 +81,7 @@ header: # `header` section is configurations for source codes license header.
     - '**/*.pem'
     - '**/.gitignore'
     - '**/buf.lock'
+    - '**/ginkgo.report'
     - 'ui'
 
   comment: on-failure # on what condition license-eye will comment on the pull request, `on-failure`, `always`, `never`.

--- a/banyand/liaison/grpc/registry_test.go
+++ b/banyand/liaison/grpc/registry_test.go
@@ -34,7 +34,9 @@ import (
 	"github.com/apache/skywalking-banyandb/banyand/liaison/grpc"
 	"github.com/apache/skywalking-banyandb/banyand/metadata"
 	"github.com/apache/skywalking-banyandb/banyand/queue"
+	"github.com/apache/skywalking-banyandb/pkg/grpchelper"
 	"github.com/apache/skywalking-banyandb/pkg/test"
+	"github.com/apache/skywalking-banyandb/pkg/test/flags"
 	"github.com/apache/skywalking-banyandb/pkg/test/helpers"
 	teststream "github.com/apache/skywalking-banyandb/pkg/test/stream"
 )
@@ -47,8 +49,12 @@ var _ = Describe("Registry", func() {
 	}
 	BeforeEach(func() {
 		gracefulStop = setupForRegistry()
+		addr := "localhost:17912"
+		Eventually(
+			helpers.HealthCheck(addr, 10*time.Second, 10*time.Second, grpclib.WithTransportCredentials(insecure.NewCredentials())),
+			flags.EventuallyTimeout).Should(Succeed())
 		var err error
-		conn, err = grpclib.Dial("localhost:17912", grpclib.WithTransportCredentials(insecure.NewCredentials()))
+		conn, err = grpchelper.Conn(addr, 10*time.Second, grpclib.WithTransportCredentials(insecure.NewCredentials()))
 		Expect(err).NotTo(HaveOccurred())
 	})
 	It("manages the stream", func() {
@@ -187,7 +193,9 @@ func setupForRegistry() func() {
 		preloadStreamSvc,
 		tcp,
 	)
-	Eventually(helpers.HealthCheck("localhost:17912", 10*time.Second, 10*time.Second), 20*time.Second).Should(Succeed())
+	Eventually(
+		helpers.HealthCheck("localhost:17912", 10*time.Second, 10*time.Second, grpclib.WithTransportCredentials(insecure.NewCredentials())),
+		20*time.Second).Should(Succeed())
 	return func() {
 		deferFunc()
 		metaDeferFunc()

--- a/banyand/tsdb/shard_test.go
+++ b/banyand/tsdb/shard_test.go
@@ -61,13 +61,6 @@ var _ = Describe("Shard", func() {
 				}, flags.EventuallyTimeout).Should(BeTrue())
 			}
 		}
-		stopped := func(tasks ...string) {
-			for _, task := range tasks {
-				Eventually(func() bool {
-					return shard.TriggerSchedule(task)
-				}, flags.EventuallyTimeout).Should(BeFalse())
-			}
-		}
 		forward := func(hours int, tasks ...string) {
 			for i := 0; i < hours; i++ {
 				clock.Add(1 * time.Hour)
@@ -136,7 +129,6 @@ var _ = Describe("Shard", func() {
 			}, flags.EventuallyTimeout).Should(Equal([]tsdb.BlockID{}))
 			By("01/01 13:00 moves to the 2nd block")
 			forward(2, "BlockID-19700101-00-1", "SegID-19700101-1")
-			stopped("BlockID-19700101-00-1")
 			started("BlockID-19700101-12-1")
 			Eventually(func() []tsdb.BlockID {
 				return shard.State().OpenBlocks
@@ -176,7 +168,6 @@ var _ = Describe("Shard", func() {
 			}))
 			By("01/02 01:00 moves to 3rd block")
 			forward(2, "BlockID-19700101-12-1", "SegID-19700101-1")
-			stopped("BlockID-19700101-12-1", "SegID-19700101-1")
 			started("BlockID-19700102-00-1", "SegID-19700102-1")
 			Eventually(func() []tsdb.BlockID {
 				if clock.TriggerTimer() {
@@ -233,7 +224,6 @@ var _ = Describe("Shard", func() {
 			}))
 			By("01/02 13:00 moves to 4th block")
 			forward(2, "BlockID-19700102-00-1", "SegID-19700102-1")
-			stopped("BlockID-19700102-00-1")
 			started("BlockID-19700102-12-1")
 			Eventually(func() []tsdb.BlockID {
 				return shard.State().OpenBlocks
@@ -295,7 +285,6 @@ var _ = Describe("Shard", func() {
 			}))
 			By("01/03 01:00 close 1st block by adding 5th block")
 			forward(2, "BlockID-19700102-12-1", "SegID-19700102-1")
-			stopped("BlockID-19700102-12-1", "SegID-19700102-1")
 			started("BlockID-19700103-00-1", "SegID-19700103-1")
 			Eventually(func() []tsdb.BlockID {
 				return shard.State().OpenBlocks
@@ -448,14 +437,12 @@ var _ = Describe("Shard", func() {
 			t2 := clock.Now().Add(1 * time.Hour)
 			By("01/01 13:00 moves to the 2nd block")
 			forward(2, "BlockID-19700101-00-1", "SegID-19700101-1", "retention")
-			stopped("BlockID-19700101-00-1")
 			started("BlockID-19700101-12-1", "retention")
 			By("01/01 23:00 3rd block is opened")
 			forward(10, "BlockID-19700101-12-1", "SegID-19700101-1", "retention")
 			t3 := clock.Now().Add(1 * time.Hour)
 			By("01/02 01:00 moves to 3rd block")
 			forward(2, "BlockID-19700101-12-1", "SegID-19700101-1", "retention")
-			stopped("BlockID-19700101-12-1", "SegID-19700101-1")
 			started("BlockID-19700102-00-1", "SegID-19700102-1", "retention")
 			By("01/02 11:00 4th block is opened")
 			forward(10, "BlockID-19700102-00-1", "SegID-19700102-1", "retention")
@@ -495,14 +482,12 @@ var _ = Describe("Shard", func() {
 			}))
 			By("01/02 13:00 moves to 4th block")
 			forward(2, "BlockID-19700102-00-1", "SegID-19700102-1", "retention")
-			stopped("BlockID-19700102-00-1")
 			started("BlockID-19700102-12-1", "retention")
 			By("01/02 23:00 5th block is opened")
 			forward(10, "BlockID-19700102-12-1", "SegID-19700102-1", "retention")
 			t5 := clock.Now().Add(1 * time.Hour)
 			By("01/03 01:00 close 1st block by adding 5th block")
 			forward(2, "BlockID-19700102-12-1", "SegID-19700102-1", "retention")
-			stopped("BlockID-19700102-12-1", "SegID-19700102-1")
 			started("BlockID-19700103-00-1", "SegID-19700103-1", "retention")
 			Eventually(func() []tsdb.BlockState {
 				started("retention")

--- a/pkg/grpchelper/client.go
+++ b/pkg/grpchelper/client.go
@@ -22,7 +22,6 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
@@ -31,11 +30,11 @@ import (
 
 var l = logger.GetLogger()
 
-func Conn(addr string, connTimeout time.Duration) (*grpc.ClientConn, error) {
-	opts := []grpc.DialOption{
+func Conn(addr string, connTimeout time.Duration, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	defaultOpts := []grpc.DialOption{
 		grpc.WithBlock(),
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	}
+	opts = append(opts, defaultOpts...)
 
 	connStart := time.Now()
 	dialCtx, dialCancel := context.WithTimeout(context.Background(), connTimeout)

--- a/pkg/test/helpers/grpc_health.go
+++ b/pkg/test/helpers/grpc_health.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"time"
 
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/apache/skywalking-banyandb/pkg/grpchelper"
@@ -32,9 +33,9 @@ var (
 	l                   = logger.GetLogger()
 )
 
-func HealthCheck(addr string, connTimeout time.Duration, rpcTimeout time.Duration) func() error {
+func HealthCheck(addr string, connTimeout time.Duration, rpcTimeout time.Duration, opts ...grpc.DialOption) func() error {
 	return func() error {
-		conn, err := grpchelper.Conn(addr, connTimeout)
+		conn, err := grpchelper.Conn(addr, connTimeout, opts...)
 		if err != nil {
 			return err
 		}

--- a/pkg/test/measure/etcd.go
+++ b/pkg/test/measure/etcd.go
@@ -29,6 +29,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"go.uber.org/multierr"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 
@@ -106,7 +108,7 @@ func loadSchema[T proto.Message](dir string, resource T, loadFn func(resource T)
 var rpcTimeout = 10 * time.Second
 
 func RegisterForNew(addr string, metricNum int) error {
-	conn, err := grpchelper.Conn(addr, 1*time.Second)
+	conn, err := grpchelper.Conn(addr, 1*time.Second, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return err
 	}

--- a/pkg/test/measure/traffic/traffic.go
+++ b/pkg/test/measure/traffic/traffic.go
@@ -26,6 +26,8 @@ import (
 	"time"
 
 	"github.com/dgraph-io/ristretto/z"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	commonv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/common/v1"
@@ -46,7 +48,7 @@ type TestCase struct {
 }
 
 func SendWrites(ts TestCase) (*z.Closer, error) {
-	conn, err := grpchelper.Conn(ts.Addr, 1*time.Second)
+	conn, err := grpchelper.Conn(ts.Addr, 1*time.Second, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/test/stream/etcd.go
+++ b/pkg/test/stream/etcd.go
@@ -26,6 +26,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/encoding/protojson"
 
 	commonv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/common/v1"
@@ -101,7 +103,7 @@ func RandomTempDir() string {
 var rpcTimeout = 10 * time.Second
 
 func RegisterForNew(addr string) error {
-	conn, err := grpchelper.Conn(addr, 1*time.Second)
+	conn, err := grpchelper.Conn(addr, 1*time.Second, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return err
 	}

--- a/pkg/test/stream/traffic/traffic.go
+++ b/pkg/test/stream/traffic/traffic.go
@@ -30,6 +30,8 @@ import (
 	"time"
 
 	"github.com/dgraph-io/ristretto/z"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -61,7 +63,7 @@ func SendWrites(ts TestCase) (*z.Closer, error) {
 		l.Err(err).Msg("unmarshal template")
 		return nil, err
 	}
-	conn, err := grpchelper.Conn(ts.Addr, 1*time.Second)
+	conn, err := grpchelper.Conn(ts.Addr, 1*time.Second, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, err
 	}

--- a/test/integration/other/measure_test.go
+++ b/test/integration/other/measure_test.go
@@ -22,9 +22,11 @@ import (
 
 	g "github.com/onsi/ginkgo/v2"
 	gm "github.com/onsi/gomega"
-	grpclib "google.golang.org/grpc"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/apache/skywalking-banyandb/pkg/grpchelper"
+	"github.com/apache/skywalking-banyandb/pkg/test/flags"
 	"github.com/apache/skywalking-banyandb/pkg/test/helpers"
 	"github.com/apache/skywalking-banyandb/pkg/test/setup"
 	"github.com/apache/skywalking-banyandb/pkg/timestamp"
@@ -35,16 +37,15 @@ var _ = g.Describe("Query service_cpm_minute", func() {
 	var deferFn func()
 	var baseTime time.Time
 	var interval time.Duration
-	var conn *grpclib.ClientConn
+	var conn *grpc.ClientConn
 
 	g.BeforeEach(func() {
 		var addr string
 		addr, _, deferFn = setup.SetUp()
+		gm.Eventually(helpers.HealthCheck(addr, 10*time.Second, 10*time.Second, grpc.WithTransportCredentials(insecure.NewCredentials())),
+			flags.EventuallyTimeout).Should(gm.Succeed())
 		var err error
-		conn, err = grpclib.Dial(
-			addr,
-			grpclib.WithTransportCredentials(insecure.NewCredentials()),
-		)
+		conn, err = grpchelper.Conn(addr, 10*time.Second, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		gm.Expect(err).NotTo(gm.HaveOccurred())
 		baseTime = timestamp.NowMilli()
 		interval = 500 * time.Millisecond

--- a/test/integration/other/property_test.go
+++ b/test/integration/other/property_test.go
@@ -19,31 +19,34 @@ package integration_other_test
 
 import (
 	"context"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	grpclib "google.golang.org/grpc"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
 	common_v1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/common/v1"
 	model_v1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/model/v1"
 	property_v1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/property/v1"
+	"github.com/apache/skywalking-banyandb/pkg/grpchelper"
+	"github.com/apache/skywalking-banyandb/pkg/test/flags"
+	"github.com/apache/skywalking-banyandb/pkg/test/helpers"
 	"github.com/apache/skywalking-banyandb/pkg/test/setup"
 )
 
 var _ = Describe("Property application", func() {
 	var deferFn func()
-	var conn *grpclib.ClientConn
+	var conn *grpc.ClientConn
 	var client property_v1.PropertyServiceClient
 
 	BeforeEach(func() {
 		var addr string
 		addr, _, deferFn = setup.SetUp()
+		Eventually(helpers.HealthCheck(addr, 10*time.Second, 10*time.Second, grpc.WithTransportCredentials(insecure.NewCredentials())),
+			flags.EventuallyTimeout).Should(Succeed())
 		var err error
-		conn, err = grpclib.Dial(
-			addr,
-			grpclib.WithTransportCredentials(insecure.NewCredentials()),
-		)
+		conn, err = grpchelper.Conn(addr, 10*time.Second, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		Expect(err).NotTo(HaveOccurred())
 		client = property_v1.NewPropertyServiceClient(conn)
 	})
@@ -95,7 +98,7 @@ var _ = Describe("Property application", func() {
 
 var _ = Describe("Property application", func() {
 	var deferFn func()
-	var conn *grpclib.ClientConn
+	var conn *grpc.ClientConn
 	var client property_v1.PropertyServiceClient
 	var md *property_v1.Metadata
 
@@ -103,10 +106,7 @@ var _ = Describe("Property application", func() {
 		var addr string
 		addr, _, deferFn = setup.SetUp()
 		var err error
-		conn, err = grpclib.Dial(
-			addr,
-			grpclib.WithTransportCredentials(insecure.NewCredentials()),
-		)
+		conn, err = grpchelper.Conn(addr, 10*time.Second, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		Expect(err).NotTo(HaveOccurred())
 		client = property_v1.NewPropertyServiceClient(conn)
 		md = &property_v1.Metadata{

--- a/test/integration/other/tls_test.go
+++ b/test/integration/other/tls_test.go
@@ -27,6 +27,8 @@ import (
 	grpclib "google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
+	"github.com/apache/skywalking-banyandb/pkg/grpchelper"
+	"github.com/apache/skywalking-banyandb/pkg/test/flags"
 	"github.com/apache/skywalking-banyandb/pkg/test/helpers"
 	"github.com/apache/skywalking-banyandb/pkg/test/setup"
 	"github.com/apache/skywalking-banyandb/pkg/timestamp"
@@ -49,7 +51,8 @@ var _ = g.Describe("Query service_cpm_minute", func() {
 		var err error
 		creds, err := credentials.NewClientTLSFromFile(certFile, "localhost")
 		gm.Expect(err).NotTo(gm.HaveOccurred())
-		conn, err = grpclib.Dial(addr, grpclib.WithTransportCredentials(creds))
+		gm.Eventually(helpers.HealthCheck(addr, 10*time.Second, 10*time.Second, grpclib.WithTransportCredentials(creds)), flags.EventuallyTimeout).Should(gm.Succeed())
+		conn, err = grpchelper.Conn(addr, 10*time.Second, grpclib.WithTransportCredentials(creds))
 		gm.Expect(err).NotTo(gm.HaveOccurred())
 		baseTime = timestamp.NowMilli()
 		interval = 500 * time.Millisecond

--- a/test/integration/query/query_suite_test.go
+++ b/test/integration/query/query_suite_test.go
@@ -23,9 +23,10 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	grpclib "google.golang.org/grpc"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/apache/skywalking-banyandb/pkg/grpchelper"
 	"github.com/apache/skywalking-banyandb/pkg/logger"
 	"github.com/apache/skywalking-banyandb/pkg/test/flags"
 	"github.com/apache/skywalking-banyandb/pkg/test/helpers"
@@ -44,7 +45,7 @@ func TestIntegrationQuery(t *testing.T) {
 }
 
 var (
-	connection *grpclib.ClientConn
+	connection *grpc.ClientConn
 	now        time.Time
 	deferFunc  func()
 )
@@ -56,10 +57,9 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	})).To(Succeed())
 	var addr string
 	addr, _, deferFunc = setup.SetUp()
-	conn, err := grpclib.Dial(
-		addr,
-		grpclib.WithTransportCredentials(insecure.NewCredentials()),
-	)
+	Eventually(helpers.HealthCheck(addr, 10*time.Second, 10*time.Second, grpc.WithTransportCredentials(insecure.NewCredentials())),
+		flags.EventuallyTimeout).Should(Succeed())
+	conn, err := grpchelper.Conn(addr, 10*time.Second, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	Expect(err).NotTo(HaveOccurred())
 	ns := timestamp.NowMilli().UnixNano()
 	now = time.Unix(0, ns-ns%int64(time.Minute))
@@ -77,11 +77,8 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	return []byte(addr)
 }, func(address []byte) {
 	var err error
-	connection, err = grpclib.Dial(
-		string(address),
-		grpclib.WithTransportCredentials(insecure.NewCredentials()),
-		grpclib.WithBlock(),
-	)
+	connection, err = grpchelper.Conn(string(address), 10*time.Second,
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
 	cases_stream.SharedContext = helpers.SharedContext{
 		Connection: connection,
 		BaseTime:   now,


### PR DESCRIPTION
Integration test cases rely on the gRPC client to perform API accessing. The server might not be ready before the first connection. This PR introduces the gRPC health checker to wait until the server is ready. 

Signed-off-by: Gao Hongtao <hanahmily@gmail.com>