### PR TITLE
docs: generate protobuf api before bydbctl build

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,7 @@ Release Notes.
 - Bump several tools.
 - Bump all dependencies of Go and Node.
 - Combine banyand and bydbctl Dockerfile.
+- Update readme for bydbctl
 
 ## 0.5.0
 

--- a/bydbctl/README.md
+++ b/bydbctl/README.md
@@ -5,5 +5,8 @@
 ## Build
 
 ```
+# If you haven't generated the API code yet
+make -C ../api generate
+
 make build
 ```


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

<!-- ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👇 ====
### Fix <bug description or the bug issue number or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly why the bug exists and how to fix it.
     ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Fixes apache/skywalking#<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-banyandb/blob/main/CHANGES.md).

For one only want to build `bydbctl`, they will encouter

```
Building binary
GOOS=linux GOARCH=amd64 go build -v --ldflags '-X github.com/apache/skywalking-banyandb/pkg/version.build=v0.5.0-67-gd5b4543-main' -o build/bin/bydbctl github.com/apache/skywalking-banyandb/bydbctl/cmd/bydbctl/
internal/cmd/group.go:27:2: no required module provides package github.com/apache/skywalking-banyandb/api/proto/banyandb/common/v1; to add it:
        go get github.com/apache/skywalking-banyandb/api/proto/banyandb/common/v1
internal/cmd/group.go:28:2: no required module provides package github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1; to add it:
        go get github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1
internal/cmd/property.go:27:2: no required module provides package github.com/apache/skywalking-banyandb/api/proto/banyandb/property/v1; to add it:
        go get github.com/apache/skywalking-banyandb/api/proto/banyandb/property/v1
../pkg/test/helpers/context.go:30:2: no required module provides package github.com/apache/skywalking-banyandb/api/proto/banyandb/model/v1; to add it:
        go get github.com/apache/skywalking-banyandb/api/proto/banyandb/model/v1
make: *** [Makefile:35: build] Error 1
```

Added docs will fix this issue.

BTW, I'm interested in OSPP 2024 `Support function in row merging` proposal and have been trying skywalking and banyandb these days, what could be a good starting point to start the proposal?