### PR TITLE
Refine load testing issues and optimize performance

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,10 +14,17 @@ Release Notes.
 - Add multiple metrics for measuring the storage subsystem.
 - Refactor callback of TopNAggregation schema event to avoid deadlock and reload issue.
 - Fix max ModRevision computation with inclusion of `TopNAggregation`
+- Enhance meter performance
+- Reduce logger creation frequency
+
+### Bugs
+
+- Fix iterator leaks and ensure proper closure and introduce a closer to guarantee all iterators are closed
 
 ### Chores
 
 - Bump go to 1.20.
+- Set KV's minimum memtable size to 8MB
 
 ## 0.3.1
 

--- a/banyand/Dockerfile
+++ b/banyand/Dockerfile
@@ -39,14 +39,14 @@ FROM base AS builder
 
 RUN --mount=target=. \
             --mount=type=cache,target=/root/.cache/go-build \
-            BUILD_DIR=/out BUILD_TAGS=prometheus make -C banyand all
+            BUILD_DIR=/out BUILD_TAGS=prometheus make -C banyand banyand-server-static
 
 FROM alpine:edge AS certs
 RUN apk add --no-cache ca-certificates && update-ca-certificates
 
 FROM busybox:stable-glibc
 
-COPY --from=builder /out/banyand-server /banyand-server
+COPY --from=builder /out/banyand-server-static /banyand-server
 COPY --from=certs /etc/ssl/certs /etc/ssl/certs
 
 EXPOSE 17912

--- a/banyand/k8s.yml
+++ b/banyand/k8s.yml
@@ -83,10 +83,6 @@ spec:
         - "standalone"
         - "--measure-idx-batch-wait-sec=30"
         - "--logging.level=warn"
-        - "--logging.modules=measure.measure-default.service_cpm_minute"
-        - "--logging.levels=debug"
-        - "--logging.modules=query.measure.measure-default.service_cpm_minute"
-        - "--logging.levels=debug"
         imagePullPolicy: Always
         livenessProbe:
           failureThreshold: 5
@@ -100,8 +96,8 @@ spec:
           timeoutSeconds: 10
         resources:
           limits:
-            memory: "29G"
-            cpu: "7"
+            memory: "8G"
+            cpu: "4"
         ports:
         - containerPort: 17912
         - containerPort: 17913
@@ -129,6 +125,13 @@ spec:
           mountPath: /tmp/measure
         - name:  stream
           mountPath: /tmp/stream
+      nodeSelector:
+        group: banyandb
+      tolerations:
+      - effect: NoSchedule
+        key: group
+        operator: Equal
+        value: banyandb
       volumes:
         - name: metadata
           persistentVolumeClaim:

--- a/banyand/kv/kv.go
+++ b/banyand/kv/kv.go
@@ -40,6 +40,8 @@ var (
 		PrefetchSize:   100,
 		PrefetchValues: true,
 	}
