### PR TITLE
Fix parse environment variables error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Release Notes.
 - Support for recovery buffer using wal.
 - Register the node role to the metadata registry.
 - Implement the remote queue to spreading data to data nodes.
+- Fix parse environment variables error
 
 ### Bugs
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -88,8 +88,8 @@ func bindFlags(fs *pflag.FlagSet, v *viper.Viper) error {
 	fs.VisitAll(func(f *pflag.Flag) {
 		// Environment variables can't have dashes in them, so bind them to their equivalent
 		// keys with underscores.
-		if strings.Contains(f.Name, ".") {
-			envVarSuffix := strings.ToUpper(strings.ReplaceAll(f.Name, ".", "_"))
+		if strings.Contains(f.Name, "-") {
+			envVarSuffix := strings.ToUpper(strings.ReplaceAll(f.Name, "-", "_"))
 			err = multierr.Append(err, v.BindEnv(f.Name, fmt.Sprintf("%s_%s", envPrefix, envVarSuffix)))
 		}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,64 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package config
+
+import (
+	"os"
+	"testing"
+
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadConfig(t *testing.T) {
+	tester := assert.New(t)
+	fs := pflag.NewFlagSet("test", pflag.ExitOnError)
+	tests := []struct {
+		flagName        string
+		flagDescription string
+		envName         string
+		envValue        string
+	}{
+		{
+			flagName:        "cert-file",
+			flagDescription: "path to cert file",
+			envName:         "BYDB_CERT_FILE",
+			envValue:        "foo",
+		},
+		{
+			flagName:        "key-file",
+			flagDescription: "path to key file",
+			envName:         "BYDB_KEY_FILE",
+			envValue:        "bar",
+		},
+	}
+	for _, tt := range tests {
+		name := "bind flag: " + tt.flagName
+		t.Run(name, func(t *testing.T) {
+			var flagValue string
+			fs.StringVar(&flagValue, tt.flagName, "", tt.flagDescription)
+			os.Setenv(tt.envName, tt.envValue)
+			err := Load("cfg", fs)
+			tester.NoError(err, name)
+			tester.NotNil(flagValue, name)
+			tester.Equal(flagValue, tt.envValue, name)
+			tester.NotNil(fs.Lookup(tt.flagName).Value.String(), name)
+			tester.Equal(fs.Lookup(tt.flagName).Value.String(), tt.envValue, name)
+		})
+	}
+}


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

### Fix parse environment variables error
The flags passed through the command line are connected by hyphens instead of dots.
- [x] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Fixes apache/skywalking#<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-banyandb/blob/main/CHANGES.md).
