### PR TITLE
Fix 11273 remove exception log is output in console

### DIFF
--- a/ui/src/components/Read/index.vue
+++ b/ui/src/components/Read/index.vue
@@ -191,7 +191,8 @@ watch(() => data.code, () => {
         data.codeStorage[index].params.code = data.code
     } else {
         route.params.code = data.code
-        data.codeStorage.push(JSON.parse(JSON.stringify(route)))
+        const clonedObject = clonedObject(route)
+        data.codeStorage.push(clonedObject)
     }
 })
 function initCode() {
@@ -216,6 +217,28 @@ orderBy:
   sort: SORT_UNSPECIFIED
 `)
     }
+}
+function cloneObject(obj){
+    if (obj === null || typeof obj !== 'object') {
+        return obj;
+    }
+
+    if (Array.isArray(obj)) {
+        const arrCopy = [];
+        for (let i = 0; i < obj.length; i++) {
+        arrCopy[i] = cloneObject(obj[i]);
+        }
+        return arrCopy;
+    }
+
+    const objCopy = {};
+    for (const key in obj) {
+        if (obj.hasOwnProperty !== undefined && obj.hasOwnProperty(key)) {
+            objCopy[key] = cloneObject(obj[key]);
+        }
+    }
+
+    return objCopy;
 }
 function changeCode(name, value) {
     let code = yamlToJson(data.code).data


### PR DESCRIPTION

### Fix [banyandb web-ui console error logs](https://github.com/apache/skywalking/issues/11273)
Experiencing exception logs in the console of the banyandb dashboard when we switch between two read tabs. 

- [ ] Add a unit test to verify that the fix works.

- [X] Explain briefly why the bug exists and how to fix it.
The issue was caused due to the use of `JSON.parse(JSON.stringify())` to clone the route object. This method of cloning objects cannot handle circular references, leading to an exception in the console.

- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [X] If it's UI related, attach the screenshots below.

https://github.com/apache/skywalking-banyandb/assets/53624363/b62bba6e-2678-4e8a-9b3e-4436cd0f5649

- [X] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Fixes apache/skywalking#11273.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking-banyandb/blob/main/CHANGES.md).
