### PR TITLE
Fix flaws found by stream load test

### DIFF
--- a/banyand/internal/storage/index.go
+++ b/banyand/internal/storage/index.go
@@ -198,7 +198,7 @@ func (s *seriesIndex) Search(ctx context.Context, series *pbv1.Series, filter in
 
 	var sortedSeriesList pbv1.SeriesList
 	for iter.Next() {
-		seriesID := iter.Val()
+		seriesID, _ := iter.Val()
 		if !pl.Contains(seriesID) {
 			continue
 		}

--- a/banyand/internal/storage/index.go
+++ b/banyand/internal/storage/index.go
@@ -198,14 +198,11 @@ func (s *seriesIndex) Search(ctx context.Context, series *pbv1.Series, filter in
 
 	var sortedSeriesList pbv1.SeriesList
 	for iter.Next() {
-		pv := iter.Val().Value
-		if err = pv.Intersect(pl); err != nil {
-			return nil, err
-		}
-		if pv.IsEmpty() {
+		seriesID := iter.Val()
+		if !pl.Contains(seriesID) {
 			continue
 		}
-		sortedSeriesList = appendSeriesList(sortedSeriesList, seriesList, pv)
+		sortedSeriesList = appendSeriesList(sortedSeriesList, seriesList, common.SeriesID(seriesID))
 		if err != nil {
 			return nil, err
 		}
@@ -223,12 +220,12 @@ func filterSeriesList(seriesList pbv1.SeriesList, filter posting.List) pbv1.Seri
 	return seriesList
 }
 
-func appendSeriesList(dest, src pbv1.SeriesList, filter posting.List) pbv1.SeriesList {
+func appendSeriesList(dest, src pbv1.SeriesList, target common.SeriesID) pbv1.SeriesList {
 	for i := 0; i < len(src); i++ {
-		if !filter.Contains(uint64(src[i].ID)) {
-			continue
+		if target == src[i].ID {
+			dest = append(dest, src[i])
+			break
 		}
-		dest = append(dest, src[i])
 	}
 	return dest
 }

--- a/banyand/internal/storage/retention.go
+++ b/banyand/internal/storage/retention.go
@@ -51,13 +51,13 @@ func newRetentionTask[T TSTable, O any](database *database[T, O], ttl IntervalRu
 }
 
 func (rc *retentionTask[T, O]) run(now time.Time, l *logger.Logger) bool {
-	var shardList []*shard[T, O]
-	rc.database.RLock()
-	shardList = append(shardList, rc.database.sLst...)
-	rc.database.RUnlock()
+	shardList := rc.database.sLst.Load()
+	if shardList == nil {
+		return false
+	}
 	deadline := now.Add(-rc.duration)
 
-	for _, shard := range shardList {
+	for _, shard := range *shardList {
 		if err := shard.segmentController.remove(deadline); err != nil {
 			l.Error().Err(err)
 		}

--- a/banyand/internal/storage/segment.go
+++ b/banyand/internal/storage/segment.go
@@ -182,7 +182,7 @@ func (sc *segmentController[T, O]) segments() (ss []*segment[T]) {
 
 func (sc *segmentController[T, O]) Current() (bucket.Reporter, error) {
 	now := sc.segmentSize.Unit.standard(sc.clock.Now())
-	ns := uint64(now.UnixNano())
+	ns := now.UnixNano()
 	if b := func() bucket.Reporter {
 		sc.RLock()
 		defer sc.RUnlock()
@@ -275,7 +275,7 @@ func (sc *segmentController[T, O]) create(start time.Time) (*segment[T], error) 
 	start = sc.segmentSize.Unit.standard(start)
 	var next *segment[T]
 	for _, s := range sc.lst {
-		if s.Contains(uint64(start.UnixNano())) {
+		if s.Contains(start.UnixNano()) {
 			return s, nil
 		}
 		if next == nil && s.Start.After(start) {
@@ -334,7 +334,7 @@ func (sc *segmentController[T, O]) load(start, end time.Time, root string) (seg 
 func (sc *segmentController[T, O]) remove(deadline time.Time) (err error) {
 	sc.l.Info().Time("deadline", deadline).Msg("start to remove before deadline")
 	for _, s := range sc.segments() {
-		if s.End.Before(deadline) || s.Contains(uint64(deadline.UnixNano())) {
+		if s.End.Before(deadline) || s.Contains(deadline.UnixNano()) {
 			if e := sc.l.Debug(); e.Enabled() {
 				e.Stringer("segment", s).Msg("start to remove data in a segment")
 			}

--- a/banyand/liaison/grpc/measure.go
+++ b/banyand/liaison/grpc/measure.go
@@ -64,7 +64,7 @@ func (ms *measureService) activeIngestionAccessLog(root string) (err error) {
 func (ms *measureService) Write(measure measurev1.MeasureService_WriteServer) error {
 	reply := func(metadata *commonv1.Metadata, status modelv1.Status, messageId uint64, measure measurev1.MeasureService_WriteServer, logger *logger.Logger) {
 		if errResp := measure.Send(&measurev1.WriteResponse{Metadata: metadata, Status: status, MessageId: messageId}); errResp != nil {
-			logger.Err(errResp).Msg("failed to send response")
+			logger.Debug().Err(errResp).Msg("failed to send response")
 		}
 	}
 	ctx := measure.Context()

--- a/banyand/liaison/grpc/stream.go
+++ b/banyand/liaison/grpc/stream.go
@@ -64,7 +64,7 @@ func (s *streamService) activeIngestionAccessLog(root string) (err error) {
 func (s *streamService) Write(stream streamv1.StreamService_WriteServer) error {
 	reply := func(metadata *commonv1.Metadata, status modelv1.Status, messageId uint64, stream streamv1.StreamService_WriteServer, logger *logger.Logger) {
 		if errResp := stream.Send(&streamv1.WriteResponse{Metadata: metadata, Status: status, MessageId: messageId}); errResp != nil {
-			logger.Err(errResp).Msg("failed to send response")
+			logger.Debug().Err(errResp).Msg("failed to send response")
 		}
 	}
 	publisher := s.pipeline.NewBatchPublisher(s.writeTimeout)

--- a/banyand/liaison/grpc/stream.go
+++ b/banyand/liaison/grpc/stream.go
@@ -131,6 +131,7 @@ func (s *streamService) Write(stream streamv1.StreamService_WriteServer) error {
 		if errWritePub != nil {
 			s.sampled.Error().Err(errWritePub).RawJSON("written", logger.Proto(writeEntity)).Str("nodeID", nodeID).Msg("failed to send a message")
 			reply(writeEntity.GetMetadata(), modelv1.Status_STATUS_INTERNAL_ERROR, writeEntity.GetMessageId(), stream, s.sampled)
+			continue
 		}
 		reply(nil, modelv1.Status_STATUS_SUCCEED, writeEntity.GetMessageId(), stream, s.sampled)
 	}

--- a/banyand/measure/measure.go
+++ b/banyand/measure/measure.go
@@ -58,7 +58,7 @@ type measure struct {
 	name              string
 	group             string
 	indexRules        []*databasev1.IndexRule
-	indexRuleLocators []*partition.IndexRuleLocator
+	indexRuleLocators partition.IndexRuleLocator
 	topNAggregations  []*databasev1.TopNAggregation
 	interval          time.Duration
 	shardNum          uint32
@@ -103,7 +103,7 @@ func (s *measure) parseSpec() (err error) {
 	if s.schema.Interval != "" {
 		s.interval, err = timestamp.ParseDuration(s.schema.Interval)
 	}
-	s.indexRuleLocators = partition.ParseIndexRuleLocators(s.schema.GetTagFamilies(), s.indexRules)
+	s.indexRuleLocators = partition.ParseIndexRuleLocators(s.schema.GetEntity(), s.schema.GetTagFamilies(), s.indexRules)
 
 	return err
 }

--- a/banyand/measure/write.go
+++ b/banyand/measure/write.go
@@ -32,7 +32,6 @@ import (
 	"github.com/apache/skywalking-banyandb/pkg/convert"
 	"github.com/apache/skywalking-banyandb/pkg/index"
 	"github.com/apache/skywalking-banyandb/pkg/logger"
-	"github.com/apache/skywalking-banyandb/pkg/partition"
 	pbv1 "github.com/apache/skywalking-banyandb/pkg/pb/v1"
 	"github.com/apache/skywalking-banyandb/pkg/timestamp"
 )
@@ -126,11 +125,11 @@ func (w *writeCallback) handle(dst map[string]*dataPointsInGroup, writeEvent *me
 	}
 	dpt.dataPoints.fields = append(dpt.dataPoints.fields, field)
 	tagFamilies := make([]nameValues, 0, len(stm.schema.TagFamilies))
-	tagFamiliesForIndexWrite := make([]nameValues, len(stm.schema.TagFamilies))
-	entityMap := make(map[string]bool)
-	for _, entity := range stm.GetSchema().GetEntity().GetTagNames() {
-		entityMap[entity] = true
+	if len(stm.indexRuleLocators.TagFamilyTRule) != len(stm.GetSchema().GetTagFamilies()) {
+		logger.Panicf("metadata crashed, tag family rule length %d, tag family length %d",
+			len(stm.indexRuleLocators.TagFamilyTRule), len(stm.GetSchema().GetTagFamilies()))
 	}
+	var fields []index.Field
 	for i := range stm.GetSchema().GetTagFamilies() {
 		var tagFamily *modelv1.TagFamilyForWrite
 		if len(req.DataPoint.TagFamilies) <= i {
@@ -138,6 +137,7 @@ func (w *writeCallback) handle(dst map[string]*dataPointsInGroup, writeEvent *me
 		} else {
 			tagFamily = req.DataPoint.TagFamilies[i]
 		}
+		tfr := stm.indexRuleLocators.TagFamilyTRule[i]
 		tagFamilySpec := stm.GetSchema().GetTagFamilies()[i]
 		tf := nameValues{
 			name: tagFamilySpec.Name,
@@ -150,15 +150,37 @@ func (w *writeCallback) handle(dst map[string]*dataPointsInGroup, writeEvent *me
 				tagValue = tagFamily.Tags[j]
 			}
 
-			nameValue := encodeTagValue(
-				tagFamilySpec.Tags[j].Name,
-				tagFamilySpec.Tags[j].Type,
+			t := tagFamilySpec.Tags[j]
+			encodeTagValue := encodeTagValue(
+				t.Name,
+				t.Type,
 				tagValue)
-			tagFamiliesForIndexWrite[i].values = append(tagFamiliesForIndexWrite[i].values, nameValue)
-			if tagFamilySpec.Tags[j].IndexedOnly || entityMap[tagFamilySpec.Tags[j].Name] {
+			if r, ok := tfr[t.Name]; ok {
+				if encodeTagValue.value != nil {
+					fields = append(fields, index.Field{
+						Key: index.FieldKey{
+							IndexRuleID: r.GetMetadata().GetId(),
+							Analyzer:    r.Analyzer,
+						},
+						Term: encodeTagValue.value,
+					})
+				} else {
+					for _, val := range encodeTagValue.valueArr {
+						fields = append(fields, index.Field{
+							Key: index.FieldKey{
+								IndexRuleID: r.GetMetadata().GetId(),
+								Analyzer:    r.Analyzer,
+							},
+							Term: val,
+						})
+					}
+				}
+			}
+			_, isEntity := stm.indexRuleLocators.EntitySet[t.Name]
+			if tagFamilySpec.Tags[j].IndexedOnly || isEntity {
 				continue
 			}
-			tf.values = append(tf.values, nameValue)
+			tf.values = append(tf.values, encodeTagValue)
 		}
 		if len(tf.values) > 0 {
 			tagFamilies = append(tagFamilies, tf)
@@ -176,33 +198,7 @@ func (w *writeCallback) handle(dst map[string]*dataPointsInGroup, writeEvent *me
 			EntityValues: writeEvent.EntityValues,
 		})
 	}
-	var fields []index.Field
-	for _, ruleIndex := range stm.indexRuleLocators {
-		nv := getIndexValue(ruleIndex, tagFamiliesForIndexWrite)
-		if nv == nil {
-			continue
-		}
-		if nv.value != nil {
-			fields = append(fields, index.Field{
-				Key: index.FieldKey{
-					IndexRuleID: ruleIndex.Rule.GetMetadata().GetId(),
-					Analyzer:    ruleIndex.Rule.Analyzer,
-				},
-				Term: nv.value,
-			})
-			continue
-		}
-		for _, val := range nv.valueArr {
-			rule := ruleIndex.Rule
-			fields = append(fields, index.Field{
-				Key: index.FieldKey{
-					IndexRuleID: rule.GetMetadata().GetId(),
-					Analyzer:    rule.Analyzer,
-				},
-				Term: val,
-			})
-		}
-	}
+
 	dpg.docs = append(dpg.docs, index.Document{
 		DocID:        uint64(series.ID),
 		EntityValues: series.Buffer,
@@ -327,20 +323,4 @@ func encodeTagValue(name string, tagType databasev1.TagType, tagValue *modelv1.T
 		logger.Panicf("unsupported tag value type: %T", tagValue.GetValue())
 	}
 	return nv
-}
-
-func getIndexValue(ruleIndex *partition.IndexRuleLocator, tagFamilies []nameValues) *nameValue {
-	if len(ruleIndex.TagIndices) != 1 {
-		logger.Panicf("the index rule %s(%v) didn't support composited tags",
-			ruleIndex.Rule.Metadata.Name, ruleIndex.Rule.Tags)
-	}
-	tIndex := ruleIndex.TagIndices[0]
-	if tIndex.FamilyOffset >= len(tagFamilies) {
-		return nil
-	}
-	tf := tagFamilies[tIndex.FamilyOffset]
-	if tIndex.TagOffset >= len(tf.values) {
-		return nil
-	}
-	return tf.values[tIndex.TagOffset]
 }

--- a/banyand/measure/write.go
+++ b/banyand/measure/write.go
@@ -54,7 +54,7 @@ func (w *writeCallback) handle(dst map[string]*dataPointsInGroup, writeEvent *me
 	if err := timestamp.Check(t); err != nil {
 		return nil, fmt.Errorf("invalid timestamp: %w", err)
 	}
-	ts := uint64(t.UnixNano())
+	ts := t.UnixNano()
 
 	gn := req.Metadata.Group
 	tsdb, err := w.schemaRepo.loadTSDB(gn)
@@ -89,7 +89,7 @@ func (w *writeCallback) handle(dst map[string]*dataPointsInGroup, writeEvent *me
 		}
 		dpg.tables = append(dpg.tables, dpt)
 	}
-	dpt.dataPoints.timestamps = append(dpt.dataPoints.timestamps, int64(ts))
+	dpt.dataPoints.timestamps = append(dpt.dataPoints.timestamps, ts)
 	stm, ok := w.schemaRepo.loadMeasure(writeEvent.GetRequest().GetMetadata())
 	if !ok {
 		return nil, fmt.Errorf("cannot find measure definition: %s", writeEvent.GetRequest().GetMetadata())

--- a/banyand/stream/index.go
+++ b/banyand/stream/index.go
@@ -52,8 +52,8 @@ func newElementIndex(ctx context.Context, root string, flushTimeoutSeconds int64
 	return ei, nil
 }
 
-func (e *elementIndex) Iterator(fieldKey index.FieldKey, termRange index.RangeOpts, order modelv1.Sort, preloadSize int) (index.FieldIterator, error) {
-	iter, err := e.store.Iterator(fieldKey, termRange, order, preloadSize)
+func (e *elementIndex) Sort(sids []common.SeriesID, fieldKey index.FieldKey, order modelv1.Sort, preloadSize int) (index.FieldIterator, error) {
+	iter, err := e.store.Sort(sids, fieldKey, order, preloadSize)
 	if err != nil {
 		return nil, err
 	}

--- a/banyand/stream/index.go
+++ b/banyand/stream/index.go
@@ -90,7 +90,7 @@ func (e *elementIndex) Close() error {
 
 type elementRef struct {
 	seriesID  common.SeriesID
-	timestamp uint64
+	timestamp int64
 }
 
 type indexedElementRef struct {
@@ -130,7 +130,7 @@ func merge(postingMap map[common.SeriesID][]uint64) []elementRef {
 
 	for seriesID, timestamps := range postingMap {
 		if len(timestamps) > 0 {
-			er := elementRef{seriesID: seriesID, timestamp: timestamps[0]}
+			er := elementRef{seriesID: seriesID, timestamp: int64(timestamps[0])}
 			item := &indexedElementRef{elementRef: er, elemIdx: 0}
 			heap.Push(&pq, item)
 		}
@@ -141,7 +141,7 @@ func merge(postingMap map[common.SeriesID][]uint64) []elementRef {
 
 		if item.elemIdx+1 < len(postingMap[item.seriesID]) {
 			nextTS := postingMap[item.seriesID][item.elemIdx+1]
-			nextEr := elementRef{seriesID: item.seriesID, timestamp: nextTS}
+			nextEr := elementRef{seriesID: item.seriesID, timestamp: int64(nextTS)}
 			nextItem := &indexedElementRef{elementRef: nextEr, elemIdx: item.elemIdx + 1}
 			heap.Push(&pq, nextItem)
 		}

--- a/banyand/stream/index.go
+++ b/banyand/stream/index.go
@@ -61,16 +61,9 @@ func (e *elementIndex) Iterator(fieldKey index.FieldKey, termRange index.RangeOp
 }
 
 func (e *elementIndex) Write(docs index.Documents) error {
-	applied := make(chan struct{})
-	err := e.store.Batch(index.Batch{
+	return e.store.Batch(index.Batch{
 		Documents: docs,
-		Applied:   applied,
 	})
-	if err != nil {
-		return err
-	}
-	<-applied
-	return nil
 }
 
 func (e *elementIndex) Search(_ context.Context, seriesList pbv1.SeriesList, filter index.Filter) ([]elementRef, error) {

--- a/banyand/stream/iter_builder.go
+++ b/banyand/stream/iter_builder.go
@@ -23,57 +23,29 @@ import (
 
 	"github.com/apache/skywalking-banyandb/api/common"
 	databasev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
-	modelv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/model/v1"
 	"github.com/apache/skywalking-banyandb/banyand/internal/storage"
 	"github.com/apache/skywalking-banyandb/pkg/index"
 	"github.com/apache/skywalking-banyandb/pkg/index/posting"
-	"github.com/apache/skywalking-banyandb/pkg/logger"
 	pbv1 "github.com/apache/skywalking-banyandb/pkg/pb/v1"
-	"github.com/apache/skywalking-banyandb/pkg/timestamp"
 )
-
-var rangeOpts = index.RangeOpts{}
 
 type filterFn func(itemID uint64) bool
 
-type iterBuilder struct {
-	indexFilter         index.Filter
-	timeRange           *timestamp.TimeRange
-	tableWrappers       []storage.TSTableWrapper[*tsTable]
-	indexRuleForSorting *databasev1.IndexRule
-	l                   *logger.Logger
-	tagProjection       []pbv1.TagProjection
-	seriesID            common.SeriesID
-	order               modelv1.Sort
-	preloadSize         int
-}
-
-func newIterBuilder(tableWrappers []storage.TSTableWrapper[*tsTable], id common.SeriesID, sso pbv1.StreamSortOptions) *iterBuilder {
-	return &iterBuilder{
-		indexFilter:         sso.Filter,
-		timeRange:           sso.TimeRange,
-		tableWrappers:       tableWrappers,
-		indexRuleForSorting: sso.Order.Index,
-		l:                   logger.GetLogger("seeker-builder"),
-		tagProjection:       sso.TagProjection,
-		seriesID:            id,
-		order:               sso.Order.Sort,
-		preloadSize:         sso.MaxElementSize,
-	}
-}
-
-func buildSeriesByIndex(s *iterBuilder) (series []*searcherIterator, err error) {
+func (s *stream) buildSeriesByIndex(tableWrappers []storage.TSTableWrapper[*tsTable],
+	sids []common.SeriesID, sso pbv1.StreamSortOptions,
+) (series []*searcherIterator, err error) {
 	timeFilter := func(itemID uint64) bool {
-		return s.timeRange.Contains(int64(itemID))
+		return sso.TimeRange.Contains(int64(itemID))
 	}
-	if len(s.indexRuleForSorting.Tags) != 1 {
-		return nil, fmt.Errorf("only support one tag for sorting, but got %d", len(s.indexRuleForSorting.Tags))
+	indexRuleForSorting := sso.Order.Index
+	if len(indexRuleForSorting.Tags) != 1 {
+		return nil, fmt.Errorf("only support one tag for sorting, but got %d", len(indexRuleForSorting.Tags))
 	}
-	sortedTag := s.indexRuleForSorting.Tags[0]
+	sortedTag := indexRuleForSorting.Tags[0]
 	tl := newTagLocation()
-	for i := range s.tagProjection {
-		for j := range s.tagProjection[i].Names {
-			if s.tagProjection[i].Names[j] == sortedTag {
+	for i := range sso.TagProjection {
+		for j := range sso.TagProjection[i].Names {
+			if sso.TagProjection[i].Names[j] == sortedTag {
 				tl.familyIndex, tl.tagIndex = i, j
 			}
 		}
@@ -81,38 +53,40 @@ func buildSeriesByIndex(s *iterBuilder) (series []*searcherIterator, err error) 
 	if !tl.valid() {
 		return nil, fmt.Errorf("sorted tag %s not found in tag projection", sortedTag)
 	}
-	for _, tw := range s.tableWrappers {
-		var indexFilter filterFn
-		if s.indexFilter != nil {
-			var pl posting.List
-			pl, err = s.indexFilter.Execute(func(ruleType databasev1.IndexRule_Type) (index.Searcher, error) {
-				return tw.Table().Index().store, nil
-			}, s.seriesID)
-			if err != nil {
-				return nil, err
-			}
-			indexFilter = func(itemID uint64) bool {
-				if pl == nil {
-					return true
+	var pl posting.List
+	for _, tw := range tableWrappers {
+		seriesFilter := make(map[common.SeriesID]filterFn)
+		if sso.Filter != nil {
+			for i := range sids {
+				pl, err = sso.Filter.Execute(func(ruleType databasev1.IndexRule_Type) (index.Searcher, error) {
+					return tw.Table().Index().store, nil
+				}, sids[i])
+				if err != nil {
+					return nil, err
 				}
-				return pl.Contains(itemID)
+
+				seriesFilter[sids[i]] = func(itemID uint64) bool {
+					if pl == nil {
+						return true
+					}
+					return pl.Contains(itemID)
+				}
 			}
 		}
 
 		var inner index.FieldIterator
 		fieldKey := index.FieldKey{
-			SeriesID:    s.seriesID,
-			IndexRuleID: s.indexRuleForSorting.GetMetadata().GetId(),
-			Analyzer:    s.indexRuleForSorting.GetAnalyzer(),
+			IndexRuleID: indexRuleForSorting.GetMetadata().GetId(),
+			Analyzer:    indexRuleForSorting.GetAnalyzer(),
 		}
-		inner, err = tw.Table().Index().Iterator(fieldKey, rangeOpts, s.order, s.preloadSize)
+		inner, err = tw.Table().Index().Sort(sids, fieldKey, sso.Order.Sort, sso.MaxElementSize)
 		if err != nil {
 			return nil, err
 		}
 
 		if inner != nil {
 			series = append(series, newSearcherIterator(s.l, inner, tw.Table(),
-				s.seriesID, indexFilter, timeFilter, s.tagProjection, tl))
+				seriesFilter, timeFilter, sso.TagProjection, tl))
 		}
 	}
 	return

--- a/banyand/stream/iter_builder.go
+++ b/banyand/stream/iter_builder.go
@@ -25,7 +25,6 @@ import (
 	databasev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
 	"github.com/apache/skywalking-banyandb/banyand/internal/storage"
 	"github.com/apache/skywalking-banyandb/pkg/index"
-	"github.com/apache/skywalking-banyandb/pkg/index/posting"
 	pbv1 "github.com/apache/skywalking-banyandb/pkg/pb/v1"
 )
 
@@ -53,15 +52,14 @@ func (s *stream) buildSeriesByIndex(tableWrappers []storage.TSTableWrapper[*tsTa
 	if !tl.valid() {
 		return nil, fmt.Errorf("sorted tag %s not found in tag projection", sortedTag)
 	}
-	var pl posting.List
 	for _, tw := range tableWrappers {
 		seriesFilter := make(map[common.SeriesID]filterFn)
 		if sso.Filter != nil {
 			for i := range sids {
-				pl, err = sso.Filter.Execute(func(ruleType databasev1.IndexRule_Type) (index.Searcher, error) {
+				pl, errExe := sso.Filter.Execute(func(ruleType databasev1.IndexRule_Type) (index.Searcher, error) {
 					return tw.Table().Index().store, nil
 				}, sids[i])
-				if err != nil {
+				if errExe != nil {
 					return nil, err
 				}
 

--- a/banyand/stream/iter_builder.go
+++ b/banyand/stream/iter_builder.go
@@ -18,13 +18,15 @@
 package stream
 
 import (
-	"time"
+	"bytes"
+	"fmt"
 
 	"github.com/apache/skywalking-banyandb/api/common"
 	databasev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
 	modelv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/model/v1"
 	"github.com/apache/skywalking-banyandb/banyand/internal/storage"
 	"github.com/apache/skywalking-banyandb/pkg/index"
+	"github.com/apache/skywalking-banyandb/pkg/index/posting"
 	"github.com/apache/skywalking-banyandb/pkg/logger"
 	pbv1 "github.com/apache/skywalking-banyandb/pkg/pb/v1"
 	"github.com/apache/skywalking-banyandb/pkg/timestamp"
@@ -32,7 +34,7 @@ import (
 
 var rangeOpts = index.RangeOpts{}
 
-type filterFn func(item item) bool
+type filterFn func(itemID uint64) bool
 
 type iterBuilder struct {
 	indexFilter         index.Filter
@@ -61,31 +63,43 @@ func newIterBuilder(tableWrappers []storage.TSTableWrapper[*tsTable], id common.
 }
 
 func buildSeriesByIndex(s *iterBuilder) (series []*searcherIterator, err error) {
-	timeFilter := func(item item) bool {
-		valid := s.timeRange.Contains(item.Time())
-		timeRange := s.timeRange
-		s.l.Trace().
-			Times("time_range", []time.Time{timeRange.Start, timeRange.End}).
-			Bool("valid", valid).Msg("filter item by time range")
-		return valid
+	timeFilter := func(itemID uint64) bool {
+		return s.timeRange.Contains(int64(itemID))
+	}
+	if len(s.indexRuleForSorting.Tags) != 1 {
+		return nil, fmt.Errorf("only support one tag for sorting, but got %d", len(s.indexRuleForSorting.Tags))
+	}
+	sortedTag := s.indexRuleForSorting.Tags[0]
+	tl := newTagLocation()
+	for i := range s.tagProjection {
+		for j := range s.tagProjection[i].Names {
+			if s.tagProjection[i].Names[j] == sortedTag {
+				tl.familyIndex, tl.tagIndex = i, j
+			}
+		}
+	}
+	if !tl.valid() {
+		return nil, fmt.Errorf("sorted tag %s not found in tag projection", sortedTag)
 	}
 	for _, tw := range s.tableWrappers {
-		indexFilter := func(item item) bool {
-			if s.indexFilter == nil {
-				return true
-			}
-			pl, err := s.indexFilter.Execute(func(ruleType databasev1.IndexRule_Type) (index.Searcher, error) {
+		var indexFilter filterFn
+		if s.indexFilter != nil {
+			var pl posting.List
+			pl, err = s.indexFilter.Execute(func(ruleType databasev1.IndexRule_Type) (index.Searcher, error) {
 				return tw.Table().Index().store, nil
 			}, s.seriesID)
 			if err != nil {
-				return false
+				return nil, err
 			}
-			valid := pl.Contains(item.Time())
-			s.l.Trace().Int("valid_item_num", pl.Len()).Bool("valid", valid).Msg("filter item by index")
-			return valid
+			indexFilter = func(itemID uint64) bool {
+				if pl == nil {
+					return true
+				}
+				return pl.Contains(itemID)
+			}
 		}
+
 		var inner index.FieldIterator
-		var err error
 		fieldKey := index.FieldKey{
 			SeriesID:    s.seriesID,
 			IndexRuleID: s.indexRuleForSorting.GetMetadata().GetId(),
@@ -95,10 +109,41 @@ func buildSeriesByIndex(s *iterBuilder) (series []*searcherIterator, err error) 
 		if err != nil {
 			return nil, err
 		}
+
 		if inner != nil {
 			series = append(series, newSearcherIterator(s.l, inner, tw.Table(),
-				s.seriesID, indexFilter, timeFilter, s.tagProjection))
+				s.seriesID, indexFilter, timeFilter, s.tagProjection, tl))
 		}
 	}
 	return
+}
+
+type tagLocation struct {
+	familyIndex int
+	tagIndex    int
+}
+
+func newTagLocation() tagLocation {
+	return tagLocation{
+		familyIndex: -1,
+		tagIndex:    -1,
+	}
+}
+
+func (t tagLocation) valid() bool {
+	return t.familyIndex != -1 && t.tagIndex != -1
+}
+
+func (t tagLocation) getTagValue(e *element) ([]byte, error) {
+	if len(e.tagFamilies) <= t.familyIndex {
+		return nil, fmt.Errorf("tag family index %d out of range", t.familyIndex)
+	}
+	if len(e.tagFamilies[t.familyIndex].tags) <= t.tagIndex {
+		return nil, fmt.Errorf("tag index %d out of range", t.tagIndex)
+	}
+	if len(e.tagFamilies[t.familyIndex].tags[t.tagIndex].values) <= e.index {
+		return nil, fmt.Errorf("element index %d out of range", e.index)
+	}
+	v := e.tagFamilies[t.familyIndex].tags[t.tagIndex].values[e.index]
+	return bytes.Clone(v), nil
 }

--- a/banyand/stream/part.go
+++ b/banyand/stream/part.go
@@ -120,8 +120,8 @@ type part struct {
 	partMetadata         partMetadata
 }
 
-func (p *part) containTimestamp(timestamp common.ItemID) bool {
-	return timestamp >= common.ItemID(p.partMetadata.MinTimestamp) && timestamp <= common.ItemID(p.partMetadata.MaxTimestamp)
+func (p *part) containTimestamp(timestamp int64) bool {
+	return timestamp >= p.partMetadata.MinTimestamp && timestamp <= p.partMetadata.MaxTimestamp
 }
 
 func (p *part) close() {
@@ -140,7 +140,7 @@ func (p *part) String() string {
 	return fmt.Sprintf("part %d", p.partMetadata.ID)
 }
 
-func (p *part) getElement(seriesID common.SeriesID, timestamp common.ItemID, tagProjection []pbv1.TagProjection) (*element, int, error) {
+func (p *part) getElement(seriesID common.SeriesID, timestamp int64, tagProjection []pbv1.TagProjection) (*element, int, error) {
 	// TODO: refactor to column-based query
 	// TODO: cache blocks
 	for i, primaryMeta := range p.primaryBlockMetadata {
@@ -148,8 +148,8 @@ func (p *part) getElement(seriesID common.SeriesID, timestamp common.ItemID, tag
 			continue
 		}
 		if seriesID < p.primaryBlockMetadata[i].seriesID ||
-			timestamp < common.ItemID(p.primaryBlockMetadata[i].minTimestamp) ||
-			timestamp > common.ItemID(p.primaryBlockMetadata[i].maxTimestamp) {
+			timestamp < p.primaryBlockMetadata[i].minTimestamp ||
+			timestamp > p.primaryBlockMetadata[i].maxTimestamp {
 			break
 		}
 
@@ -180,7 +180,7 @@ func (p *part) getElement(seriesID common.SeriesID, timestamp common.ItemID, tag
 		timestamps := make([]int64, 0)
 		timestamps = mustReadTimestampsFrom(timestamps, &targetBlockMetadata.timestamps, int(targetBlockMetadata.count), p.timestamps)
 		for i, ts := range timestamps {
-			if timestamp == common.ItemID(ts) {
+			if timestamp == ts {
 				elementIDs := make([]string, 0)
 				elementIDs = mustReadElementIDsFrom(elementIDs, &targetBlockMetadata.elementIDs, int(targetBlockMetadata.count), p.elementIDs)
 				tfs := make([]*tagFamily, 0)
@@ -202,7 +202,7 @@ func (p *part) getElement(seriesID common.SeriesID, timestamp common.ItemID, tag
 					index:       i,
 				}, len(timestamps), nil
 			}
-			if common.ItemID(ts) > timestamp {
+			if ts > timestamp {
 				break
 			}
 		}

--- a/banyand/stream/part.go
+++ b/banyand/stream/part.go
@@ -177,6 +177,7 @@ func (p *part) getElement(seriesID common.SeriesID, timestamp int64, tagProjecti
 							name := tagProjection[k].Family
 							block, ok := bm[i].tagFamilies[name]
 							if !ok {
+								tfs = append(tfs, &tagFamily{name: name, tags: make([]tag, len(tagProjection[k].Names))})
 								continue
 							}
 							decoder := &encoding.BytesBlockDecoder{}

--- a/banyand/stream/query.go
+++ b/banyand/stream/query.go
@@ -402,7 +402,7 @@ func (s *stream) Filter(ctx context.Context, sfo pbv1.StreamFilterOptions) (sfr 
 			erl = erl[:sfo.MaxElementSize-len(ces.timestamp)]
 		}
 		for _, er := range erl {
-			e, count, err := tw.Table().getElement(er.seriesID, common.ItemID(er.timestamp), sfo.TagProjection)
+			e, count, err := tw.Table().getElement(er.seriesID, er.timestamp, sfo.TagProjection)
 			if err != nil {
 				return nil, err
 			}
@@ -481,10 +481,7 @@ func (s *stream) Sort(ctx context.Context, sso pbv1.StreamSortOptions) (ssr pbv1
 	ces := newColumnElements()
 	for it.Next() {
 		nextItem := it.Val()
-		e, count, err := nextItem.Element()
-		if err != nil {
-			return nil, err
-		}
+		e, count := nextItem.element, nextItem.count
 		if len(tagProjIndex) != 0 {
 			for entity, offset := range tagProjIndex {
 				tagSpec := tagSpecIndex[entity]
@@ -505,7 +502,7 @@ func (s *stream) Sort(ctx context.Context, sso pbv1.StreamSortOptions) (ssr pbv1
 			break
 		}
 	}
-	return ces, nil
+	return ces, err
 }
 
 func (s *stream) Query(ctx context.Context, sqo pbv1.StreamQueryOptions) (pbv1.StreamQueryResult, error) {

--- a/banyand/stream/stream.go
+++ b/banyand/stream/stream.go
@@ -40,7 +40,7 @@ const (
 	maxUncompressedBlockSize        = 2 * 1024 * 1024
 	maxUncompressedPrimaryBlockSize = 128 * 1024
 
-	defaultFlushTimeout = 5 * time.Second
+	defaultFlushTimeout = time.Second
 )
 
 type option struct {
@@ -74,7 +74,7 @@ type stream struct {
 	name              string
 	group             string
 	indexRules        []*databasev1.IndexRule
-	indexRuleLocators []*partition.IndexRuleLocator
+	indexRuleLocators partition.IndexRuleLocator
 	shardNum          uint32
 }
 
@@ -92,7 +92,7 @@ func (s *stream) Close() error {
 
 func (s *stream) parseSpec() {
 	s.name, s.group = s.schema.GetMetadata().GetName(), s.schema.GetMetadata().GetGroup()
-	s.indexRuleLocators = partition.ParseIndexRuleLocators(s.schema.GetTagFamilies(), s.indexRules)
+	s.indexRuleLocators = partition.ParseIndexRuleLocators(s.schema.GetEntity(), s.schema.GetTagFamilies(), s.indexRules)
 }
 
 type streamSpec struct {

--- a/banyand/stream/tstable.go
+++ b/banyand/stream/tstable.go
@@ -290,6 +290,7 @@ func (tst *tsTable) getElement(seriesID common.SeriesID, timestamp int64, tagPro
 		return nil, 0, fmt.Errorf("snapshot is absent, cannot find element with seriesID %d and timestamp %d", seriesID, timestamp)
 	}
 	defer s.decRef()
+
 	for _, p := range s.parts {
 		if !p.p.containTimestamp(timestamp) {
 			continue

--- a/banyand/stream/tstable.go
+++ b/banyand/stream/tstable.go
@@ -284,7 +284,7 @@ func (tst *tsTable) mustAddElements(es *elements) {
 	}
 }
 
-func (tst *tsTable) getElement(seriesID common.SeriesID, timestamp common.ItemID, tagProjection []pbv1.TagProjection) (*element, int, error) {
+func (tst *tsTable) getElement(seriesID common.SeriesID, timestamp int64, tagProjection []pbv1.TagProjection) (*element, int, error) {
 	s := tst.currentSnapshot()
 	if s == nil {
 		return nil, 0, fmt.Errorf("snapshot is absent, cannot find element with seriesID %d and timestamp %d", seriesID, timestamp)

--- a/banyand/stream/write.go
+++ b/banyand/stream/write.go
@@ -78,13 +78,13 @@ func (w *writeCallback) handle(dst map[string]*elementsInGroup, writeEvent *stre
 	}
 	shardID := common.ShardID(writeEvent.ShardId)
 	if et == nil {
-		tstb, err := tsdb.CreateTSTableIfNotExist(shardID, t)
+		tsdb, err := tsdb.CreateTSTableIfNotExist(shardID, t)
 		if err != nil {
 			return nil, fmt.Errorf("cannot create ts table: %w", err)
 		}
 		et = &elementsInTable{
-			timeRange: tstb.GetTimeRange(),
-			tsTable:   tstb,
+			timeRange: tsdb.GetTimeRange(),
+			tsTable:   tsdb,
 		}
 		eg.tables = append(eg.tables, et)
 	}

--- a/banyand/stream/write.go
+++ b/banyand/stream/write.go
@@ -53,7 +53,7 @@ func (w *writeCallback) handle(dst map[string]*elementsInGroup, writeEvent *stre
 	if err := timestamp.Check(t); err != nil {
 		return nil, fmt.Errorf("invalid timestamp: %w", err)
 	}
-	ts := uint64(t.UnixNano())
+	ts := t.UnixNano()
 
 	gn := req.Metadata.Group
 	tsdb, err := w.schemaRepo.loadTSDB(gn)
@@ -88,7 +88,7 @@ func (w *writeCallback) handle(dst map[string]*elementsInGroup, writeEvent *stre
 		}
 		eg.tables = append(eg.tables, et)
 	}
-	et.elements.timestamps = append(et.elements.timestamps, int64(ts))
+	et.elements.timestamps = append(et.elements.timestamps, ts)
 	et.elements.elementIDs = append(et.elements.elementIDs, writeEvent.Request.Element.GetElementId())
 	stm, ok := w.schemaRepo.loadStream(writeEvent.GetRequest().GetMetadata())
 	if !ok {
@@ -172,7 +172,7 @@ func (w *writeCallback) handle(dst map[string]*elementsInGroup, writeEvent *stre
 	}
 
 	et.docs = append(et.docs, index.Document{
-		DocID:  ts,
+		DocID:  uint64(ts),
 		Fields: fields,
 	})
 

--- a/banyand/stream/write.go
+++ b/banyand/stream/write.go
@@ -31,7 +31,6 @@ import (
 	"github.com/apache/skywalking-banyandb/pkg/convert"
 	"github.com/apache/skywalking-banyandb/pkg/index"
 	"github.com/apache/skywalking-banyandb/pkg/logger"
-	"github.com/apache/skywalking-banyandb/pkg/partition"
 	pbv1 "github.com/apache/skywalking-banyandb/pkg/pb/v1"
 	"github.com/apache/skywalking-banyandb/pkg/timestamp"
 )
@@ -112,12 +111,12 @@ func (w *writeCallback) handle(dst map[string]*elementsInGroup, writeEvent *stre
 	et.elements.seriesIDs = append(et.elements.seriesIDs, series.ID)
 
 	tagFamilies := make([]tagValues, len(stm.schema.TagFamilies))
-	tagFamiliesForIndexWrite := make([]tagValues, len(stm.schema.TagFamilies))
-	entityMap := make(map[string]bool)
 	et.elements.tagFamilies = append(et.elements.tagFamilies, tagFamilies)
-	for _, entity := range stm.GetSchema().GetEntity().GetTagNames() {
-		entityMap[entity] = true
+	if len(stm.indexRuleLocators.TagFamilyTRule) != len(stm.GetSchema().GetTagFamilies()) {
+		logger.Panicf("metadata crashed, tag family rule length %d, tag family length %d",
+			len(stm.indexRuleLocators.TagFamilyTRule), len(stm.GetSchema().GetTagFamilies()))
 	}
+	var fields []index.Field
 	for i := range stm.GetSchema().GetTagFamilies() {
 		var tagFamily *modelv1.TagFamilyForWrite
 		if len(req.Element.TagFamilies) <= i {
@@ -125,6 +124,7 @@ func (w *writeCallback) handle(dst map[string]*elementsInGroup, writeEvent *stre
 		} else {
 			tagFamily = req.Element.TagFamilies[i]
 		}
+		tfr := stm.indexRuleLocators.TagFamilyTRule[i]
 		tagFamilySpec := stm.GetSchema().GetTagFamilies()[i]
 		tagFamilies[i].tag = tagFamilySpec.Name
 		for j := range tagFamilySpec.Tags {
@@ -135,44 +135,39 @@ func (w *writeCallback) handle(dst map[string]*elementsInGroup, writeEvent *stre
 				tagValue = tagFamily.Tags[j]
 			}
 
+			t := tagFamilySpec.Tags[j]
 			encodeTagValue := encodeTagValue(
-				tagFamilySpec.Tags[j].Name,
-				tagFamilySpec.Tags[j].Type,
+				t.Name,
+				t.Type,
 				tagValue)
-			tagFamiliesForIndexWrite[i].values = append(tagFamiliesForIndexWrite[i].values, encodeTagValue)
-			if tagFamilySpec.Tags[j].IndexedOnly || entityMap[tagFamilySpec.Tags[j].Name] {
+			if r, ok := tfr[t.Name]; ok {
+				if encodeTagValue.value != nil {
+					fields = append(fields, index.Field{
+						Key: index.FieldKey{
+							IndexRuleID: r.GetMetadata().GetId(),
+							Analyzer:    r.Analyzer,
+							SeriesID:    series.ID,
+						},
+						Term: encodeTagValue.value,
+					})
+				} else {
+					for _, val := range encodeTagValue.valueArr {
+						fields = append(fields, index.Field{
+							Key: index.FieldKey{
+								IndexRuleID: r.GetMetadata().GetId(),
+								Analyzer:    r.Analyzer,
+								SeriesID:    series.ID,
+							},
+							Term: val,
+						})
+					}
+				}
+			}
+			_, isEntity := stm.indexRuleLocators.EntitySet[tagFamilySpec.Tags[j].Name]
+			if tagFamilySpec.Tags[j].IndexedOnly || isEntity {
 				continue
 			}
 			tagFamilies[i].values = append(tagFamilies[i].values, encodeTagValue)
-		}
-	}
-
-	var fields []index.Field
-	for _, indexRule := range stm.indexRuleLocators {
-		tv := getIndexValue(indexRule, tagFamiliesForIndexWrite)
-		if tv == nil {
-			continue
-		}
-		if tv.value != nil {
-			fields = append(fields, index.Field{
-				Key: index.FieldKey{
-					IndexRuleID: indexRule.Rule.GetMetadata().GetId(),
-					Analyzer:    indexRule.Rule.Analyzer,
-					SeriesID:    series.ID,
-				},
-				Term: tv.value,
-			})
-			continue
-		}
-		for _, val := range tv.valueArr {
-			fields = append(fields, index.Field{
-				Key: index.FieldKey{
-					IndexRuleID: indexRule.Rule.GetMetadata().GetId(),
-					Analyzer:    indexRule.Rule.Analyzer,
-					SeriesID:    series.ID,
-				},
-				Term: val,
-			})
 		}
 	}
 
@@ -226,14 +221,20 @@ func (w *writeCallback) Rev(message bus.Message) (resp bus.Message) {
 		for j := range g.tables {
 			es := g.tables[j]
 			es.tsTable.Table().mustAddElements(&es.elements)
-			index := es.tsTable.Table().Index()
-			if err := index.Write(es.docs); err != nil {
-				w.l.Error().Err(err).Msg("cannot write element index")
+			if len(es.docs) > 0 {
+				go func() {
+					index := es.tsTable.Table().Index()
+					if err := index.Write(es.docs); err != nil {
+						w.l.Error().Err(err).Msg("cannot write element index")
+					}
+				}()
 			}
 			es.tsTable.DecRef()
 		}
-		if err := g.tsdb.IndexDB().Write(g.docs); err != nil {
-			w.l.Error().Err(err).Msg("cannot write series index")
+		if len(g.docs) > 0 {
+			if err := g.tsdb.IndexDB().Write(g.docs); err != nil {
+				w.l.Error().Err(err).Msg("cannot write series index")
+			}
 		}
 	}
 	return
@@ -279,20 +280,4 @@ func encodeTagValue(name string, tagType databasev1.TagType, tagVal *modelv1.Tag
 		logger.Panicf("unsupported tag value type: %T", tagVal.GetValue())
 	}
 	return tv
-}
-
-func getIndexValue(ruleIndex *partition.IndexRuleLocator, tagFamilies []tagValues) *tagValue {
-	if len(ruleIndex.TagIndices) != 1 {
-		logger.Panicf("the index rule %s(%v) didn't support composited tags",
-			ruleIndex.Rule.Metadata.Name, ruleIndex.Rule.Tags)
-	}
-	tIndex := ruleIndex.TagIndices[0]
-	if tIndex.FamilyOffset >= len(tagFamilies) {
-		return nil
-	}
-	tf := tagFamilies[tIndex.FamilyOffset]
-	if tIndex.TagOffset >= len(tf.values) {
-		return nil
-	}
-	return tf.values[tIndex.TagOffset]
 }

--- a/banyand/stream/write.go
+++ b/banyand/stream/write.go
@@ -222,12 +222,10 @@ func (w *writeCallback) Rev(message bus.Message) (resp bus.Message) {
 			es := g.tables[j]
 			es.tsTable.Table().mustAddElements(&es.elements)
 			if len(es.docs) > 0 {
-				go func() {
-					index := es.tsTable.Table().Index()
-					if err := index.Write(es.docs); err != nil {
-						w.l.Error().Err(err).Msg("cannot write element index")
-					}
-				}()
+				index := es.tsTable.Table().Index()
+				if err := index.Write(es.docs); err != nil {
+					w.l.Error().Err(err).Msg("cannot write element index")
+				}
 			}
 			es.tsTable.DecRef()
 		}

--- a/pkg/index/index.go
+++ b/pkg/index/index.go
@@ -164,7 +164,7 @@ func (r RangeOpts) Between(value []byte) int {
 // FieldIterator allows iterating over a field's posting values.
 type FieldIterator interface {
 	Next() bool
-	Val() uint64
+	Val() (uint64, common.SeriesID)
 	Close() error
 }
 
@@ -177,8 +177,8 @@ func (i *dummyIterator) Next() bool {
 	return false
 }
 
-func (i *dummyIterator) Val() uint64 {
-	return 0
+func (i *dummyIterator) Val() (uint64, common.SeriesID) {
+	return 0, 0
 }
 
 func (i *dummyIterator) Close() error {
@@ -210,6 +210,7 @@ type Writer interface {
 // FieldIterable allows building a FieldIterator.
 type FieldIterable interface {
 	Iterator(fieldKey FieldKey, termRange RangeOpts, order modelv1.Sort, preLoadSize int) (iter FieldIterator, err error)
+	Sort(sids []common.SeriesID, fieldKey FieldKey, order modelv1.Sort, preLoadSize int) (FieldIterator, error)
 }
 
 // Searcher allows searching a field either by its key or by its key and term.

--- a/pkg/index/index.go
+++ b/pkg/index/index.go
@@ -187,9 +187,8 @@ func (i *dummyIterator) Close() error {
 
 // PostingValue is the collection of a field's values.
 type PostingValue struct {
-	Value   posting.List
-	Term    []byte
-	TermRaw []byte
+	Value posting.List
+	Term  []byte
 }
 
 // Document represents a document in a index.

--- a/pkg/index/index.go
+++ b/pkg/index/index.go
@@ -164,7 +164,7 @@ func (r RangeOpts) Between(value []byte) int {
 // FieldIterator allows iterating over a field's posting values.
 type FieldIterator interface {
 	Next() bool
-	Val() *PostingValue
+	Val() uint64
 	Close() error
 }
 
@@ -177,18 +177,12 @@ func (i *dummyIterator) Next() bool {
 	return false
 }
 
-func (i *dummyIterator) Val() *PostingValue {
-	return nil
+func (i *dummyIterator) Val() uint64 {
+	return 0
 }
 
 func (i *dummyIterator) Close() error {
 	return nil
-}
-
-// PostingValue is the collection of a field's values.
-type PostingValue struct {
-	Value posting.List
-	Term  []byte
 }
 
 // Document represents a document in a index.

--- a/pkg/index/inverted/inverted.go
+++ b/pkg/index/inverted/inverted.go
@@ -37,7 +37,6 @@ import (
 
 	databasev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
 	modelv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/model/v1"
-	pbytes "github.com/apache/skywalking-banyandb/pkg/bytes"
 	"github.com/apache/skywalking-banyandb/pkg/convert"
 	"github.com/apache/skywalking-banyandb/pkg/index"
 	"github.com/apache/skywalking-banyandb/pkg/index/posting"
@@ -178,7 +177,6 @@ func (s *store) Iterator(fieldKey index.FieldKey, termRange index.RangeOpts, ord
 	}
 	fk := fieldKey.MarshalIndexRule()
 	var query bluge.Query
-	shouldDecodeTerm := true
 	if fieldKey.Analyzer == databasev1.IndexRule_ANALYZER_UNSPECIFIED {
 		query = bluge.NewTermRangeInclusiveQuery(
 			index.FieldStr(fieldKey, termRange.Lower),
@@ -188,7 +186,6 @@ func (s *store) Iterator(fieldKey index.FieldKey, termRange index.RangeOpts, ord
 		).
 			SetField(fk)
 	} else {
-		shouldDecodeTerm = false
 		bQuery := bluge.NewBooleanQuery().
 			AddMust(bluge.NewTermRangeInclusiveQuery(
 				string(termRange.Lower),
@@ -208,12 +205,10 @@ func (s *store) Iterator(fieldKey index.FieldKey, termRange index.RangeOpts, ord
 		sortedKey = "-" + sortedKey
 	}
 	result := &sortIterator{
-		query:            query,
-		reader:           reader,
-		sortedKey:        sortedKey,
-		fk:               fk,
-		shouldDecodeTerm: shouldDecodeTerm,
-		size:             preLoadSize,
+		query:     query,
+		reader:    reader,
+		sortedKey: sortedKey,
+		size:      preLoadSize,
 	}
 	return result, nil
 }
@@ -229,11 +224,9 @@ func (s *store) MatchTerms(field index.Field) (list posting.List, err error) {
 	}
 	fk := field.Key.MarshalIndexRule()
 	var query bluge.Query
-	shouldDecodeTerm := true
 	if field.Key.Analyzer == databasev1.IndexRule_ANALYZER_UNSPECIFIED {
 		query = bluge.NewTermQuery(string(field.Marshal())).SetField(fk)
 	} else {
-		shouldDecodeTerm = false
 		bQuery := bluge.NewBooleanQuery().
 			AddMust(bluge.NewTermQuery(string(field.Term)).SetField(fk))
 		if field.Key.HasSeriesID() {
@@ -245,13 +238,13 @@ func (s *store) MatchTerms(field index.Field) (list posting.List, err error) {
 	if err != nil {
 		return nil, err
 	}
-	iter := newBlugeMatchIterator(documentMatchIterator, fk, shouldDecodeTerm, reader)
+	iter := newBlugeMatchIterator(documentMatchIterator, reader)
 	defer func() {
 		err = multierr.Append(err, iter.Close())
 	}()
 	list = roaring.NewPostingList()
 	for iter.Next() {
-		err = multierr.Append(err, list.Union(iter.Val().Value))
+		list.Insert(iter.Val())
 	}
 	return list, err
 }
@@ -278,13 +271,13 @@ func (s *store) Match(fieldKey index.FieldKey, matches []string) (posting.List, 
 	if err != nil {
 		return nil, err
 	}
-	iter := newBlugeMatchIterator(documentMatchIterator, fk, false, reader)
+	iter := newBlugeMatchIterator(documentMatchIterator, reader)
 	defer func() {
 		err = multierr.Append(err, iter.Close())
 	}()
 	list := roaring.NewPostingList()
 	for iter.Next() {
-		err = multierr.Append(err, list.Union(iter.Val().Value))
+		list.Insert(iter.Val())
 	}
 	return list, err
 }
@@ -296,7 +289,7 @@ func (s *store) Range(fieldKey index.FieldKey, opts index.RangeOpts) (list posti
 	}
 	list = roaring.NewPostingList()
 	for iter.Next() {
-		err = multierr.Append(err, list.Union(iter.Val().Value))
+		list.Insert(iter.Val())
 	}
 	err = multierr.Append(err, iter.Close())
 	return
@@ -372,10 +365,10 @@ func (s *store) run() {
 						toAddSeriesIDField := false
 						for _, f := range d.Fields {
 							if f.Key.Analyzer == databasev1.IndexRule_ANALYZER_UNSPECIFIED {
-								doc.AddField(bluge.NewKeywordFieldBytes(f.Key.MarshalIndexRule(), f.Marshal()).StoreValue().Sortable())
+								doc.AddField(bluge.NewKeywordFieldBytes(f.Key.MarshalIndexRule(), f.Marshal()).Sortable())
 							} else {
 								toAddSeriesIDField = true
-								doc.AddField(bluge.NewKeywordFieldBytes(f.Key.MarshalIndexRule(), f.Term).StoreValue().Sortable().
+								doc.AddField(bluge.NewKeywordFieldBytes(f.Key.MarshalIndexRule(), f.Term).Sortable().
 									WithAnalyzer(analyzers[f.Key.Analyzer]))
 							}
 						}
@@ -419,113 +412,57 @@ func (s *store) flush() {
 }
 
 type blugeMatchIterator struct {
-	delegated        search.DocumentMatchIterator
-	err              error
-	closer           io.Closer
-	current          *index.PostingValue
-	agg              *index.PostingValue
-	fieldKey         string
-	shouldDecodeTerm bool
-	closed           bool
+	delegated search.DocumentMatchIterator
+	err       error
+	closer    io.Closer
+	docID     uint64
 }
 
-func newBlugeMatchIterator(delegated search.DocumentMatchIterator, fieldKey string, shouldDecodeTerm bool, closer io.Closer) blugeMatchIterator {
+func newBlugeMatchIterator(delegated search.DocumentMatchIterator, closer io.Closer) blugeMatchIterator {
 	return blugeMatchIterator{
-		delegated:        delegated,
-		fieldKey:         fieldKey,
-		shouldDecodeTerm: shouldDecodeTerm,
-		closer:           closer,
+		delegated: delegated,
+		closer:    closer,
 	}
 }
 
 func (bmi *blugeMatchIterator) Next() bool {
-	if bmi.err != nil || bmi.closed {
-		return false
-	}
-	//revive:disable:empty-block
-	for bmi.nextTerm() {
-	}
-	//revive:enable:empty-block
-	if bmi.err != nil || bmi.closed {
-		return false
-	}
-	return true
-}
-
-func (bmi *blugeMatchIterator) nextTerm() bool {
 	var match *search.DocumentMatch
 	match, bmi.err = bmi.delegated.Next()
 	if bmi.err != nil {
 		return false
 	}
 	if match == nil {
-		if bmi.agg == nil {
-			bmi.closed = true
-		} else {
-			bmi.current = bmi.agg
-			bmi.agg = nil
-		}
+		bmi.err = io.EOF
 		return false
 	}
-	i := 0
-	var docID uint64
-	var term []byte
 	bmi.err = match.VisitStoredFields(func(field string, value []byte) bool {
 		if field == docIDField {
 			if len(value) == 8 {
-				docID = convert.BytesToUint64(value)
+				bmi.docID = convert.BytesToUint64(value)
 			} else if len(value) == 16 {
 				// value = seriesID(8bytes)+docID(8bytes)
-				docID = convert.BytesToUint64(value[8:])
+				bmi.docID = convert.BytesToUint64(value[8:])
 			}
-			i++
 		}
-		if field == bmi.fieldKey {
-			v := pbytes.Copy(value)
-			if bmi.shouldDecodeTerm {
-				term = index.UnmarshalTerm(v)
-			} else {
-				term = v
-			}
-			i++
-		}
-		return i < 2
+		return true
 	})
-	if i != 2 {
-		// ignore invalid data
-		// TODO: add metric to cumulate ignored docs
-		return true
-	}
-	if bmi.err != nil {
-		return false
-	}
-	if bmi.agg == nil {
-		bmi.agg = &index.PostingValue{
-			Term:  term,
-			Value: roaring.NewPostingListWithInitialData(docID),
-		}
-		return true
-	}
-	if bytes.Equal(bmi.agg.Term, term) {
-		bmi.agg.Value.Insert(docID)
-		return true
-	}
-	bmi.current = bmi.agg
-	bmi.agg = &index.PostingValue{
-		Term:  term,
-		Value: roaring.NewPostingListWithInitialData(docID),
-	}
-	return false
+	return bmi.err == nil
 }
 
-func (bmi *blugeMatchIterator) Val() *index.PostingValue {
-	return bmi.current
+func (bmi *blugeMatchIterator) Val() uint64 {
+	return bmi.docID
 }
 
 func (bmi *blugeMatchIterator) Close() error {
-	bmi.closed = true
 	if bmi.closer == nil {
+		if errors.Is(bmi.err, io.EOF) {
+			return nil
+		}
 		return bmi.err
+	}
+	err := bmi.closer.Close()
+	if errors.Is(bmi.err, io.EOF) {
+		return err
 	}
 	return errors.Join(bmi.err, bmi.closer.Close())
 }

--- a/pkg/index/inverted/inverted_test.go
+++ b/pkg/index/inverted/inverted_test.go
@@ -53,12 +53,7 @@ func TestStore_Match(t *testing.T) {
 		SeriesID:    common.SeriesID(11),
 		Analyzer:    databasev1.IndexRule_ANALYZER_SIMPLE,
 	}
-	setup(tester, s, serviceName, index.FieldKey{
-		// http_method
-		IndexRuleID: 6,
-		SeriesID:    common.SeriesID(1),
-		Analyzer:    databasev1.IndexRule_ANALYZER_SIMPLE,
-	})
+	setup(tester, s, serviceName)
 
 	tests := []struct {
 		want    posting.List
@@ -154,7 +149,7 @@ func TestStore_SeriesMatch(t *testing.T) {
 		IndexRuleID: 6,
 		Analyzer:    databasev1.IndexRule_ANALYZER_SIMPLE,
 	}
-	setup(tester, s, serviceName, serviceName)
+	setupSeries(tester, s, serviceName)
 
 	tests := []struct {
 		want    posting.List
@@ -189,7 +184,7 @@ func TestStore_SeriesMatch(t *testing.T) {
 	}
 }
 
-func setup(tester *assert.Assertions, s index.Store, serviceName, serviceName1 index.FieldKey) {
+func setup(tester *assert.Assertions, s index.Store, serviceName index.FieldKey) {
 	tester.NoError(s.Write([]index.Field{{
 		Key:  serviceName,
 		Term: []byte("GET::/product/order"),
@@ -203,16 +198,19 @@ func setup(tester *assert.Assertions, s index.Store, serviceName, serviceName1 i
 		Term: []byte("org.apache.skywalking.examples.OrderService.order"),
 	}}, 3))
 	s.(*store).flush()
+}
+
+func setupSeries(tester *assert.Assertions, s index.Store, serviceName index.FieldKey) {
 	tester.NoError(s.Write([]index.Field{{
-		Key:  serviceName1,
+		Key:  serviceName,
 		Term: []byte("test.a"),
 	}}, 1))
 	tester.NoError(s.Write([]index.Field{{
-		Key:  serviceName1,
+		Key:  serviceName,
 		Term: []byte("test.b"),
 	}}, 2))
 	tester.NoError(s.Write([]index.Field{{
-		Key:  serviceName1,
+		Key:  serviceName,
 		Term: []byte("test.c"),
 	}}, 3))
 	s.(*store).flush()

--- a/pkg/index/inverted/sort.go
+++ b/pkg/index/inverted/sort.go
@@ -25,20 +25,16 @@ import (
 	"math"
 
 	"github.com/blugelabs/bluge"
-
-	"github.com/apache/skywalking-banyandb/pkg/index"
 )
 
 type sortIterator struct {
-	query            bluge.Query
-	err              error
-	reader           *bluge.Reader
-	current          *blugeMatchIterator
-	sortedKey        string
-	fk               string
-	size             int
-	skipped          int
-	shouldDecodeTerm bool
+	query     bluge.Query
+	err       error
+	reader    *bluge.Reader
+	current   *blugeMatchIterator
+	sortedKey string
+	size      int
+	skipped   int
 }
 
 func (si *sortIterator) Next() bool {
@@ -73,7 +69,7 @@ func (si *sortIterator) loadCurrent() bool {
 		return false
 	}
 
-	iter := newBlugeMatchIterator(documentMatchIterator, si.fk, si.shouldDecodeTerm, nil)
+	iter := newBlugeMatchIterator(documentMatchIterator, nil)
 	si.current = &iter
 	if si.next() {
 		return true
@@ -84,13 +80,13 @@ func (si *sortIterator) loadCurrent() bool {
 
 func (si *sortIterator) next() bool {
 	if si.current.Next() {
-		si.skipped += si.current.Val().Value.Len()
+		si.skipped++
 		return true
 	}
 	return false
 }
 
-func (si *sortIterator) Val() *index.PostingValue {
+func (si *sortIterator) Val() uint64 {
 	return si.current.Val()
 }
 

--- a/pkg/index/inverted/sort_test.go
+++ b/pkg/index/inverted/sort_test.go
@@ -1,0 +1,226 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package inverted
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/apache/skywalking-banyandb/api/common"
+	modelv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/model/v1"
+	"github.com/apache/skywalking-banyandb/pkg/convert"
+	"github.com/apache/skywalking-banyandb/pkg/index"
+	"github.com/apache/skywalking-banyandb/pkg/index/posting"
+	"github.com/apache/skywalking-banyandb/pkg/index/posting/roaring"
+	"github.com/apache/skywalking-banyandb/pkg/logger"
+)
+
+const indexRuleID = 3
+
+func TestStore_Sort(t *testing.T) {
+	tester := assert.New(t)
+	path, fn := setUp(require.New(t))
+	s, err := NewStore(StoreOpts{
+		Path:   path,
+		Logger: logger.GetLogger("test"),
+	})
+	defer func() {
+		tester.NoError(s.Close())
+		fn()
+	}()
+	tester.NoError(err)
+	data := setUpDuration(require.New(t), s)
+	s.(*store).flush()
+
+	tests := []struct {
+		name string
+		want []int
+		args args
+	}{
+		{
+			name: "sort all in asc order",
+			args: args{
+				orderType: modelv1.Sort_SORT_ASC,
+			},
+			want: []int{50, 200, 500, 1000, 2000},
+		},
+		{
+			name: "sort all in desc order",
+			args: args{
+				orderType: modelv1.Sort_SORT_DESC,
+			},
+			want: []int{2000, 1000, 500, 200, 50},
+		},
+		{
+			name: "sort all in asc order with sids",
+			args: args{
+				sids:      []common.SeriesID{1, 2},
+				orderType: modelv1.Sort_SORT_ASC,
+			},
+			want: []int{50, 200, 500, 1000, 2000},
+		},
+		{
+			name: "sort all in desc order with sids",
+			args: args{
+				sids:      []common.SeriesID{1, 2},
+				orderType: modelv1.Sort_SORT_DESC,
+			},
+			want: []int{2000, 1000, 500, 200, 50},
+		},
+		{
+			name: "sort sid 1 in asc order",
+			args: args{
+				sids:      []common.SeriesID{1},
+				orderType: modelv1.Sort_SORT_ASC,
+			},
+			want: []int{50, 500, 2000},
+		},
+		{
+			name: "sort sid 2 in asc order",
+			args: args{
+				sids:      []common.SeriesID{2},
+				orderType: modelv1.Sort_SORT_ASC,
+			},
+			want: []int{200, 1000},
+		},
+		{
+			name: "sort sid 1 in desc order",
+			args: args{
+				sids:      []common.SeriesID{1},
+				orderType: modelv1.Sort_SORT_DESC,
+			},
+			want: []int{2000, 500, 50},
+		},
+		{
+			name: "sort sid 2 in desc order",
+			args: args{
+				sids:      []common.SeriesID{2},
+				orderType: modelv1.Sort_SORT_DESC,
+			},
+			want: []int{1000, 200},
+		},
+
+		{
+			name: "default order",
+			args: args{},
+			want: []int{50, 200, 500, 1000, 2000},
+		},
+	}
+	preLoadSizes := []int{7, 20, 50}
+	allTests := make([]struct {
+		name        string
+		want        []int
+		args        args
+		preloadSize int
+	}, 0, len(tests)*len(preLoadSizes))
+
+	for _, size := range preLoadSizes {
+		for _, t := range tests {
+			allTests = append(allTests, struct {
+				name        string
+				want        []int
+				args        args
+				preloadSize int
+			}{
+				name:        t.name + " preLoadSize " + fmt.Sprint(size),
+				want:        t.want,
+				preloadSize: size,
+				args:        t.args,
+			})
+		}
+	}
+	for _, tt := range allTests {
+		t.Run(tt.name, func(t *testing.T) {
+			tester := assert.New(t)
+			is := require.New(t)
+			iter, err := s.Sort(tt.args.sids, index.FieldKey{IndexRuleID: indexRuleID}, tt.args.orderType, tt.preloadSize)
+			is.NoError(err)
+			if iter == nil {
+				tester.Empty(tt.want)
+				return
+			}
+			defer func() {
+				tester.NoError(iter.Close())
+				for i := 0; i < 10; i++ {
+					is.False(iter.Next())
+				}
+			}()
+			is.NotNil(iter)
+			var got result
+			for iter.Next() {
+				docID, _ := iter.Val()
+				got.items = append(got.items, docID)
+			}
+			for i := 0; i < 10; i++ {
+				is.False(iter.Next())
+			}
+			var wants result
+			for _, w := range tt.want {
+				pl := data[w]
+				wants.items = append(wants.items, pl.ToSlice()...)
+			}
+			tester.Equal(wants, got, tt.name)
+		})
+	}
+}
+
+type args struct {
+	sids      []common.SeriesID
+	orderType modelv1.Sort
+}
+
+type result struct {
+	items []uint64
+}
+
+func setUpDuration(t *require.Assertions, store index.Writer) map[int]posting.List {
+	r := map[int]posting.List{
+		50:   roaring.NewPostingList(),
+		200:  roaring.NewPostingList(),
+		500:  roaring.NewPostingList(),
+		1000: roaring.NewPostingList(),
+		2000: roaring.NewPostingList(),
+	}
+	idx := make([]int, 0, len(r))
+	for key := range r {
+		idx = append(idx, key)
+	}
+	sort.Ints(idx)
+	for i := 100; i < 200; i++ {
+		id := uint64(i)
+		for i2, term := range idx {
+			if i%len(idx) != i2 || r[term] == nil {
+				continue
+			}
+			sid := i2%2 + 1
+			t.NoError(store.Write([]index.Field{{
+				Key: index.FieldKey{
+					SeriesID:    common.SeriesID(sid),
+					IndexRuleID: indexRuleID,
+				},
+				Term: convert.Int64ToBytes(int64(term)),
+			}}, id))
+			r[term].Insert(id)
+		}
+	}
+	return r
+}

--- a/pkg/index/testcases/duration.go
+++ b/pkg/index/testcases/duration.go
@@ -34,6 +34,7 @@ import (
 )
 
 var duration = index.FieldKey{
+	SeriesID: 998,
 	// duration
 	IndexRuleID: 3,
 }
@@ -302,7 +303,8 @@ func RunDuration(t *testing.T, data map[int]posting.List, store SimpleStore) {
 			is.NotNil(iter)
 			var got result
 			for iter.Next() {
-				got.items = append(got.items, iter.Val())
+				docID, _ := iter.Val()
+				got.items = append(got.items, docID)
 			}
 			for i := 0; i < 10; i++ {
 				is.False(iter.Next())

--- a/pkg/index/testcases/duration.go
+++ b/pkg/index/testcases/duration.go
@@ -52,8 +52,7 @@ type args struct {
 }
 
 type result struct {
-	items []int
-	key   int
+	items []uint64
 }
 
 // RunDuration executes duration related cases.
@@ -301,47 +300,21 @@ func RunDuration(t *testing.T, data map[int]posting.List, store SimpleStore) {
 				}
 			}()
 			is.NotNil(iter)
-			got := make([]result, 0)
-			var currResult result
+			var got result
 			for iter.Next() {
-				key := int(convert.BytesToInt64(iter.Val().Term))
-				if currResult.key != key {
-					if currResult.key != 0 {
-						got = append(got, currResult)
-						currResult = result{}
-					}
-					currResult.key = key
-				}
-				currResult.items = append(currResult.items, toArray(iter.Val().Value)...)
-			}
-			if len(currResult.items) > 0 {
-				got = append(got, currResult)
+				got.items = append(got.items, iter.Val())
 			}
 			for i := 0; i < 10; i++ {
 				is.False(iter.Next())
 			}
-			wants := make([]result, 0, len(tt.want))
+			var wants result
 			for _, w := range tt.want {
-				wants = append(wants, result{
-					key:   w,
-					items: toArray(data[w]),
-				})
+				pl := data[w]
+				wants.items = append(wants.items, pl.ToSlice()...)
 			}
 			tester.Equal(wants, got, tt.name)
 		})
 	}
-}
-
-func toArray(list posting.List) []int {
-	ints := make([]int, 0, list.Len())
-	iter := list.Iterator()
-	defer func(iter posting.Iterator) {
-		_ = iter.Close()
-	}(iter)
-	for iter.Next() {
-		ints = append(ints, int(iter.Current()))
-	}
-	return ints
 }
 
 // SetUpDuration initializes data for testing duration related cases.

--- a/pkg/index/testcases/service_name.go
+++ b/pkg/index/testcases/service_name.go
@@ -28,6 +28,7 @@ import (
 )
 
 var serviceName = index.FieldKey{
+	SeriesID: 887,
 	// http_method
 	IndexRuleID: 6,
 }

--- a/pkg/pb/v1/series.go
+++ b/pkg/pb/v1/series.go
@@ -154,3 +154,12 @@ func (a SeriesList) ToList() posting.List {
 	}
 	return pl
 }
+
+// IDs returns the IDs of the SeriesList.
+func (a SeriesList) IDs() []common.SeriesID {
+	ids := make([]common.SeriesID, 0, len(a))
+	for _, v := range a {
+		ids = append(ids, v.ID)
+	}
+	return ids
+}

--- a/pkg/test/query/metric.go
+++ b/pkg/test/query/metric.go
@@ -1,0 +1,193 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package query
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path"
+	"sync"
+	"time"
+
+	"github.com/apache/skywalking-cli/pkg/graphql/metrics"
+	"github.com/apache/skywalking-cli/pkg/graphql/utils"
+	"github.com/urfave/cli/v2"
+	api "skywalking.apache.org/repo/goapi/query"
+)
+
+var (
+	isNormal   = true
+	serviceTpl = "g%d::service_0"
+)
+
+// ServiceList verifies the service list.
+func ServiceList(basePath string, timeout time.Duration, groupNum int, fs *flag.FlagSet) {
+	basePath = path.Join(basePath, "svc-list")
+	err := os.MkdirAll(basePath, 0o755)
+	if err != nil {
+		panic(err)
+	}
+	stopCh := make(chan struct{})
+	go func() {
+		time.Sleep(timeout)
+		close(stopCh)
+	}()
+	metricNames := []string{"service_sla", "service_cpm", "service_resp_time", "service_apdex"}
+	size := len(metricNames) * groupNum
+	header := make([]string, size)
+	for k, mName := range metricNames {
+		for i := 0; i < groupNum; i++ {
+			offset := k*groupNum + i
+			header[offset] = fmt.Sprintf("%s-%d", mName, i)
+		}
+	}
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		collect(basePath, func() ([]float64, error) {
+			data := make([]float64, size)
+			var subWg sync.WaitGroup
+			for k, mName := range metricNames {
+				for i := 0; i < groupNum; i++ {
+					offset := k*groupNum + i
+					svc := fmt.Sprintf(serviceTpl, i)
+					subWg.Add(1)
+					go func(mName, svc string) {
+						defer subWg.Done()
+						d, err := execute(mName, svc, "", fs)
+						if err != nil {
+							fmt.Printf("query metric %s %s error: %v \n", mName, svc, err)
+						}
+						data[offset] = d.Seconds()
+					}(mName, svc)
+				}
+			}
+			subWg.Wait()
+			return data, nil
+		}, 500*time.Millisecond, stopCh)
+		analyze(header, basePath)
+	}()
+	wg.Wait()
+}
+
+func execute(exp, svc, instance string, fs *flag.FlagSet) (time.Duration, error) {
+	ctx := cli.NewContext(cli.NewApp(), fs, nil)
+	entity := &api.Entity{
+		ServiceName:         &svc,
+		Normal:              &isNormal,
+		ServiceInstanceName: &instance,
+	}
+	duration := api.Duration{
+		Start: time.Now().Add(-30 * time.Minute).Format(utils.StepFormats[api.StepMinute]),
+		End:   time.Now().Format(utils.StepFormats[api.StepMinute]),
+		Step:  api.StepMinute,
+	}
+	start := time.Now()
+	result, err := metrics.Execute(ctx, exp, entity, duration)
+	elapsed := time.Since(start)
+	if err != nil {
+		return 0, err
+	}
+	if len(result.Results) < 1 {
+		return 0, fmt.Errorf("no result")
+	}
+	return elapsed, nil
+}
+
+// TopN verifies the top N.
+func TopN(basePath string, timeout time.Duration, groupNum int, fs *flag.FlagSet) {
+	basePath = path.Join(basePath, "topn")
+	err := os.MkdirAll(basePath, 0o755)
+	if err != nil {
+		panic(err)
+	}
+	stopCh := make(chan struct{})
+	go func() {
+		time.Sleep(timeout)
+		close(stopCh)
+	}()
+	metricNames := []string{"service_instance_resp_time", "service_instance_cpm"}
+	size := len(metricNames) * groupNum
+	header := make([]string, size)
+	for k, mName := range metricNames {
+		for i := 0; i < groupNum; i++ {
+			offset := k*groupNum + i
+			header[offset] = fmt.Sprintf("%s-%d", mName, i)
+		}
+	}
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		collect(basePath, func() ([]float64, error) {
+			data := make([]float64, size)
+			var subWg sync.WaitGroup
+			for k, mName := range metricNames {
+				for i := 0; i < groupNum; i++ {
+					offset := k*groupNum + i
+					svc := fmt.Sprintf(serviceTpl, i)
+					subWg.Add(1)
+					go func(mName, svc string) {
+						defer subWg.Done()
+						d, err := sortMetrics(mName, svc, 5, api.OrderDes, fs)
+						if err != nil {
+							data[offset] = -1
+							fmt.Printf("query metric %s %s error: %v \n", mName, svc, err)
+						} else {
+							data[offset] = d.Seconds()
+						}
+					}(mName, svc)
+				}
+			}
+			subWg.Wait()
+			return data, nil
+		}, 500*time.Millisecond, stopCh)
+		analyze(header, basePath)
+	}()
+	wg.Wait()
+}
+
+func sortMetrics(name, svc string, limit int, order api.Order, fs *flag.FlagSet) (time.Duration, error) {
+	ctx := cli.NewContext(cli.NewApp(), fs, nil)
+	duration := api.Duration{
+		Start: time.Now().Add(-30 * time.Minute).Format(utils.StepFormats[api.StepMinute]),
+		End:   time.Now().Format(utils.StepFormats[api.StepMinute]),
+		Step:  api.StepMinute,
+	}
+	scope := api.ScopeServiceInstance
+	cond := api.TopNCondition{
+		Name:          name,
+		ParentService: &svc,
+		Normal:        &isNormal,
+		Scope:         &scope,
+		TopN:          limit,
+		Order:         order,
+	}
+	start := time.Now()
+	result, err := metrics.SortMetrics(ctx, cond, duration)
+	elapsed := time.Since(start)
+	if err != nil {
+		return 0, err
+	}
+	if len(result) < 1 {
+		return 0, fmt.Errorf("no result")
+	}
+	return elapsed, nil
+}

--- a/pkg/test/query/trace.go
+++ b/pkg/test/query/trace.go
@@ -48,7 +48,7 @@ func TraceListOrderByDuration(basePath string, timeout time.Duration, fs *flag.F
 			return nil, err
 		}
 		return []float64{d.Seconds()}, nil
-	}, 500*time.Millisecond, stopCh)
+	}, time.Second, stopCh)
 	analyze([]string{"result"}, basePath)
 }
 
@@ -70,7 +70,7 @@ func TraceListOrderByTime(basePath string, timeout time.Duration, fs *flag.FlagS
 			return nil, err
 		}
 		return []float64{d.Seconds()}, nil
-	}, 500*time.Millisecond, stopCh)
+	}, time.Second, stopCh)
 	analyze([]string{"result"}, basePath)
 }
 

--- a/pkg/test/query/trace.go
+++ b/pkg/test/query/trace.go
@@ -87,7 +87,7 @@ func TraceByID(basePath string, timeout time.Duration, fs *flag.FlagSet) {
 		close(stopCh)
 	}()
 	collect(basePath, func() ([]float64, error) {
-		d, err := traceByID(api.QueryOrderByDuration, fs)
+		d, err := traceByID(api.QueryOrderByStartTime, fs)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/timestamp/range.go
+++ b/pkg/timestamp/range.go
@@ -30,8 +30,8 @@ type TimeRange struct {
 }
 
 // Contains returns whether the unixNano is in the TimeRange.
-func (t TimeRange) Contains(unixNano uint64) bool {
-	tp := time.Unix(0, int64(unixNano))
+func (t TimeRange) Contains(unixNano int64) bool {
+	tp := time.Unix(0, unixNano)
 	if t.Start.Equal(tp) {
 		return t.IncludeStart
 	}

--- a/test/cases/stream/data/input/sort_filter.yaml
+++ b/test/cases/stream/data/input/sort_filter.yaml
@@ -1,0 +1,36 @@
+# Licensed to Apache Software Foundation (ASF) under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Apache Software Foundation (ASF) licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+metadata:
+  group: "default"
+  name: "sw"
+projection:
+  tagFamilies:
+  - name: "searchable"
+    tags: ["trace_id", "duration"]
+  - name: "data"
+    tags: ["data_binary"]
+criteria:
+  condition:
+    name: "duration"
+    op: "BINARY_OP_LT"
+    value:
+      int:
+        value: 500
+orderBy:
+  indexRuleName: "duration"
+  sort: "SORT_DESC"

--- a/test/cases/stream/data/want/sort_filter.yaml
+++ b/test/cases/stream/data/want/sort_filter.yaml
@@ -1,0 +1,52 @@
+elements:
+  - elementId: "4"
+    tagFamilies:
+    - name: searchable
+      tags:
+      - key: trace_id
+        value:
+          str:
+            value: "5"
+      - key: duration
+        value:
+          int:
+            value: "300"
+    - name: data
+      tags:
+      - key: data_binary
+        value:
+          binaryData: YWJjMTIzIT8kKiYoKSctPUB+
+  - elementId: "3"
+    tagFamilies:
+    - name: searchable
+      tags:
+      - key: trace_id
+        value:
+          str:
+            value: "4"
+      - key: duration
+        value:
+          int:
+            value: "60"
+    - name: data
+      tags:
+      - key: data_binary
+        value:
+          binaryData: YWJjMTIzIT8kKiYoKSctPUB+
+  - elementId: "2"
+    tagFamilies:
+    - name: searchable
+      tags:
+      - key: trace_id
+        value:
+          str:
+            value: "3"
+      - key: duration
+        value:
+          int:
+            value: "30"
+    - name: data
+      tags:
+      - key: data_binary
+        value:
+          binaryData: YWJjMTIzIT8kKiYoKSctPUB+

--- a/test/cases/stream/data/want/sort_filter.yaml
+++ b/test/cases/stream/data/want/sort_filter.yaml
@@ -1,3 +1,20 @@
+# Licensed to Apache Software Foundation (ASF) under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Apache Software Foundation (ASF) licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 elements:
   - elementId: "4"
     tagFamilies:

--- a/test/cases/stream/stream.go
+++ b/test/cases/stream/stream.go
@@ -61,6 +61,7 @@ var _ = g.DescribeTable("Scanning Streams", func(args helpers.Args) {
 		End:   timestamppb.New(time.Unix(0, math.MaxInt64).Truncate(time.Millisecond)),
 	}),
 	g.Entry("sort desc", helpers.Args{Input: "sort_desc", Duration: 1 * time.Hour}),
+	g.Entry("sort with filter", helpers.Args{Input: "sort_filter", Duration: 1 * time.Hour}),
 	g.Entry("global index", helpers.Args{Input: "global_index", Duration: 1 * time.Hour}),
 	g.Entry("multi-global index", helpers.Args{Input: "global_indices", Duration: 1 * time.Hour}),
 	g.Entry("filter by non-indexed tag", helpers.Args{Input: "filter_tag", Duration: 1 * time.Hour}),

--- a/test/docker/base-compose.yml
+++ b/test/docker/base-compose.yml
@@ -20,11 +20,11 @@ services:
       - 2121
       - 6060
     command: standalone
-    healthcheck:
-      test: ["CMD", "./bydbctl", "health", "--config=-", "--addr=http://banyandb:17913"]
-      interval: 5s
-      timeout: 10s
-      retries: 120
+    # healthcheck:
+    #   test: ["CMD", "./bydbctl", "health", "--config=-", "--addr=http://banyandb:17913"]
+    #   interval: 30s
+    #   timeout: 30s
+    #   retries: 120
 
   liaison:
     hostname: liaison
@@ -35,8 +35,8 @@ services:
     command: liaison --etcd-endpoints=http://etcd:2379 
     healthcheck:
       test: ["CMD", "./bydbctl", "health", "--addr=http://liaison:17913"]
-      interval: 5s
-      timeout: 10s
+      interval: 30s
+      timeout: 30s
       retries: 120
   
   data:
@@ -48,8 +48,8 @@ services:
     command: data --etcd-endpoints=http://etcd:2379 
     healthcheck:
       test: ["CMD", "./bydbctl", "health", "--grpc-addr=data:17912"]
-      interval: 5s
-      timeout: 10s
+      interval: 30s
+      timeout: 30s
       retries: 120
   
   agent:

--- a/test/docker/base-compose.yml
+++ b/test/docker/base-compose.yml
@@ -20,11 +20,11 @@ services:
       - 2121
       - 6060
     command: standalone
-    # healthcheck:
-    #   test: ["CMD", "./bydbctl", "health", "--config=-", "--addr=http://banyandb:17913"]
-    #   interval: 30s
-    #   timeout: 30s
-    #   retries: 120
+    healthcheck:
+      test: ["CMD", "./bydbctl", "health", "--config=-", "--addr=http://banyandb:17913"]
+      interval: 30s
+      timeout: 30s
+      retries: 120
 
   liaison:
     hostname: liaison

--- a/test/stress/trace/Makefile
+++ b/test/stress/trace/Makefile
@@ -37,6 +37,10 @@ SIZE ?= 2
 
 QPS ?= 10
 
+GROUP ?= "default"
+
+GINKGO_FLAGS ?=
+
 .PHONY: clean
 clean:
 	rm -rf /tmp/banyandb-stress-trace
@@ -49,11 +53,11 @@ down-%:
 
 .PHONY: test_traffic
 test_traffic:
-	curl -XPOST 'http://localhost:12800/mock-data/segments/tasks?size=$(SIZE)' -H'Content-Type: application/json' -d "@segment.tpl.json"
+	curl -XPOST 'http://localhost:12800/mock-data/segments/tasks?size=$(SIZE)&group=$(GROUP)' -H'Content-Type: application/json' -d "@segment.tpl.json"
 
 .PHONY: up_traffic
 up_traffic:
-	curl -XPOST 'http://localhost:12800/mock-data/segments/tasks?qps=$(QPS)' -H'Content-Type: application/json' -d "@segment.tpl.json"
+	curl -XPOST 'http://localhost:12800/mock-data/segments/tasks?qps=$(QPS)&group=$(GROUP)' -H'Content-Type: application/json' -d "@segment.tpl.json"
 
 .PHONY: ls_traffic
 ls_traffic:
@@ -65,5 +69,5 @@ rm_traffic:
 
 .PHONY: test_query
 test_query: $(GINKGO)
-	$(GINKGO) -v -timeout 1h TestQuery ./...
+	$(GINKGO) $(GINKGO_FLAGS) -p -v -timeout 2h TestQuery ./...
 	

--- a/test/stress/trace/docker-compose-cluster.yaml
+++ b/test/stress/trace/docker-compose-cluster.yaml
@@ -37,6 +37,37 @@ services:
           memory: 8G
     networks:
       - cluster-test
+  data1:
+    extends:
+      file: ../../docker/base-compose.yml
+      service: data
+    build:
+      dockerfile: ./docker/Dockerfile
+      context: ../../..
+    hostname: data1
+    deploy:
+      resources:
+        limits:
+          cpus: "4"
+          memory: 8G
+    networks:
+      - cluster-test
+
+  data2:
+    extends:
+      file: ../../docker/base-compose.yml
+      service: data
+    build:
+      dockerfile: ./docker/Dockerfile
+      context: ../../..
+    hostname: data2
+    deploy:
+      resources:
+        limits:
+          cpus: "4"
+          memory: 8G
+    networks:
+      - cluster-test
 
   liaison:
     extends:
@@ -62,6 +93,9 @@ services:
     environment:
       SW_STORAGE: banyandb
       SW_STORAGE_BANYANDB_TARGETS: "liaison:17912"
+      SW_STORAGE_BANYANDB_METRICS_SHARDS_NUMBER: "3"
+      SW_STORAGE_BANYANDB_RECORD_SHARDS_NUMBER: "3"
+      SW_STORAGE_BANYANDB_SUPERDATASET_SHARDS_FACTOR: "1"
     ports:
       - 12800:12800
     volumes:

--- a/test/stress/trace/docker-compose-cluster.yaml
+++ b/test/stress/trace/docker-compose-cluster.yaml
@@ -34,7 +34,7 @@ services:
       resources:
         limits:
           cpus: "4"
-          memory: 4G
+          memory: 8G
     networks:
       - cluster-test
 

--- a/test/stress/trace/docker-compose-single.yaml
+++ b/test/stress/trace/docker-compose-single.yaml
@@ -37,11 +37,11 @@ services:
     - 17913:17913
     - 6060:6060
     - 2121:2121
-    deploy:
-      resources:
-        limits:
-          cpus: "4"
-          memory: 4G
+    # deploy:
+    #   resources:
+    #     limits:
+    #       cpus: "4"
+    #       memory: 8G
     networks:
       - test
       - monitoring
@@ -63,9 +63,9 @@ services:
       - ./log4j2.xml:/skywalking/config/log4j2.xml
     networks:
       - test
-    depends_on:
-      banyandb:
-        condition: service_healthy
+    # depends_on:
+    #   banyandb:
+    #     condition: service_healthy
 
   prometheus:
     image: prom/prometheus:latest

--- a/test/stress/trace/docker-compose-single.yaml
+++ b/test/stress/trace/docker-compose-single.yaml
@@ -37,11 +37,11 @@ services:
     - 17913:17913
     - 6060:6060
     - 2121:2121
-    # deploy:
-    #   resources:
-    #     limits:
-    #       cpus: "4"
-    #       memory: 8G
+    deploy:
+      resources:
+        limits:
+          cpus: "4"
+          memory: 8G
     networks:
       - test
       - monitoring
@@ -63,9 +63,9 @@ services:
       - ./log4j2.xml:/skywalking/config/log4j2.xml
     networks:
       - test
-    # depends_on:
-    #   banyandb:
-    #     condition: service_healthy
+    depends_on:
+      banyandb:
+        condition: service_healthy
 
   prometheus:
     image: prom/prometheus:latest

--- a/test/stress/trace/trace_suite_test.go
+++ b/test/stress/trace/trace_suite_test.go
@@ -37,7 +37,7 @@ func TestIntegrationLoad(t *testing.T) {
 }
 
 var _ = Describe("Query", func() {
-	const timeout = 30 * time.Minute
+	const timeout = time.Hour
 	var (
 		fs       *flag.FlagSet
 		basePath string
@@ -45,14 +45,14 @@ var _ = Describe("Query", func() {
 
 	BeforeEach(func() {
 		// Check if the URL is reachable
-		resp, err := http.Get("http://localhost:12800/graphql")
-		if err != nil || resp.StatusCode != 200 {
+		_, err := http.Get("http://localhost:12800/graphql")
+		if err != nil {
 			// If the request fails or the status code is not 200, skip the test
 			Skip("http://localhost:12800/graphql is not reachable")
 		}
 		fs = flag.NewFlagSet("", flag.PanicOnError)
 		fs.String("base-url", "http://localhost:12800/graphql", "")
-		fs.String("service-id", "c2VydmljZV8x.1", "")
+		fs.String("service-id", "ZzE6OnNlcnZpY2VfMQ==.1", "")
 		_, basePath, _, _ = runtime.Caller(0)
 		basePath = path.Dir(basePath)
 	})
@@ -61,11 +61,19 @@ var _ = Describe("Query", func() {
 		query.TraceListOrderByDuration(basePath, timeout, fs)
 	})
 
-	It("TraceListOrderByTime", func() {
-		query.TraceListOrderByTime(basePath, timeout, fs)
-	})
+	// It("TraceListOrderByTime", func() {
+	// 	query.TraceListOrderByTime(basePath, timeout, fs)
+	// })
 
 	It("TraceByID", func() {
 		query.TraceByID(basePath, timeout, fs)
+	})
+
+	It("Metric", func() {
+		query.ServiceList(basePath, timeout, 6, fs)
+	})
+
+	It("TopN", func() {
+		query.TopN(basePath, timeout, 6, fs)
 	})
 })

--- a/test/stress/trace/trace_suite_test.go
+++ b/test/stress/trace/trace_suite_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Query", func() {
 		}
 		fs = flag.NewFlagSet("", flag.PanicOnError)
 		fs.String("base-url", "http://localhost:12800/graphql", "")
-		fs.String("service-id", "ZzE6OnNlcnZpY2VfMQ==.1", "")
+		fs.String("service-id", "ZzA6OnNlcnZpY2VfMQ==.1", "")
 		_, basePath, _, _ = runtime.Caller(0)
 		basePath = path.Dir(basePath)
 	})

--- a/test/stress/trace/trace_suite_test.go
+++ b/test/stress/trace/trace_suite_test.go
@@ -70,10 +70,10 @@ var _ = Describe("Query", func() {
 	})
 
 	It("Metric", func() {
-		query.ServiceList(basePath, timeout, 6, fs)
+		query.ServiceList(basePath, timeout, 1, fs)
 	})
 
 	It("TopN", func() {
-		query.TopN(basePath, timeout, 6, fs)
+		query.TopN(basePath, timeout, 1, fs)
 	})
 })


### PR DESCRIPTION
Fix several issues:

1. If no index data is generated, memory leaks can occur, causing the index writer to block the entire writing process.
2. Approximately 50% of the space can be saved by removing the term value from the inverted index.
3. The stream previously did not scan all block metadata when retrieving a single element from part. This has been fixed.
4. In the stream query process, instead of scanning each series separately, a single query sorts data.
5. Empty shards have been removed.