### PR TITLE
Enhance the inverted index, metadata and logger

### DIFF
--- a/banyand/Dockerfile
+++ b/banyand/Dockerfile
@@ -34,8 +34,6 @@ ENV GO111MODULE "on"
 WORKDIR /src
 COPY go.* ./
 RUN go mod download
-RUN GOBIN=/bin go install github.com/grpc-ecosystem/grpc-health-probe@v0.4.11 \
-    && chmod 755 /bin/grpc-health-probe
 
 FROM base AS builder
 
@@ -44,8 +42,7 @@ RUN --mount=target=. \
             BUILD_DIR=/out make -C banyand all
 
 FROM alpine:edge AS certs
-RUN apk add --no-cache ca-certificates
-RUN update-ca-certificates
+RUN apk add --no-cache ca-certificates && update-ca-certificates
 
 FROM busybox:stable-glibc
 
@@ -61,7 +58,6 @@ ENTRYPOINT ["/banyand-server"]
 FROM busybox:stable-glibc AS test
 
 COPY --from=builder /out/banyand-server /banyand-server
-COPY --from=base /bin/grpc-health-probe /grpc-health-probe
 
 EXPOSE 17912
 EXPOSE 17913

--- a/banyand/k8s.yml
+++ b/banyand/k8s.yml
@@ -81,6 +81,7 @@ spec:
         image: apache/skywalking-banyandb:v0.0.0-dev
         args:
         - "standalone"
+        - "--measure-idx-batch-wait-sec=30"
         - "--logging.level=warn"
         - "--logging.modules=measure.measure-default.service_cpm_minute"
         - "--logging.levels=debug"

