### PR TITLE
chore: add quick_start docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The database research community usually uses [RUM Conjecture](http://daslab.seas
 - [Dev version doc](https://skywalking.apache.org/docs/skywalking-banyandb/next/readme/)
 - [Latest release doc](https://skywalking.apache.org/docs/skywalking-banyandb/latest/readme/)
 - [Java Client SDK doc](https://skywalking.apache.org/docs/#BanyanDBJavaClient)
+- [Quick start](https://skywalking.apache.org/docs/skywalking-banyandb/next/installation/standalone/)
 
 
 ## Contributing


### PR DESCRIPTION
I don’t think my change is reasonable, but I think the readme should add a quick_start so that users can know how to use skywalking-banyandb faster. I didn't find it at first

Or I should add a quick_start document. I haven’t found the corresponding information in the document so far.