### PR TITLE
Fix testcase unstable state when tsdb/buffer is not closed

### DIFF
--- a/banyand/tsdb/buffer_test.go
+++ b/banyand/tsdb/buffer_test.go
@@ -199,7 +199,6 @@ var _ = Describe("Buffer", func() {
 				true,
 				&path)
 			Expect(err).ToNot(HaveOccurred())
-			defer buffer.Close()
 
 			// Write buffer & wal
 			var wg sync.WaitGroup
@@ -218,9 +217,7 @@ var _ = Describe("Buffer", func() {
 				}(i)
 			}
 			wg.Wait()
-
-			flushMutex.Lock()
-			defer flushMutex.Unlock()
+			buffer.Close()
 
 			// Check wal
 			Expect(len(shardWalFileHistory) == numShards).To(BeTrue())


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

### Fix <bug description or the bug issue number or bug issue link>
- [x] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.

Fix tsdb/buffer testcase unstable state when tsdb/buffer is not closed

exception
https://github.com/apache/skywalking-banyandb/actions/runs/6456218886/job/17525259457
<img width="941" alt="image" src="https://github.com/apache/skywalking-banyandb/assets/14371345/d369e141-7538-404e-a5a2-e44def23a482">


<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Fixes apache/skywalking#<issue number>.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking-banyandb/blob/main/CHANGES.md).
