### PR TITLE
modified TestGoVersion to check Go CPU architectue

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,7 @@ Release Notes.
 - Bump go to 1.20.
 - Set KV's minimum memtable size to 8MB
 - [docs] Fix docs crud examples error
+- Modified `TestGoVersion` to check for CPU architecture and Go Version
 
 ## 0.3.1
 

--- a/scripts/ci/check/version_test.go
+++ b/scripts/ci/check/version_test.go
@@ -38,7 +38,7 @@ const (
 func TestGoVersion(t *testing.T) {
 	// the value of ptr will be 8 for 64 bit system and 4 for 32 bit system
 	ptr := 4 << (^uintptr(0) >> 63)
-	require.Equal(t, CPUType, ptr, "This CPU architectue is not supported, should be 64 bits Go version")
+	require.Equal(t, CPUType, ptr, "This CPU architectue is not supported, it should be a 64 bits Go version")
 
 	currentVersion := runtime.Version()
 	versionRegex := regexp.MustCompile(`go(\d+\.\d+\.\d)`)

--- a/scripts/ci/check/version_test.go
+++ b/scripts/ci/check/version_test.go
@@ -32,14 +32,13 @@ import (
 
 const (
 	GoVersion = "1.20"
-	CPUType   = "64"
+	CPUType   = 8
 )
 
 func TestGoVersion(t *testing.T) {
-	types := runtime.GOARCH
-
-	ok := strings.Contains(types, CPUType)
-	require.True(t, ok, "CPU type not supported, current[%s], want[%s bit Go release]", types, CPUType)
+	// the value of ptr will be 8 for 64 bit system and 4 for 32 bit system
+	ptr := 4 << (^uintptr(0) >> 63)
+	require.Equal(t, CPUType, ptr, "This CPU architectue is not supported, should be 64 bits Go version")
 
 	currentVersion := runtime.Version()
 	versionRegex := regexp.MustCompile(`go(\d+\.\d+\.\d)`)

--- a/scripts/ci/check/version_test.go
+++ b/scripts/ci/check/version_test.go
@@ -28,13 +28,23 @@ import (
 	"golang.org/x/mod/modfile"
 )
 
-const GoVersion = "1.20"
+const (
+	GoVersion = "1.20"
+	CpuType   = "64"
+)
 
 func TestGoVersion(t *testing.T) {
 	goversion, err := exec.Command("go", "version").Output()
 	require.NoError(t, err)
 
-	currentVersion := strings.Split(string(goversion), " ")[2][2:]
+	splited_output := strings.Split(string(goversion), " ")
+
+	types := splited_output[3][1:]
+	
+	ok := strings.Contains(types, CpuType)
+	require.True(t, ok, "CPU type not supported, current[%s], want[%s bit Go release]", types, CpuType)
+
+	currentVersion := splited_output[2][2:]
 
 	currentMajorMinor, currentPatch := splitVersion(currentVersion)
 	expectedMajorMinor, expectedPatch := splitVersion(GoVersion)

--- a/scripts/ci/check/version_test.go
+++ b/scripts/ci/check/version_test.go
@@ -37,7 +37,7 @@ const (
 
 func TestGoVersion(t *testing.T) {
 	types := runtime.GOARCH
-	
+
 	ok := strings.Contains(types, CPUType)
 	require.True(t, ok, "CPU type not supported, current[%s], want[%s bit Go release]", types, CPUType)
 

--- a/scripts/ci/check/version_test.go
+++ b/scripts/ci/check/version_test.go
@@ -32,14 +32,14 @@ import (
 
 const (
 	GoVersion = "1.20"
-	CpuType   = "64"
+	CPUType   = "64"
 )
 
 func TestGoVersion(t *testing.T) {
 	types := runtime.GOARCH
 	
-	ok := strings.Contains(types, CpuType)
-	require.True(t, ok, "CPU type not supported, current[%s], want[%s bit Go release]", types, CpuType)
+	ok := strings.Contains(types, CPUType)
+	require.True(t, ok, "CPU type not supported, current[%s], want[%s bit Go release]", types, CPUType)
 
 	currentVersion := runtime.Version()
 	versionRegex := regexp.MustCompile(`go(\d+\.\d+\.\d)`)

--- a/scripts/ci/check/version_test.go
+++ b/scripts/ci/check/version_test.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"regexp"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -34,19 +36,20 @@ const (
 )
 
 func TestGoVersion(t *testing.T) {
-	goversion, err := exec.Command("go", "version").Output()
-	require.NoError(t, err)
-
-	splited_output := strings.Split(string(goversion), " ")
-
-	types := splited_output[3][1:]
+	types := runtime.GOARCH
 	
 	ok := strings.Contains(types, CpuType)
 	require.True(t, ok, "CPU type not supported, current[%s], want[%s bit Go release]", types, CpuType)
 
-	currentVersion := splited_output[2][2:]
+	currentVersion := runtime.Version()
+	versionRegex := regexp.MustCompile(`go(\d+\.\d+\.\d)`)
+	matches := versionRegex.FindStringSubmatch(currentVersion)
 
-	currentMajorMinor, currentPatch := splitVersion(currentVersion)
+	require.GreaterOrEqual(t, len(matches), 2)
+
+	versionNumber := matches[1]
+
+	currentMajorMinor, currentPatch := splitVersion(versionNumber)
 	expectedMajorMinor, expectedPatch := splitVersion(GoVersion)
 
 	require.Equal(t, currentMajorMinor, expectedMajorMinor,


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->


### Fix <Added a check for Go CPU architecture in [TestGoVersion](https://github.com/apache/skywalking-banyandb/blob/main/scripts/ci/check/version_test.go)>
- [ ] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.
	According to the documentation, it is advisable to run `make check-req` before building BanyanDB from the source. It checks if the device has the necessary software version or not. I recently faced an issue where I had Go 1.20 Linux-386 where `make check-req` passed perfectly but the build failed with this error.

![error](https://github.com/apache/skywalking-banyandb/assets/67036708/66f971eb-d624-4ebc-9010-a02117a21e31)
 
To resolve this, I had a check which parses through the output string of `go version` and checks if it has 64 in it or not.

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->