+
+	defaultKVMemorySize = 8 << 20
 )
 
 type writer interface {
@@ -179,8 +181,8 @@ func OpenTimeSeriesStore(path string, options ...TimeSeriesOptions) (TimeSeriesS
 	// Put all values into LSM
 	btss.dbOpts = btss.dbOpts.WithNumVersionsToKeep(math.MaxUint32)
 	btss.dbOpts = btss.dbOpts.WithVLogPercentile(1.0)
-	if btss.dbOpts.MemTableSize < 8<<20 {
-		btss.dbOpts = btss.dbOpts.WithValueThreshold(1 << 10)
+	if btss.dbOpts.MemTableSize < int64(defaultKVMemorySize) {
+		btss.dbOpts.MemTableSize = int64(defaultKVMemorySize)
 	}
 	btss.dbOpts = btss.dbOpts.WithInTable()
 	var err error
@@ -231,9 +233,8 @@ func OpenStore(path string, options ...StoreOptions) (Store, error) {
 	for _, opt := range options {
 		opt(bdb)
 	}
-	bdb.dbOpts = bdb.dbOpts.WithNumVersionsToKeep(math.MaxUint32)
-	if bdb.dbOpts.MemTableSize > 0 && bdb.dbOpts.MemTableSize < 8<<20 {
-		bdb.dbOpts = bdb.dbOpts.WithValueThreshold(1 << 10)
+	if bdb.dbOpts.MemTableSize < int64(defaultKVMemorySize) {
+		bdb.dbOpts.MemTableSize = int64(defaultKVMemorySize)
 	}
 
 	var err error

--- a/banyand/measure/measure_write.go
+++ b/banyand/measure/measure_write.go
@@ -104,8 +104,8 @@ func (s *measure) write(shardID common.ShardID, entity []byte, entityValues tsdb
 			return nil, errWrite
 		}
 		_, errWrite = writer.Write()
-		if e := s.l.Named(s.schema.GetMetadata().GetGroup(), s.schema.GetMetadata().GetName()).Debug(); e.Enabled() {
-			e.Time("ts", t).
+		if s.l.Debug().Enabled() {
+			s.l.Debug().Time("ts", t).
 				Int("ts_nano", t.Nanosecond()).
 				RawJSON("data", logger.Proto(value)).
 				Uint64("series_id", uint64(series.ID())).

--- a/banyand/query/processor.go
+++ b/banyand/query/processor.go
@@ -74,9 +74,8 @@ func (p *streamQueryProcessor) Rev(message bus.Message) (resp bus.Message) {
 		resp = bus.NewMessage(bus.MessageID(now), common.NewError("invalid event data type"))
 		return
 	}
-	sl := p.log.Named("stream", queryCriteria.Metadata.Group, queryCriteria.Metadata.Name)
-	if e := sl.Debug(); e.Enabled() {
-		e.RawJSON("criteria", logger.Proto(queryCriteria)).Msg("received a query request")
+	if p.log.Debug().Enabled() {
+		p.log.Debug().RawJSON("criteria", logger.Proto(queryCriteria)).Msg("received a query request")
 	}
 
 	meta := queryCriteria.GetMetadata()
@@ -98,13 +97,13 @@ func (p *streamQueryProcessor) Rev(message bus.Message) (resp bus.Message) {
 		return
 	}
 
-	if e := sl.Debug(); e.Enabled() {
-		e.Str("plan", plan.String()).Msg("query plan")
+	if p.log.Debug().Enabled() {
+		p.log.Debug().Str("plan", plan.String()).Msg("query plan")
 	}
 
 	entities, err := plan.(executor.StreamExecutable).Execute(ec)
 	if err != nil {
-		sl.Error().Err(err).RawJSON("req", logger.Proto(queryCriteria)).Msg("fail to execute the query plan")
+		p.log.Error().Err(err).RawJSON("req", logger.Proto(queryCriteria)).Msg("fail to execute the query plan")
 		resp = bus.NewMessage(bus.MessageID(now), common.NewError("execute the query plan for stream %s: %v", meta.GetName(), err))
 		return
 	}

--- a/banyand/tsdb/block.go
+++ b/banyand/tsdb/block.go
@@ -167,7 +167,7 @@ func (b *block) options(ctx context.Context) {
 		Logger:       b.l.Named(componentSecondInvertedIdx),
 		BatchWaitSec: options.BlockInvertedIndex.BatchWaitSec,
 	}
-	lsmMemSize := bufferSize / 4
+	lsmMemSize := bufferSize / 2
 	if lsmMemSize < defaultKVMemorySize {
 		lsmMemSize = defaultKVMemorySize
 	}

--- a/banyand/tsdb/buffer.go
+++ b/banyand/tsdb/buffer.go
@@ -233,7 +233,9 @@ func (bsb *bufferShardBucket) start(onFlushFn onFlush) {
 			flushNum.Inc(1, append(bsb.shardLabelValues, "false")...)
 
 			bsb.mutex.Lock()
-			bsb.immutables = bsb.immutables[1:]
+			if len(bsb.immutables) > 0 {
+				bsb.immutables = bsb.immutables[1:]
+			}
 			bsb.mutex.Unlock()
 			oldSkipList.DecrRef()
 		}

--- a/banyand/tsdb/shard.go
+++ b/banyand/tsdb/shard.go
@@ -40,7 +40,7 @@ import (
 const (
 	defaultBlockQueueSize    = 4
 	defaultMaxBlockQueueSize = 64
-	defaultKVMemorySize      = 1 << 20
+	defaultKVMemorySize      = 8 << 20
 )
 
 var (

--- a/pkg/encoding/encoding.go
+++ b/pkg/encoding/encoding.go
@@ -19,27 +19,10 @@
 package encoding
 
 import (
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/apache/skywalking-banyandb/banyand/observability"
 )
 
-var (
-	rawSize = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name:        "banyand_encoding_raw_size",
-		Help:        "The raw size of series",
-		ConstLabels: prometheus.Labels{"model": "encoding"},
-	}, []string{"name", "type"})
-	encodedSize = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name:        "banyand_encoding_encoded_size",
-		Help:        "The encoded size of series",
-		ConstLabels: prometheus.Labels{"model": "encoding"},
-	}, []string{"name", "type"})
-	itemsNum = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name:        "banyand_encoding_items_num",
-		Help:        "The number of items in a encoded series",
-		ConstLabels: prometheus.Labels{"model": "encoding"},
-	}, []string{"name", "type"})
-)
+var encodingScope = observability.RootScope.SubScope("encoding")
 
 // SeriesEncoderPool allows putting and getting SeriesEncoder.
 type SeriesEncoderPool interface {

--- a/pkg/index/lsm/lsm_test.go
+++ b/pkg/index/lsm/lsm_test.go
@@ -33,8 +33,9 @@ func TestStore_MatchTerm(t *testing.T) {
 	tester := assert.New(t)
 	path, fn := setUp(require.New(t))
 	s, err := NewStore(StoreOpts{
-		Path:   path,
-		Logger: logger.GetLogger("test"),
+		Path:         path,
+		Logger:       logger.GetLogger("test"),
+		MemTableSize: 1, // invalid size
 	})
 	defer func() {
 		tester.NoError(s.Close())

--- a/pkg/index/lsm/search.go
+++ b/pkg/index/lsm/search.go
@@ -64,7 +64,10 @@ func (s *store) Range(fieldKey index.FieldKey, opts index.RangeOpts) (list posti
 }
 
 func (s *store) Iterator(fieldKey index.FieldKey, termRange index.RangeOpts, order modelv1.Sort) (index.FieldIterator, error) {
-	return newFieldIteratorTemplate(s.l, fieldKey, termRange, order, s.lsm,
+	if !s.closer.AddRunning() {
+		return nil, errors.New("lsm index store is closed")
+	}
+	return newFieldIteratorTemplate(s.l, fieldKey, termRange, order, s.lsm, s.closer,
 		func(term, value []byte, delegated kv.Iterator) (*index.PostingValue, error) {
 			pv := &index.PostingValue{
 				Term:  term,

--- a/pkg/query/logical/common.go
+++ b/pkg/query/logical/common.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"go.uber.org/multierr"
 
 	modelv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/model/v1"
 	"github.com/apache/skywalking-banyandb/banyand/tsdb"
@@ -135,6 +136,11 @@ func ExecuteForShard(l *logger.Logger, series tsdb.SeriesList, timeRange timesta
 			return iters, nil
 		}()
 		if err != nil {
+			if len(closers) > 0 {
+				for _, closer := range closers {
+					err = multierr.Append(err, closer.Close())
+				}
+			}
 			return nil, nil, err
 		}
 		if len(itersInSeries) > 0 {

--- a/pkg/query/logical/measure/measure_plan_aggregation.go
+++ b/pkg/query/logical/measure/measure_plan_aggregation.go
@@ -228,7 +228,6 @@ func (ami *aggAllIterator[N]) Next() bool {
 	if ami.result != nil || ami.err != nil {
 		return false
 	}
-	defer ami.prev.Close()
 	var resultDp *measurev1.DataPoint
 	for ami.prev.Next() {
 		group := ami.prev.Current()
@@ -275,5 +274,5 @@ func (ami *aggAllIterator[N]) Current() []*measurev1.DataPoint {
 }
 
 func (ami *aggAllIterator[N]) Close() error {
-	return nil
+	return ami.prev.Close()
 }


### PR DESCRIPTION
* Fix iterator leaks and ensure proper closure
* Introduce a closer to guarantee all iterators are closed
* Set KV's minimum memtable size to 8MB
* Enhance meter performance
* Reduce logger creation frequency

- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-banyandb/blob/main/CHANGES.md).
