### PR TITLE
Add system information endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
             ${{ runner.os }}-check-tool-
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.15
+          node-version: 18.16
           cache: 'npm'
           cache-dependency-path: ui/package-lock.json
       - name: Install Go
@@ -98,7 +98,7 @@ jobs:
             ${{ runner.os }}-build-tool-
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.15
+          node-version: 18.16
           cache: 'npm'
           cache-dependency-path: ui/package-lock.json
       - name: Install Go

--- a/.github/workflows/e2e.storage.yml
+++ b/.github/workflows/e2e.storage.yml
@@ -72,7 +72,7 @@ jobs:
             ${{ runner.os }}-build-tool-
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.15
+          node-version: 18.16
           cache: 'npm'
           cache-dependency-path: ui/package-lock.json
       - name: Install Go

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -61,7 +61,7 @@ jobs:
             ${{ runner.os }}-build-tool-
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.15
+          node-version: 18.16
           cache: 'npm'
           cache-dependency-path: ui/package-lock.json
       - name: Install Go

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
             ${{ runner.os }}-test-tool-
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.15
+          node-version: 18.16
           cache: 'npm'
           cache-dependency-path: ui/package-lock.json
       - name: Install Go

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,7 +17,8 @@ Release Notes.
 - Enhance meter performance
 - Reduce logger creation frequency
 - Add units to memory flags
-- Introduce TSTable to customize the block's structure 
+- Introduce TSTable to customize the block's structure
+- Add `/system` endpoint to the monitoring server that displays a list of nodes' system information.
 
 ### Bugs
 
@@ -30,6 +31,7 @@ Release Notes.
 - Set KV's minimum memtable size to 8MB
 - [docs] Fix docs crud examples error
 - Modified `TestGoVersion` to check for CPU architecture and Go Version
+- Bump node to 18.16
 
 ## 0.3.1
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ Once we've discussed your changes and you've got your code ready, make sure that
 Users who want to build a binary from sources have to set up:
 
 * Go 1.20
-* Node 16.15
+* Node 18.16
 * Git >= 2.30
 * Linux, macOS or Windows+WSL2
 * GNU make

