### PR TITLE
Add a timeout to all go leaking checkers

### DIFF
--- a/banyand/liaison/grpc/registry_test.go
+++ b/banyand/liaison/grpc/registry_test.go
@@ -65,7 +65,7 @@ var _ = Describe("Registry", func() {
 	AfterEach(func() {
 		_ = conn.Close()
 		gracefulStop()
-		Eventually(gleak.Goroutines).ShouldNot(gleak.HaveLeaked(goods))
+		Eventually(gleak.Goroutines, testflags.EventuallyTimeout).ShouldNot(gleak.HaveLeaked(goods))
 	})
 
 	It("manages the stream", func() {

--- a/banyand/measure/metadata_test.go
+++ b/banyand/measure/metadata_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Metadata", func() {
 
 	AfterEach(func() {
 		deferFn()
-		Eventually(gleak.Goroutines).ShouldNot(gleak.HaveLeaked(goods))
+		Eventually(gleak.Goroutines, flags.EventuallyTimeout).ShouldNot(gleak.HaveLeaked(goods))
 	})
 
 	Context("Manage group", func() {

--- a/banyand/metadata/schema/checker_test.go
+++ b/banyand/metadata/schema/checker_test.go
@@ -27,6 +27,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	databasev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
+	"github.com/apache/skywalking-banyandb/pkg/test/flags"
 )
 
 func loadStream() *databasev1.Stream {
@@ -64,7 +65,7 @@ var _ = ginkgo.Describe("Utils", func() {
 		})
 
 		ginkgo.AfterEach(func() {
-			Eventually(gleak.Goroutines).ShouldNot(gleak.HaveLeaked(goods))
+			Eventually(gleak.Goroutines, flags.EventuallyTimeout).ShouldNot(gleak.HaveLeaked(goods))
 		})
 
 		ginkgo.It("should be equal if nothing changed", func() {

--- a/banyand/stream/metadata_test.go
+++ b/banyand/stream/metadata_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Metadata", func() {
 
 	AfterEach(func() {
 		deferFn()
-		Eventually(gleak.Goroutines).ShouldNot(gleak.HaveLeaked(goods))
+		Eventually(gleak.Goroutines, flags.EventuallyTimeout).ShouldNot(gleak.HaveLeaked(goods))
 	})
 
 	Context("Manage group", func() {

--- a/test/integration/cold_query/query_suite_test.go
+++ b/test/integration/cold_query/query_suite_test.go
@@ -102,5 +102,5 @@ var _ = SynchronizedAfterSuite(func() {
 	}
 }, func() {
 	deferFunc()
-	Eventually(gleak.Goroutines).ShouldNot(gleak.HaveLeaked(goods))
+	Eventually(gleak.Goroutines, flags.EventuallyTimeout).ShouldNot(gleak.HaveLeaked(goods))
 })

--- a/test/integration/load/load_suite_test.go
+++ b/test/integration/load/load_suite_test.go
@@ -100,5 +100,5 @@ var _ = SynchronizedAfterSuite(func() {
 	}
 }, func() {
 	deferFunc()
-	Eventually(gleak.Goroutines).ShouldNot(gleak.HaveLeaked(goods))
+	Eventually(gleak.Goroutines, flags.EventuallyTimeout).ShouldNot(gleak.HaveLeaked(goods))
 })

--- a/test/integration/other/measure_test.go
+++ b/test/integration/other/measure_test.go
@@ -57,7 +57,7 @@ var _ = g.Describe("Query service_cpm_minute", func() {
 	g.AfterEach(func() {
 		gm.Expect(conn.Close()).To(gm.Succeed())
 		deferFn()
-		gm.Eventually(gleak.Goroutines).ShouldNot(gleak.HaveLeaked(goods))
+		gm.Eventually(gleak.Goroutines, flags.EventuallyTimeout).ShouldNot(gleak.HaveLeaked(goods))
 	})
 	g.It("queries service_cpm_minute by id after updating", func() {
 		casesMeasureData.Write(conn, "service_cpm_minute", "sw_metric", "service_cpm_minute_data1.json", baseTime, interval)

--- a/test/integration/other/property_test.go
+++ b/test/integration/other/property_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Property application", func() {
 	AfterEach(func() {
 		Expect(conn.Close()).To(Succeed())
 		deferFn()
-		Eventually(gleak.Goroutines).ShouldNot(gleak.HaveLeaked(goods))
+		Eventually(gleak.Goroutines, flags.EventuallyTimeout).ShouldNot(gleak.HaveLeaked(goods))
 	})
 	It("applies properties", func() {
 		md := &propertyv1.Metadata{

--- a/test/integration/other/tls_test.go
+++ b/test/integration/other/tls_test.go
@@ -64,7 +64,7 @@ var _ = g.Describe("Query service_cpm_minute", func() {
 	g.AfterEach(func() {
 		gm.Expect(conn.Close()).To(gm.Succeed())
 		deferFn()
-		gm.Eventually(gleak.Goroutines).ShouldNot(gleak.HaveLeaked(goods))
+		gm.Eventually(gleak.Goroutines, flags.EventuallyTimeout).ShouldNot(gleak.HaveLeaked(goods))
 	})
 	g.It("queries a tls server", func() {
 		gm.Eventually(func(innerGm gm.Gomega) {

--- a/test/integration/query/query_suite_test.go
+++ b/test/integration/query/query_suite_test.go
@@ -104,5 +104,5 @@ var _ = SynchronizedAfterSuite(func() {
 	}
 }, func() {
 	deferFunc()
-	Eventually(gleak.Goroutines).ShouldNot(gleak.HaveLeaked(goods))
+	Eventually(gleak.Goroutines, flags.EventuallyTimeout).ShouldNot(gleak.HaveLeaked(goods))
 })


### PR DESCRIPTION
Fixes flaky test cases by defaulting a timeout to `eventually`.