### PR TITLE
Move group as the first doc of concepts

### DIFF
--- a/docs/menu.yml
+++ b/docs/menu.yml
@@ -28,6 +28,8 @@ catalog:
         path: "/concept/data-model"
   - name: "CRUD Operations"
     catalog:
+      - name: "Group"
+        path: "/crud/group"
       - name: "Measure"
         catalog:
           - name: "Schema" 
@@ -40,8 +42,6 @@ catalog:
             path: "/crud/stream/schema"
           - name: "Query" 
             path: "/crud/stream/query"
-      - name: "Group"
-        path: "/crud/group"
       - name: "IndexRule"
         path: "/crud/index_rule"
       - name: "IndexRuleBinding"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5441976/202610544-50bbc070-b5f9-4e56-bbdf-c5d40cbbb94a.png)

By following this, the group is the top concept, so CRUD docs should follow them as well.

@lujiajing1126 We seem to need some docs to introduce which `group`, `measure`, `stream`, `properties` are used in OAP server?