### PR TITLE
Feature to view and download value of property from UI

### DIFF
--- a/ui/src/components/Property/PropertyRead.vue
+++ b/ui/src/components/Property/PropertyRead.vue
@@ -25,6 +25,7 @@ import { ElMessage } from 'element-plus';
 import { onMounted, reactive, ref } from 'vue';
 import { RefreshRight } from '@element-plus/icons-vue';
 import PropertyEditror from './PropertyEditror.vue';
+import PropertyValueReader from './PropertyValueReader.vue';
 
 const { proxy } = getCurrentInstance()
 // Loading
@@ -33,6 +34,7 @@ const $bus = getCurrentInstance().appContext.config.globalProperties.mittBus
 const $loadingCreate = getCurrentInstance().appContext.config.globalProperties.$loadingCreate
 const $loadingClose = proxy.$loadingClose
 const propertyEditorRef = ref()
+const propertyValueViewerRef = ref()
 const data = reactive({
     group: "",
     tableData: []
@@ -61,6 +63,13 @@ const getProperty = () => {
         .finally(() => {
             $loadingClose()
         })
+}
+const openPropertyView = (data) => {
+    propertyValueViewerRef?.value.openDialog(data)
+}
+
+const ellipsizeValueData = (data) => {
+    return data.value.slice(0, 20)+"..."
 }
 const openEditField = (index) => {
     const item = data.tableData[index]
@@ -156,7 +165,13 @@ onMounted(() => {
                     <template #default="scope">
                         <el-table :data="scope.row.tags">
                             <el-table-column label="Key" prop="key" width="150"></el-table-column>
-                            <el-table-column label="Value" prop="value"></el-table-column>
+                            <el-table-column label="Value" prop="value">
+                                <template #default="scope">
+                                    {{ellipsizeValueData(scope.row)}}
+                                    <el-button link type="primary" @click.prevent="openPropertyView(scope.row)"
+                                style="color: var(--color-main); font-weight: bold;">view</el-button>
+                                </template>
+                          </el-table-column>
                         </el-table>
                     </template>
                 </el-table-column>
@@ -174,6 +189,7 @@ onMounted(() => {
             </el-table>
         </el-card>
         <PropertyEditror ref="propertyEditorRef"></PropertyEditror>
+        <PropertyValueReader ref="propertyValueViewerRef"></PropertyValueReader>
     </div>
 </template>
 <style lang="scss" scoped>

--- a/ui/src/components/Property/PropertyValueReader.vue
+++ b/ui/src/components/Property/PropertyValueReader.vue
@@ -1,0 +1,87 @@
+<!--
+  ~ Licensed to Apache Software Foundation (ASF) under one or more contributor
+  ~ license agreements. See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright
+  ~ ownership. Apache Software Foundation (ASF) licenses this file to you under
+  ~ the Apache License, Version 2.0 (the "License"); you may
+  ~ not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+-->
+
+<script setup>
+import { applyProperty } from '@/api';
+import { reactive, ref } from 'vue';
+import { getCurrentInstance } from '@vue/runtime-core'
+import TagEditor from './TagEditor.vue';
+import { ElMessage } from 'element-plus';
+const $loadingCreate = getCurrentInstance().appContext.config.globalProperties.$loadingCreate
+const $loadingClose = getCurrentInstance().appContext.config.globalProperties.$loadingClose
+const showDialog = ref(false)
+const title = ref('')
+const valueData = reactive({
+    data: '',
+    formattedData: ''
+})
+
+const numSpaces = 2
+const initData = () => {
+    valueData.data = temp
+}
+const closeDialog = () => {
+    showDialog.value = false
+    initData()
+}
+
+const downloadValue = () => {
+    const dataBlob = new Blob([valueData.formattedData], { type: 'text/JSON' })
+    var a = document.createElement('a');
+
+    a.download = 'value.txt';
+    a.href = URL.createObjectURL(dataBlob);
+    document.body.appendChild(a);
+
+    a.click();
+    document.body.removeChild(a);
+}
+
+const openDialog = (data) => {
+    title.value = "Value of key " + data.key
+    showDialog.value = true
+    valueData.data = data.value
+    valueData.formattedData = JSON.stringify(JSON.parse(valueData.data), null, numSpaces)
+}
+defineExpose({
+    openDialog
+})
+</script>
+
+<template>
+    <el-dialog v-model="showDialog" :title="title">
+        <pre>{{valueData.formattedData}}</pre>
+        <template #footer>
+            <span class="dialog-footer footer">
+                <el-button @click="closeDialog">Cancel</el-button>
+                <el-button type="primary" @click.prevent="downloadValue()">
+                    Download
+                </el-button>
+            </span>
+        </template>
+    </el-dialog>
+</template>
+
+<style lang="scss" scoped>
+.footer {
+    width: 100%;
+    display: flex;
+    justify-content: center;
+}
+</style>

--- a/ui/src/components/Property/PropertyValueReader.vue
+++ b/ui/src/components/Property/PropertyValueReader.vue
@@ -44,11 +44,9 @@ const closeDialog = () => {
 const downloadValue = () => {
     const dataBlob = new Blob([valueData.formattedData], { type: 'text/JSON' })
     var a = document.createElement('a');
-
     a.download = 'value.txt';
     a.href = URL.createObjectURL(dataBlob);
     document.body.appendChild(a);
-
     a.click();
     document.body.removeChild(a);
 }


### PR DESCRIPTION
Fix https://github.com/apache/skywalking/issues/11974
Large amount of text to display in property value 

- [ ] Add a unit test to verify that the fix works.

- [X] Explain briefly why the bug exists and how to fix it.
The issue was caused due to the use of `property` value being very long in some cases resulting in bad UX. The fix ellipsizes the content of the value beyond 20 characters and provides a new popup to view and download the value of a property.

- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.

- [ ] Update the documentation to include this new feature.

- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
 
- [X] If it's UI related, attach the screenshots below.

https://github.com/apache/skywalking-banyandb/assets/53624363/dff66b02-b8a6-4c93-95b9-3f794a028601
 