--- a/banyand/liaison/grpc/server.go
+++ b/banyand/liaison/grpc/server.go
@@ -168,6 +168,7 @@ func (s *server) Validate() error {
 	if s.addr == "" {
 		return errNoAddr
 	}
+	observability.UpdateAddress("grpc", s.addr)
 	if !s.tls {
 		return nil
 	}

--- a/banyand/liaison/http/server.go
+++ b/banyand/liaison/http/server.go
@@ -38,6 +38,7 @@ import (
 	measurev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/measure/v1"
 	propertyv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/property/v1"
 	streamv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/stream/v1"
+	"github.com/apache/skywalking-banyandb/banyand/observability"
 	"github.com/apache/skywalking-banyandb/pkg/logger"
 	"github.com/apache/skywalking-banyandb/pkg/run"
 	"github.com/apache/skywalking-banyandb/ui"
@@ -89,6 +90,7 @@ func (p *service) Validate() error {
 	if p.listenAddr == "" {
 		return errNoAddr
 	}
+	observability.UpdateAddress("http", p.listenAddr)
 	if p.grpcCert != "" {
 		creds, errTLS := credentials.NewClientTLSFromFile(p.grpcCert, "")
 		if errTLS != nil {

--- a/banyand/measure/service.go
+++ b/banyand/measure/service.go
@@ -31,6 +31,7 @@ import (
 	"github.com/apache/skywalking-banyandb/banyand/discovery"
 	"github.com/apache/skywalking-banyandb/banyand/metadata"
 	"github.com/apache/skywalking-banyandb/banyand/metadata/schema"
+	"github.com/apache/skywalking-banyandb/banyand/observability"
 	"github.com/apache/skywalking-banyandb/banyand/queue"
 	"github.com/apache/skywalking-banyandb/banyand/tsdb"
 	"github.com/apache/skywalking-banyandb/pkg/bus"
@@ -113,7 +114,9 @@ func (s *service) PreRun() error {
 	if err != nil {
 		return err
 	}
-	s.schemaRepo = newSchemaRepo(path.Join(s.root, s.Name()), s.metadata, s.repo, s.dbOpts,
+	path := path.Join(s.root, s.Name())
+	observability.UpdatePath(path)
+	s.schemaRepo = newSchemaRepo(path, s.metadata, s.repo, s.dbOpts,
 		s.l, s.pipeline, int64(s.BlockEncoderBufferSize), int64(s.BlockBufferSize))
 	for _, g := range groups {
 		if g.Catalog != commonv1.Catalog_CATALOG_MEASURE {

--- a/banyand/metadata/schema/etcd.go
+++ b/banyand/metadata/schema/etcd.go
@@ -35,6 +35,7 @@ import (
 	commonv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/common/v1"
 	databasev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
 	propertyv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/property/v1"
+	"github.com/apache/skywalking-banyandb/banyand/observability"
 	"github.com/apache/skywalking-banyandb/pkg/logger"
 	"github.com/apache/skywalking-banyandb/pkg/run"
 )
@@ -401,6 +402,7 @@ func newStandaloneEtcdConfig(config *etcdSchemaRegistryConfig, logger *zap.Logge
 	cfg := embed.NewConfig()
 	cfg.ZapLoggerBuilder = embed.NewZapLoggerBuilder(logger)
 	cfg.Dir = filepath.Join(config.rootDir, "metadata")
+	observability.UpdatePath(cfg.Dir)
 	cURL, _ := url.Parse(config.listenerClientURL)
 	pURL, _ := url.Parse(config.listenerPeerURL)
 

--- a/banyand/observability/meter_noop.go
+++ b/banyand/observability/meter_noop.go
@@ -24,14 +24,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/apache/skywalking-banyandb/pkg/meter"
-	"github.com/apache/skywalking-banyandb/pkg/run"
 )
-
-// NewMetricService returns a metric service.
-func NewMetricService() run.Service {
-	MetricsCollector.collect()
-	return nil
-}
 
 // NewMeterProvider returns a meter.Provider based on the given scope.
 func NewMeterProvider(_ meter.Scope) meter.Provider {

--- a/banyand/observability/meter_prom.go
+++ b/banyand/observability/meter_prom.go
@@ -21,102 +21,24 @@
 package observability
 
 import (
-	"context"
-	"net/http"
-	"time"
-
 	grpcprom "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/robfig/cron/v3"
 
-	"github.com/apache/skywalking-banyandb/pkg/logger"
 	"github.com/apache/skywalking-banyandb/pkg/meter"
 	"github.com/apache/skywalking-banyandb/pkg/meter/prom"
-	"github.com/apache/skywalking-banyandb/pkg/run"
-	"github.com/apache/skywalking-banyandb/pkg/timestamp"
 	"google.golang.org/grpc"
 )
 
-var (
-	_ run.Service = (*metricService)(nil)
-	_ run.Config  = (*metricService)(nil)
+var reg = prometheus.NewRegistry()
 
-	reg = prometheus.NewRegistry()
-)
-
-// NewMetricService returns a metric service.
-func NewMetricService() run.Service {
-	return &metricService{
-		closer: run.NewCloser(1),
-	}
-}
-
-type metricService struct {
-	l          *logger.Logger
-	svr        *http.Server
-	closer     *run.Closer
-	listenAddr string
-	scheduler  *timestamp.Scheduler
-}
-
-func (p *metricService) FlagSet() *run.FlagSet {
-	flagSet := run.NewFlagSet("observability")
-	flagSet.StringVar(&p.listenAddr, "observability-listener-addr", ":2121", "listen addr for observability")
-	return flagSet
-}
-
-func (p *metricService) Validate() error {
-	if p.listenAddr == "" {
-		return errNoAddr
-	}
-	return nil
-}
-
-func (p *metricService) Name() string {
-	return "metric-service"
-}
-
-func (p *metricService) Serve() run.StopNotify {
-	p.l = logger.GetLogger(p.Name())
-
+func init() {
 	reg.MustRegister(prometheus.NewGoCollector())
 	reg.MustRegister(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}))
-
-	clock, _ := timestamp.GetClock(context.TODO())
-	p.scheduler = timestamp.NewScheduler(p.l, clock)
-	p.scheduler.Register("metrics-collector", cron.Descriptor, "@every 15s", func(now time.Time, logger *logger.Logger) bool {
-		MetricsCollector.collect()
-		return true
-	})
-
-	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.HandlerFor(
 		reg,
 		promhttp.HandlerOpts{},
 	))
-	p.svr = &http.Server{
-		Addr:              p.listenAddr,
-		ReadHeaderTimeout: 3 * time.Second,
-		Handler:           mux,
-	}
-
-	go func() {
-		defer p.closer.Done()
-		p.l.Info().Str("listenAddr", p.listenAddr).Msg("Start metric server")
-		_ = p.svr.ListenAndServe()
-	}()
-	return p.closer.CloseNotify()
-}
-
-func (p *metricService) GracefulStop() {
-	if p.scheduler != nil {
-		p.scheduler.Close()
-	}
-	if p.svr != nil {
-		_ = p.svr.Close()
-	}
-	p.closer.CloseThenWait()
 }
 
 // NewMeterProvider returns a meter.Provider based on the given scope.

--- a/banyand/observability/service.go
+++ b/banyand/observability/service.go
@@ -1,0 +1,103 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package observability
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/robfig/cron/v3"
+
+	"github.com/apache/skywalking-banyandb/pkg/logger"
+	"github.com/apache/skywalking-banyandb/pkg/run"
+	"github.com/apache/skywalking-banyandb/pkg/timestamp"
+)
+
+var (
+	_   run.Service = (*metricService)(nil)
+	_   run.Config  = (*metricService)(nil)
+	mux             = http.NewServeMux()
+)
+
+// NewMetricService returns a metric service.
+func NewMetricService() run.Service {
+	return &metricService{
+		closer: run.NewCloser(1),
+	}
+}
+
+type metricService struct {
+	l          *logger.Logger
+	svr        *http.Server
+	closer     *run.Closer
+	scheduler  *timestamp.Scheduler
+	listenAddr string
+}
+
+func (p *metricService) FlagSet() *run.FlagSet {
+	flagSet := run.NewFlagSet("observability")
+	flagSet.StringVar(&p.listenAddr, "observability-listener-addr", ":2121", "listen addr for observability")
+	return flagSet
+}
+
+func (p *metricService) Validate() error {
+	if p.listenAddr == "" {
+		return errNoAddr
+	}
+	return nil
+}
+
+func (p *metricService) Name() string {
+	return "metric-service"
+}
+
+func (p *metricService) Serve() run.StopNotify {
+	p.l = logger.GetLogger(p.Name())
+
+	clock, _ := timestamp.GetClock(context.TODO())
+	p.scheduler = timestamp.NewScheduler(p.l, clock)
+	err := p.scheduler.Register("metrics-collector", cron.Descriptor, "@every 15s", func(now time.Time, logger *logger.Logger) bool {
+		MetricsCollector.collect()
+		return true
+	})
+	if err != nil {
+		p.l.Fatal().Err(err).Msg("Failed to register metrics collector")
+	}
+	p.svr = &http.Server{
+		Addr:              p.listenAddr,
+		ReadHeaderTimeout: 3 * time.Second,
+		Handler:           mux,
+	}
+	go func() {
+		defer p.closer.Done()
+		p.l.Info().Str("listenAddr", p.listenAddr).Msg("Start metric server")
+		_ = p.svr.ListenAndServe()
+	}()
+	return p.closer.CloseNotify()
+}
+
+func (p *metricService) GracefulStop() {
+	if p.scheduler != nil {
+		p.scheduler.Close()
+	}
+	if p.svr != nil {
+		_ = p.svr.Close()
+	}
+	p.closer.CloseThenWait()
+}

--- a/banyand/observability/system.go
+++ b/banyand/observability/system.go
@@ -1,0 +1,162 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package observability
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"sync"
+
+	"github.com/shirou/gopsutil/v3/cpu"
+	"github.com/shirou/gopsutil/v3/disk"
+	"github.com/shirou/gopsutil/v3/host"
+	"github.com/shirou/gopsutil/v3/mem"
+
+	"github.com/apache/skywalking-banyandb/pkg/logger"
+)
+
+var systemInfoInstance *SystemInfo
+
+func init() {
+	systemInfoInstance = &SystemInfo{
+		Addresses:  make(map[string]string),
+		DiskUsages: make(map[string]*DiskUsage),
+	}
+}
+
+// UpdateAddress updates the address of the given name.
+func UpdateAddress(name, address string) {
+	systemInfoInstance.Lock()
+	defer systemInfoInstance.Unlock()
+	systemInfoInstance.Addresses[name] = address
+}
+
+func getAddresses() map[string]string {
+	systemInfoInstance.RLock()
+	defer systemInfoInstance.RUnlock()
+	return systemInfoInstance.Addresses
+}
+
+// UpdatePath updates a path to monitoring its disk usage.
+func UpdatePath(path string) {
+	systemInfoInstance.Lock()
+	defer systemInfoInstance.Unlock()
+	systemInfoInstance.DiskUsages[path] = nil
+}
+
+func getPath() map[string]*DiskUsage {
+	systemInfoInstance.RLock()
+	defer systemInfoInstance.RUnlock()
+	return systemInfoInstance.DiskUsages
+}
+
+// SystemInfo represents the system information of a node.
+type SystemInfo struct {
+	Addresses   map[string]string     `json:"addresses"`
+	DiskUsages  map[string]*DiskUsage `json:"disk_usages"`
+	NodeID      string                `json:"node_id"`
+	Hostname    string                `json:"hostname"`
+	Roles       []string              `json:"roles"`
+	Uptime      uint64                `json:"uptime"`
+	CPUUsage    float64               `json:"cpu_usage"`
+	MemoryUsage float64               `json:"memory_usage"`
+	sync.RWMutex
+}
+
+// DiskUsage represents the disk usage for a given path.
+type DiskUsage struct {
+	Capacity uint64 `json:"capacity"`
+	Used     uint64 `json:"used"`
+}
+
+// ErrorResponse represents the error response.
+type ErrorResponse struct {
+	Message       string `json:"message"`
+	OriginalError string `json:"original_error,omitempty"`
+}
+
+func init() {
+	mux.HandleFunc("/system", systemInfoHandler)
+}
+
+func systemInfoHandler(w http.ResponseWriter, _ *http.Request) {
+	hostname, _ := os.Hostname()
+	uptime, _ := getUptime()
+	cpuUsage, _ := getCPUUsage()
+	memoryUsage, _ := getMemoryUsage()
+
+	systemInfo := &SystemInfo{
+		NodeID:      "1",
+		Roles:       []string{"meta", "ingest", "query", "data"},
+		Hostname:    hostname,
+		Uptime:      uptime,
+		CPUUsage:    cpuUsage,
+		MemoryUsage: memoryUsage,
+		Addresses:   getAddresses(),
+		DiskUsages:  make(map[string]*DiskUsage),
+	}
+	for k := range getPath() {
+		usage, _ := getDiskUsage(k)
+		systemInfo.DiskUsages[k] = &usage
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode([]*SystemInfo{systemInfo}); err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		errorResponse := &ErrorResponse{
+			Message:       "Error encoding JSON response",
+			OriginalError: err.Error(),
+		}
+		if err := json.NewEncoder(w).Encode(errorResponse); err != nil {
+			logger.GetLogger().Error().Err(err).Msg("Error encoding JSON response")
+		}
+	}
+}
+
+func getUptime() (uint64, error) {
+	uptime, err := host.Uptime()
+	if err != nil {
+		return 0, err
+	}
+	return uptime, nil
+}
+
+func getCPUUsage() (float64, error) {
+	percentages, err := cpu.Percent(0, false)
+	if err != nil {
+		return 0, err
+	}
+	return percentages[0], nil
+}
+
+func getMemoryUsage() (float64, error) {
+	vm, err := mem.VirtualMemory()
+	if err != nil {
+		return 0, err
+	}
+	return vm.UsedPercent, nil
+}
+
+func getDiskUsage(path string) (DiskUsage, error) {
+	usage, err := disk.Usage(path)
+	if err != nil {
+		return DiskUsage{}, err
+	}
+	return DiskUsage{Capacity: usage.Total, Used: usage.Used}, nil
+}

--- a/banyand/stream/service.go
+++ b/banyand/stream/service.go
@@ -29,6 +29,7 @@ import (
 	"github.com/apache/skywalking-banyandb/banyand/discovery"
 	"github.com/apache/skywalking-banyandb/banyand/metadata"
 	"github.com/apache/skywalking-banyandb/banyand/metadata/schema"
+	"github.com/apache/skywalking-banyandb/banyand/observability"
 	"github.com/apache/skywalking-banyandb/banyand/queue"
 	"github.com/apache/skywalking-banyandb/banyand/tsdb"
 	"github.com/apache/skywalking-banyandb/pkg/logger"
@@ -103,7 +104,9 @@ func (s *service) PreRun() error {
 	if err != nil {
 		return err
 	}
-	s.schemaRepo = newSchemaRepo(path.Join(s.root, s.Name()), s.metadata, s.repo, int64(s.blockBufferSize), s.dbOpts, s.l)
+	path := path.Join(s.root, s.Name())
+	observability.UpdatePath(path)
+	s.schemaRepo = newSchemaRepo(path, s.metadata, s.repo, int64(s.blockBufferSize), s.dbOpts, s.l)
 	for _, g := range groups {
 		if g.Catalog != commonv1.Catalog_CATALOG_STREAM {
 			continue

--- a/dist/LICENSE
+++ b/dist/LICENSE
@@ -178,7 +178,7 @@
 Apache-2.0 licenses
 ========================================================================
 
-    github.com/SkyAPM/badger/v3 v3.0.0-20230329010346-dfdf57f0581b Apache-2.0
+    github.com/SkyAPM/badger/v3 v3.0.0-20230511223516-583c6a825854 Apache-2.0
     github.com/blevesearch/segment v0.9.0 Apache-2.0
     github.com/blevesearch/vellum v1.0.7 Apache-2.0
     github.com/coreos/go-semver v0.3.0 Apache-2.0
@@ -398,7 +398,7 @@ ISC licenses
     glob-parent 5.1.2 ISC
     graceful-fs 4.2.10 ISC
     picocolors 1.0.0 ISC
-    yaml 2.2.1 ISC
+    yaml 2.2.2 ISC
 
 ========================================================================
 MIT licenses

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -16,7 +16,7 @@ Get binaries from the [download](https://skywalking.apache.org/downloads/).
 Users who want to build a binary from sources have to set up:
 
 * Go 1.20
-* Node 16.15
+* Node 18.16
 * Git >= 2.30
 * Linux, macOS or Windows+WSL2
 * GNU make

--- a/ui/LICENSE
+++ b/ui/LICENSE
@@ -35,7 +35,7 @@ ISC licenses
     glob-parent 5.1.2 ISC
     graceful-fs 4.2.10 ISC
     picocolors 1.0.0 ISC
-    yaml 2.2.1 ISC
+    yaml 2.2.2 ISC
 
 ========================================================================
 MIT licenses

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -29,7 +29,7 @@
         "vite": "^3.0.9"
       },
       "engines": {
-        "node": "16.15"
+        "node": "18.16"
       }
     },
     "node_modules/@antfu/utils": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -2,7 +2,7 @@
   "name": "ui",
   "version": "0.1.0",
   "engines": {
-    "node": "16.15"
+    "node": "18.16"
   },
   "scripts": {
     "dev": "vite",

--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -49,6 +49,11 @@ export default defineConfig({
         target: "http://localhost:17913",
         changeOrigin: true,
       },
+      "^/monitoring": {
+        target: "http://localhost:2121",
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/monitoring/, ''),
+      },
     },
   }
 })


### PR DESCRIPTION

### <Feature description>

Add `/system` endpoint to the monitoring server that displays a list of nodes' system information.

This endpoint will provide info for rendering on "Overview" page which will be introduced by  https://github.com/apache/skywalking/issues/10634

To access the system monitoring feature, the UI pages can use the `/monitoring/system` path.

- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-banyandb/blob/main/CHANGES.md).
