### PR TITLE
[UI] Fix default port in vite.config.js 

### DIFF
--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -49,11 +49,11 @@ export default ({ mode }) => {
     server: {
       proxy: {
         "^/api": {
-          target: `${VITE_API_PROXY_TARGET || "http://127.0.0.1:12800"}`,
+          target: `${VITE_API_PROXY_TARGET || "http://127.0.0.1:17913"}`,
           changeOrigin: true,
         },
         "^/monitoring": {
-          target: `${VITE_MONITOR_PROXY_TARGET || "http://127.0.0.1:12800"}`,
+          target: `${VITE_MONITOR_PROXY_TARGET || "http://127.0.0.1:2121"}`,
           changeOrigin: true,
           rewrite: (path) => path.replace(/^\/monitoring/, ''),
         },


### PR DESCRIPTION
### Fix default port in vite.config.js  
- [ ] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.
- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Fixes apache/skywalking#<issue number>.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking-banyandb/blob/main/CHANGES.md).

### Description
Change the default port to 17913 and 2121 to fix UI development process. 