--- a/banyand/liaison/grpc/measure.go
+++ b/banyand/liaison/grpc/measure.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/rs/zerolog"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -39,34 +38,44 @@ import (
 type measureService struct {
 	measurev1.UnimplementedMeasureServiceServer
 	*discoveryService
+	sampled *logger.Logger
+}
+
+func (ms *measureService) setLogger(log *logger.Logger) {
+	ms.sampled = log.Sampled(10)
 }
 
 func (ms *measureService) Write(measure measurev1.MeasureService_WriteServer) error {
-	reply := func() error {
-		return measure.Send(&measurev1.WriteResponse{})
+	reply := func(measure measurev1.MeasureService_WriteServer, logger *logger.Logger) {
+		if errResp := measure.Send(&measurev1.WriteResponse{}); errResp != nil {
+			logger.Err(errResp).Msg("failed to send response")
+		}
 	}
-	sampled := ms.log.Sample(&zerolog.BasicSampler{N: 10})
+	ctx := measure.Context()
 	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
 		writeRequest, err := measure.Recv()
 		if errors.Is(err, io.EOF) {
 			return nil
 		}
 		if err != nil {
-			return err
+			ms.sampled.Error().Err(err).Stringer("written", writeRequest).Msg("failed to receive message")
+			reply(measure, ms.sampled)
+			continue
 		}
 		if errTime := timestamp.CheckPb(writeRequest.DataPoint.Timestamp); errTime != nil {
-			sampled.Error().Err(errTime).Stringer("written", writeRequest).Msg("the data point time is invalid")
-			if errResp := reply(); errResp != nil {
-				return errResp
-			}
+			ms.sampled.Error().Err(errTime).Stringer("written", writeRequest).Msg("the data point time is invalid")
+			reply(measure, ms.sampled)
 			continue
 		}
 		entity, tagValues, shardID, err := ms.navigate(writeRequest.GetMetadata(), writeRequest.GetDataPoint().GetTagFamilies())
 		if err != nil {
-			sampled.Error().Err(err).RawJSON("written", logger.Proto(writeRequest)).Msg("failed to navigate to the write target")
-			if errResp := reply(); errResp != nil {
-				return errResp
-			}
+			ms.sampled.Error().Err(err).RawJSON("written", logger.Proto(writeRequest)).Msg("failed to navigate to the write target")
+			reply(measure, ms.sampled)
 			continue
 		}
 		iwr := &measurev1.InternalWriteRequest{
@@ -80,15 +89,9 @@ func (ms *measureService) Write(measure measurev1.MeasureService_WriteServer) er
 		message := bus.NewMessage(bus.MessageID(time.Now().UnixNano()), iwr)
 		_, errWritePub := ms.pipeline.Publish(data.TopicMeasureWrite, message)
 		if errWritePub != nil {
-			sampled.Error().Err(errWritePub).RawJSON("written", logger.Proto(writeRequest)).Msg("failed to send a message")
-			if errResp := reply(); errResp != nil {
-				return errResp
-			}
-			continue
+			ms.sampled.Error().Err(errWritePub).RawJSON("written", logger.Proto(writeRequest)).Msg("failed to send a message")
 		}
-		if errSend := reply(); errSend != nil {
-			return errSend
-		}
+		reply(measure, ms.sampled)
 	}
 }
 

--- a/banyand/liaison/grpc/server.go
+++ b/banyand/liaison/grpc/server.go
@@ -112,6 +112,8 @@ func NewServer(_ context.Context, pipeline queue.Queue, repo discovery.ServiceRe
 
 func (s *server) PreRun() error {
 	s.log = logger.GetLogger("liaison-grpc")
+	s.streamSVC.setLogger(s.log)
+	s.measureSVC.setLogger(s.log)
 	components := []struct {
 		discoverySVC *discoveryService
 		shardEvent   bus.Topic

--- a/banyand/measure/service.go
+++ b/banyand/measure/service.go
@@ -82,6 +82,7 @@ func (s *service) FlagSet() *run.FlagSet {
 	flagS.StringVar(&s.root, "measure-root-path", "/tmp", "the root path of database")
 	flagS.Int64Var(&s.dbOpts.BlockMemSize, "measure-block-mem-size", 16<<20, "block memory size")
 	flagS.Int64Var(&s.dbOpts.SeriesMemSize, "measure-seriesmeta-mem-size", 1<<20, "series metadata memory size")
+	flagS.Int64Var(&s.dbOpts.BlockInvertedIndex.BatchWaitSec, "measure-idx-batch-wait-sec", 1, "index batch wait in second")
 	return flagS
 }
 

--- a/banyand/metadata/metadata.go
+++ b/banyand/metadata/metadata.go
@@ -29,7 +29,6 @@ import (
 	commonv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/common/v1"
 	databasev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
 	"github.com/apache/skywalking-banyandb/banyand/metadata/schema"
-	"github.com/apache/skywalking-banyandb/pkg/logger"
 	"github.com/apache/skywalking-banyandb/pkg/run"
 )
 
@@ -88,7 +87,7 @@ func (s *service) PreRun() error {
 	var err error
 	s.schemaRegistry, err = schema.NewEtcdSchemaRegistry(
 		schema.ConfigureListener(s.listenClientURL, s.listenPeerURL),
-		schema.RootDir(s.rootDir), schema.LoggerLevel(logger.GetLogger().GetLevel().String()))
+		schema.RootDir(s.rootDir))
 	if err != nil {
 		return err
 	}

--- a/banyand/metadata/schema/error.go
+++ b/banyand/metadata/schema/error.go
@@ -34,6 +34,8 @@ var (
 	errGRPCAlreadyExists       = statusGRPCAlreadyExists.Err()
 	statusDataLoss             = status.New(codes.DataLoss, "banyandb: resource corrupts.")
 	errGRPCDataLoss            = statusDataLoss.Err()
+
+	errClosed = errors.New("metadata registry is closed")
 )
 
 // BadRequest creates a gRPC error with error details with type BadRequest,

--- a/banyand/metadata/schema/etcd_test.go
+++ b/banyand/metadata/schema/etcd_test.go
@@ -136,7 +136,7 @@ func useRandomPort() RegistryOption {
 
 func Test_Etcd_Entity_Get(t *testing.T) {
 	tester := assert.New(t)
-	registry, err := NewEtcdSchemaRegistry(useRandomPort(), useRandomTempDir(), LoggerLevel("warn"))
+	registry, err := NewEtcdSchemaRegistry(useRandomPort(), useRandomTempDir())
 	tester.NoError(err)
 	tester.NotNil(registry)
 	defer registry.Close()
@@ -228,7 +228,7 @@ func Test_Etcd_Entity_Get(t *testing.T) {
 
 func Test_Etcd_Entity_List(t *testing.T) {
 	tester := assert.New(t)
-	registry, err := NewEtcdSchemaRegistry(useRandomPort(), useRandomTempDir(), LoggerLevel("warn"))
+	registry, err := NewEtcdSchemaRegistry(useRandomPort(), useRandomTempDir())
 	tester.NoError(err)
 	tester.NotNil(registry)
 	defer registry.Close()
@@ -310,7 +310,7 @@ func Test_Etcd_Entity_List(t *testing.T) {
 
 func Test_Etcd_Delete(t *testing.T) {
 	tester := assert.New(t)
-	registry, err := NewEtcdSchemaRegistry(useRandomPort(), useRandomTempDir(), LoggerLevel("warn"))
+	registry, err := NewEtcdSchemaRegistry(useRandomPort(), useRandomTempDir())
 	tester.NoError(err)
 	tester.NotNil(registry)
 	defer registry.Close()
@@ -379,7 +379,7 @@ func Test_Etcd_Delete(t *testing.T) {
 
 func Test_Notify(t *testing.T) {
 	req := require.New(t)
-	registry, err := NewEtcdSchemaRegistry(useRandomPort(), useRandomTempDir(), LoggerLevel("warn"))
+	registry, err := NewEtcdSchemaRegistry(useRandomPort(), useRandomTempDir())
 	req.NoError(err)
 	req.NotNil(registry)
 	defer registry.Close()

--- a/banyand/metadata/schema/group.go
+++ b/banyand/metadata/schema/group.go
@@ -43,7 +43,7 @@ func (e *etcdSchemaRegistry) GetGroup(ctx context.Context, group string) (*commo
 }
 
 func (e *etcdSchemaRegistry) ListGroup(ctx context.Context) ([]*commonv1.Group, error) {
-	messages, err := e.kv.Get(ctx, groupsKeyPrefix, clientv3.WithFromKey(), clientv3.WithRange(incrementLastByte(groupsKeyPrefix)))
+	messages, err := e.client.Get(ctx, groupsKeyPrefix, clientv3.WithFromKey(), clientv3.WithRange(incrementLastByte(groupsKeyPrefix)))
 	if err != nil {
 		return nil, err
 	}
@@ -69,7 +69,7 @@ func (e *etcdSchemaRegistry) DeleteGroup(ctx context.Context, group string) (boo
 		return false, errors.Wrap(err, group)
 	}
 	keyPrefix := groupsKeyPrefix + g.GetMetadata().GetName() + "/"
-	resp, err := e.kv.Delete(ctx, keyPrefix, clientv3.WithRange(incrementLastByte(keyPrefix)))
+	resp, err := e.client.Delete(ctx, keyPrefix, clientv3.WithRange(incrementLastByte(keyPrefix)))
 	if err != nil {
 		return false, err
 	}

--- a/banyand/stream/service.go
+++ b/banyand/stream/service.go
@@ -76,6 +76,7 @@ func (s *service) FlagSet() *run.FlagSet {
 	flagS.Int64Var(&s.dbOpts.BlockMemSize, "stream-block-mem-size", 8<<20, "block memory size")
 	flagS.Int64Var(&s.dbOpts.SeriesMemSize, "stream-seriesmeta-mem-size", 1<<20, "series metadata memory size")
 	flagS.Int64Var(&s.dbOpts.GlobalIndexMemSize, "stream-global-index-mem-size", 2<<20, "global index memory size")
+	flagS.Int64Var(&s.dbOpts.BlockInvertedIndex.BatchWaitSec, "stream-idx-batch-wait-sec", 1, "index batch wait in second")
 	return flagS
 }
 

--- a/banyand/tsdb/block.go
+++ b/banyand/tsdb/block.go
@@ -78,6 +78,7 @@ type block struct {
 	lock        sync.RWMutex
 	segID       SectionID
 	blockID     SectionID
+	indexOpts   InvertedIndexOpts
 }
 
 type blockOpts struct {
@@ -145,6 +146,7 @@ func (b *block) options(ctx context.Context) {
 	if b.lsmMemSize < defaultKVMemorySize {
 		b.lsmMemSize = defaultKVMemorySize
 	}
+	b.indexOpts = options.BlockInvertedIndex
 }
 
 func (b *block) openSafely() (err error) {
@@ -171,8 +173,9 @@ func (b *block) open() (err error) {
 	}
 	b.closableLst = append(b.closableLst, b.store)
 	if b.invertedIndex, err = inverted.NewStore(inverted.StoreOpts{
-		Path:   path.Join(b.path, componentSecondInvertedIdx),
-		Logger: b.l.Named(componentSecondInvertedIdx),
+		Path:         path.Join(b.path, componentSecondInvertedIdx),
+		Logger:       b.l.Named(componentSecondInvertedIdx),
+		BatchWaitSec: b.indexOpts.BatchWaitSec,
 	}); err != nil {
 		return err
 	}

--- a/banyand/tsdb/bucket/queue.go
+++ b/banyand/tsdb/bucket/queue.go
@@ -101,7 +101,7 @@ func NewQueue(l *logger.Logger, size int, maxSize int, scheduler *timestamp.Sche
 		evictFn:     evictFn,
 		l:           l,
 	}
-	if err := scheduler.Register(QueueName, cron.Descriptor, "@every 1m", c.cleanEvict); err != nil {
+	if err := scheduler.Register(QueueName, cron.Descriptor, "@every 5m", c.cleanEvict); err != nil {
 		return nil, err
 	}
 	return c, nil

--- a/banyand/tsdb/bucket/queue_test.go
+++ b/banyand/tsdb/bucket/queue_test.go
@@ -132,7 +132,7 @@ var _ = Describe("Queue", func() {
 		Expect(enRecentSize).To(Equal(192))
 		Expect(l.Len()).To(Equal(128))
 		Expect(len(evictLst)).To(Equal(0))
-		clock.Add(time.Minute)
+		clock.Add(6 * time.Minute)
 		if !scheduler.Trigger(bucket.QueueName) {
 			Fail("trigger fails")
 		}

--- a/banyand/tsdb/tsdb.go
+++ b/banyand/tsdb/tsdb.go
@@ -102,10 +102,16 @@ type DatabaseOpts struct {
 	BlockInterval      IntervalRule
 	TTL                IntervalRule
 	BlockMemSize       int64
+	BlockInvertedIndex InvertedIndexOpts
 	SeriesMemSize      int64
 	GlobalIndexMemSize int64
 	ShardNum           uint32
 	EnableGlobalIndex  bool
+}
+
+// InvertedIndexOpts wraps options to create the block inverted index.
+type InvertedIndexOpts struct {
+	BatchWaitSec int64
 }
 
 // EncodingMethod wraps encoder/decoder pools to flush/compact data on disk.

--- a/go.mod
+++ b/go.mod
@@ -118,7 +118,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.11.1 // indirect
 	go.opentelemetry.io/proto/otlp v0.19.0 // indirect
 	go.uber.org/atomic v1.10.0 // indirect
-	go.uber.org/zap v1.23.0 // indirect
+	go.uber.org/zap v1.23.0
 	golang.org/x/crypto v0.3.0 // indirect
 	golang.org/x/net v0.2.0 // indirect
 	golang.org/x/sys v0.2.0 // indirect

--- a/pkg/index/inverted/inverted.go
+++ b/pkg/index/inverted/inverted.go
@@ -28,6 +28,7 @@ import (
 	"github.com/blugelabs/bluge"
 	"github.com/blugelabs/bluge/analysis"
 	"github.com/blugelabs/bluge/analysis/analyzer"
+	blugeIndex "github.com/blugelabs/bluge/index"
 	"github.com/blugelabs/bluge/search"
 	"github.com/dgraph-io/badger/v3/y"
 	"go.uber.org/multierr"
@@ -48,6 +49,12 @@ const (
 	docID         = "_id"
 	batchSize     = 1024
 	seriesIDField = "series_id"
+	idField       = "id"
+)
+
+var (
+	defaultUpper = convert.Uint64ToBytes(math.MaxUint64)
+	defaultLower = convert.Uint64ToBytes(0)
 )
 
 var analyzers map[databasev1.IndexRule_Analyzer]*analysis.Analyzer
@@ -64,8 +71,9 @@ var _ index.Store = (*store)(nil)
 
 // StoreOpts wraps options to create a inverted index repository.
 type StoreOpts struct {
-	Logger *logger.Logger
-	Path   string
+	Logger       *logger.Logger
+	Path         string
+	BatchWaitSec int64
 }
 
 type doc struct {
@@ -78,26 +86,37 @@ type flushEvent struct {
 }
 
 type store struct {
-	writer *bluge.Writer
-	ch     chan any
-	closer *run.Closer
-	l      *logger.Logger
+	writer        *bluge.Writer
+	ch            chan any
+	closer        *run.Closer
+	l             *logger.Logger
+	batchInterval time.Duration
 }
 
 // NewStore create a new inverted index repository.
 func NewStore(opts StoreOpts) (index.Store, error) {
-	config := bluge.DefaultConfig(opts.Path)
+	indexConfig := blugeIndex.DefaultConfig(opts.Path).WithUnsafeBatches().
+		WithPersisterNapTimeMSec(60 * 1000)
+	indexConfig.MergePlanOptions.MaxSegmentsPerTier = 1
+	indexConfig.MergePlanOptions.MaxSegmentSize = 500000
+	indexConfig.MergePlanOptions.SegmentsPerMergeTask = 20
+	config := bluge.DefaultConfigWithIndexConfig(indexConfig)
 	config.DefaultSearchAnalyzer = analyzers[databasev1.IndexRule_ANALYZER_KEYWORD]
 	config.Logger = log.New(opts.Logger, opts.Logger.Module(), 0)
 	w, err := bluge.OpenWriter(config)
 	if err != nil {
 		return nil, err
 	}
+	sec := opts.BatchWaitSec
+	if sec < 1 {
+		sec = 1
+	}
 	s := &store{
-		writer: w,
-		l:      opts.Logger,
-		ch:     make(chan any, batchSize),
-		closer: run.NewCloser(1),
+		writer:        w,
+		batchInterval: time.Duration(sec * int64(time.Second)),
+		l:             opts.Logger,
+		ch:            make(chan any, batchSize),
+		closer:        run.NewCloser(1),
 	}
 	s.run()
 	return s, nil
@@ -136,21 +155,40 @@ func (s *store) Iterator(fieldKey index.FieldKey, termRange index.RangeOpts, ord
 		bytes.Compare(termRange.Lower, termRange.Upper) > 0 {
 		return index.DummyFieldIterator, nil
 	}
+	if termRange.Upper == nil {
+		termRange.Upper = defaultUpper
+	}
+	if termRange.Lower == nil {
+		termRange.Lower = defaultLower
+	}
 	reader, err := s.writer.Reader()
 	if err != nil {
 		return nil, err
 	}
 	fk := fieldKey.MarshalIndexRule()
-	query := bluge.NewBooleanQuery()
-	query.
-		AddMust(bluge.NewTermQuery(string(fieldKey.SeriesID.Marshal())).SetField(seriesIDField)).
-		AddMust(bluge.NewTermRangeInclusiveQuery(
-			string(termRange.Lower),
-			string(termRange.Upper),
+	var query bluge.Query
+	shouldDecodeTerm := true
+	if fieldKey.Analyzer == databasev1.IndexRule_ANALYZER_UNSPECIFIED {
+		query = bluge.NewTermRangeInclusiveQuery(
+			index.FieldStr(fieldKey, termRange.Lower),
+			index.FieldStr(fieldKey, termRange.Upper),
 			termRange.IncludesLower,
 			termRange.IncludesUpper,
 		).
-			SetField(fk))
+			SetField(fk)
+	} else {
+		shouldDecodeTerm = false
+		query = bluge.NewBooleanQuery().
+			AddMust(bluge.NewTermRangeInclusiveQuery(
+				string(termRange.Lower),
+				string(termRange.Upper),
+				termRange.IncludesLower,
+				termRange.IncludesUpper,
+			).
+				SetField(fk)).
+			AddMust(bluge.NewTermQuery(string(fieldKey.SeriesID.Marshal())).SetField(seriesIDField))
+	}
+
 	sortedKey := fk
 	if order == modelv1.Sort_SORT_DESC {
 		sortedKey = "-" + sortedKey
@@ -159,7 +197,7 @@ func (s *store) Iterator(fieldKey index.FieldKey, termRange index.RangeOpts, ord
 	if err != nil {
 		return nil, err
 	}
-	result := newBlugeMatchIterator(documentMatchIterator, fk)
+	result := newBlugeMatchIterator(documentMatchIterator, fk, shouldDecodeTerm)
 	return &result, nil
 }
 
@@ -173,15 +211,21 @@ func (s *store) MatchTerms(field index.Field) (list posting.List, err error) {
 		return nil, err
 	}
 	fk := field.Key.MarshalIndexRule()
-	query := bluge.NewBooleanQuery()
-	query.
-		AddMust(bluge.NewTermQuery(string(field.Key.SeriesID.Marshal())).SetField(seriesIDField)).
-		AddMust(bluge.NewTermQuery(string(field.Term)).SetField(fk))
+	var query bluge.Query
+	shouldDecodeTerm := true
+	if field.Key.Analyzer == databasev1.IndexRule_ANALYZER_UNSPECIFIED {
+		query = bluge.NewTermQuery(string(field.Marshal())).SetField(fk)
+	} else {
+		shouldDecodeTerm = false
+		query = bluge.NewBooleanQuery().
+			AddMust(bluge.NewTermQuery(string(field.Term)).SetField(fk)).
+			AddMust(bluge.NewTermQuery(string(field.Key.SeriesID.Marshal())).SetField(seriesIDField))
+	}
 	documentMatchIterator, err := reader.Search(context.Background(), bluge.NewAllMatches(query))
 	if err != nil {
 		return nil, err
 	}
-	iter := newBlugeMatchIterator(documentMatchIterator, fk)
+	iter := newBlugeMatchIterator(documentMatchIterator, fk, shouldDecodeTerm)
 	list = roaring.NewPostingList()
 	for iter.Next() {
 		err = multierr.Append(err, list.Union(iter.Val().Value))
@@ -191,28 +235,26 @@ func (s *store) MatchTerms(field index.Field) (list posting.List, err error) {
 }
 
 func (s *store) Match(fieldKey index.FieldKey, matches []string) (posting.List, error) {
-	if len(matches) == 0 {
+	if len(matches) == 0 || fieldKey.Analyzer == databasev1.IndexRule_ANALYZER_UNSPECIFIED {
 		return roaring.DummyPostingList, nil
 	}
 	reader, err := s.writer.Reader()
 	if err != nil {
 		return nil, err
 	}
+	analyzer := analyzers[fieldKey.Analyzer]
 	fk := fieldKey.MarshalIndexRule()
 	query := bluge.NewBooleanQuery()
 	query.AddMust(bluge.NewTermQuery(string(fieldKey.SeriesID.Marshal())).SetField(seriesIDField))
 	for _, m := range matches {
-		q := bluge.NewMatchQuery(m).SetField(fk)
-		if fieldKey.Analyzer != databasev1.IndexRule_ANALYZER_UNSPECIFIED {
-			q.SetAnalyzer(analyzers[fieldKey.Analyzer])
-		}
-		query.AddMust(q)
+		query.AddMust(bluge.NewMatchQuery(m).SetField(fk).
+			SetAnalyzer(analyzer))
 	}
 	documentMatchIterator, err := reader.Search(context.Background(), bluge.NewAllMatches(query))
 	if err != nil {
 		return nil, err
 	}
-	iter := newBlugeMatchIterator(documentMatchIterator, fk)
+	iter := newBlugeMatchIterator(documentMatchIterator, fk, false)
 	list := roaring.NewPostingList()
 	for iter.Next() {
 		err = multierr.Append(err, list.Union(iter.Val().Value))
@@ -239,6 +281,7 @@ func (s *store) run() {
 		defer s.closer.Done()
 		size := 0
 		batch := bluge.NewBatch()
+		timer := time.NewTimer(s.batchInterval)
 		flush := func() {
 			if size < 1 {
 				return
@@ -248,11 +291,10 @@ func (s *store) run() {
 			}
 			batch.Reset()
 			size = 0
+			timer = time.NewTimer(s.batchInterval)
 		}
 		var docIDBuffer bytes.Buffer
 		for {
-			timer := time.NewTimer(time.Second)
-			docIDBuffer.Reset()
 			select {
 			case <-s.closer.CloseNotify():
 				return
@@ -267,17 +309,22 @@ func (s *store) run() {
 				case doc:
 					// TODO: generate a segment directly.
 					fk := d.fields[0].Key
+					docIDBuffer.Reset()
 					docIDBuffer.Write(fk.SeriesID.Marshal())
 					docIDBuffer.Write(convert.Uint64ToBytes(uint64(d.itemID)))
 					doc := bluge.NewDocument(docIDBuffer.String())
-
+					toAddSeriesIDField := false
 					for _, f := range d.fields {
-						doc.AddField(bluge.NewKeywordFieldBytes(seriesIDField, f.Key.SeriesID.Marshal()))
-						field := bluge.NewKeywordFieldBytes(f.Key.MarshalIndexRule(), f.Term).StoreValue().Sortable()
-						if f.Key.Analyzer != databasev1.IndexRule_ANALYZER_UNSPECIFIED {
-							field.WithAnalyzer(analyzers[f.Key.Analyzer])
+						if f.Key.Analyzer == databasev1.IndexRule_ANALYZER_UNSPECIFIED {
+							doc.AddField(bluge.NewKeywordFieldBytes(f.Key.MarshalIndexRule(), f.Marshal()).StoreValue().Sortable())
+						} else {
+							toAddSeriesIDField = true
+							doc.AddField(bluge.NewKeywordFieldBytes(f.Key.MarshalIndexRule(), f.Term).StoreValue().
+								WithAnalyzer(analyzers[f.Key.Analyzer]))
 						}
-						doc.AddField(field)
+					}
+					if toAddSeriesIDField {
+						doc.AddField(bluge.NewKeywordFieldBytes(seriesIDField, fk.SeriesID.Marshal()))
 					}
 					size++
 					if size >= batchSize {
@@ -308,18 +355,20 @@ func (s *store) flush() {
 }
 
 type blugeMatchIterator struct {
-	delegated search.DocumentMatchIterator
-	err       error
-	current   *index.PostingValue
-	agg       *index.PostingValue
-	fieldKey  string
-	closed    bool
+	delegated        search.DocumentMatchIterator
+	err              error
+	current          *index.PostingValue
+	agg              *index.PostingValue
+	fieldKey         string
+	shouldDecodeTerm bool
+	closed           bool
 }
 
-func newBlugeMatchIterator(delegated search.DocumentMatchIterator, fieldKey string) blugeMatchIterator {
+func newBlugeMatchIterator(delegated search.DocumentMatchIterator, fieldKey string, shouldDecodeTerm bool) blugeMatchIterator {
 	return blugeMatchIterator{
-		delegated: delegated,
-		fieldKey:  fieldKey,
+		delegated:        delegated,
+		fieldKey:         fieldKey,
+		shouldDecodeTerm: shouldDecodeTerm,
 	}
 }
 
@@ -363,7 +412,12 @@ func (bmi *blugeMatchIterator) nextTerm() bool {
 			i++
 		}
 		if field == bmi.fieldKey {
-			term = y.Copy(value)
+			v := y.Copy(value)
+			if bmi.shouldDecodeTerm {
+				term = index.UnmarshalTerm(v)
+			} else {
+				term = v
+			}
 			i++
 		}
 		return i < 2

--- a/pkg/index/lsm/iterator.go
+++ b/pkg/index/lsm/iterator.go
@@ -89,7 +89,7 @@ func (f *fieldIteratorTemplate) Close() error {
 
 func newFieldIteratorTemplate(l *logger.Logger, fieldKey index.FieldKey, termRange index.RangeOpts, order modelv1.Sort, iterable kv.Iterable,
 	fn compositePostingValueFn,
-) (*fieldIteratorTemplate, error) {
+) *fieldIteratorTemplate {
 	if termRange.Upper == nil {
 		termRange.Upper = defaultUpper
 	}
@@ -117,17 +117,13 @@ func newFieldIteratorTemplate(l *logger.Logger, fieldKey index.FieldKey, termRan
 		Key:  fieldKey,
 		Term: term,
 	}
-	seekKey, err := field.Marshal()
-	if err != nil {
-		return nil, err
-	}
 	return &fieldIteratorTemplate{
 		delegated: newDelegateIterator(iter, fieldKey, l),
 		termRange: termRange,
 		fn:        fn,
 		reverse:   reverse,
-		seekKey:   seekKey,
-	}, nil
+		seekKey:   field.Marshal(),
+	}
 }
 
 func parseKey(fieldKey index.FieldKey, key []byte) (index.Field, error) {

--- a/pkg/index/lsm/lsm.go
+++ b/pkg/index/lsm/lsm.go
@@ -46,13 +46,8 @@ func (s *store) Close() error {
 
 func (s *store) Write(fields []index.Field, itemID common.ItemID) (err error) {
 	for _, field := range fields {
-		f, errInternal := field.Marshal()
-		if errInternal != nil {
-			err = multierr.Append(err, errInternal)
-			continue
-		}
 		itemIDInt := uint64(itemID)
-		err = multierr.Append(err, s.lsm.PutWithVersion(f, convert.Uint64ToBytes(itemIDInt), itemIDInt))
+		err = multierr.Append(err, s.lsm.PutWithVersion(field.Marshal(), convert.Uint64ToBytes(itemIDInt), itemIDInt))
 	}
 	return err
 }

--- a/pkg/index/lsm/search.go
+++ b/pkg/index/lsm/search.go
@@ -39,12 +39,8 @@ func (s *store) MatchField(fieldKey index.FieldKey) (list posting.List, err erro
 }
 
 func (s *store) MatchTerms(field index.Field) (list posting.List, err error) {
-	f, err := field.Marshal()
-	if err != nil {
-		return nil, err
-	}
 	list = roaring.NewPostingList()
-	err = s.lsm.GetAll(f, func(itemID []byte) error {
+	err = s.lsm.GetAll(field.Marshal(), func(itemID []byte) error {
 		list.Insert(common.ItemID(convert.BytesToUint64(itemID)))
 		return nil
 	})
@@ -94,7 +90,7 @@ func (s *store) Iterator(fieldKey index.FieldKey, termRange index.RangeOpts, ord
 				pv.Value.Insert(common.ItemID(itemID))
 			}
 			return pv, nil
-		})
+		}), nil
 }
 
 func (s *store) Match(_ index.FieldKey, _ []string) (posting.List, error) {

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -76,6 +76,13 @@ func (l *Logger) Named(name ...string) *Logger {
 	return &Logger{module: module, modules: l.modules, Logger: &subLogger}
 }
 
+// Sampled return a Logger with a sampler that will send every Nth events.
+func (l *Logger) Sampled(n uint32) *Logger {
+	sampled := l.Logger.Sample(&zerolog.BasicSampler{N: n})
+	l.Logger = &sampled
+	return l
+}
+
 // Loggable indicates the implement supports logging.
 type Loggable interface {
 	SetLogger(*Logger)


### PR DESCRIPTION
There are several enhancements in this PR:

## Improve the inverted index

`SeriesID` is a mandatory field that is scanned in each equal operation. In this PR, I composite `SeriesID` and `Term` to a composite index. The equivalent process gets rid of roaringbitmap's intersection operation. The new path improves the ID matching's performance. 

The side effect is: If the tag is marked as an `Analyzer`, the inverted index engine will split this composited index for analyzing the `Term`. That if you do an equal query on a tag with an `Analyzer`, the performance would be worse a bit.

This is related to https://github.com/apache/skywalking/issues/10119.

## Metadata 

The Etcd-powered metadata registry closing process will wait till all running operations are done. It will prevent the retry interceptor from repeatedly connecting to a closed server, which will slow down the testing.

## Logger

Etcd uses the Zap logger, while others pick up the Zerologger. The PR introduces a Zap config generator that outputs a similar log configuration with the Zerolog. 

In the development mode, both loggers will print their stacks and callers will help developers diagnose the code.



