### PR TITLE
Patch metadata

### DIFF
--- a/banyand/measure/metadata.go
+++ b/banyand/measure/metadata.go
@@ -49,8 +49,8 @@ type schemaRepo struct {
 	metadata metadata.Repo
 }
 
-func newSchemaRepo(path string, svc *service) schemaRepo {
-	sr := schemaRepo{
+func newSchemaRepo(path string, svc *service) *schemaRepo {
+	sr := &schemaRepo{
 		l:        svc.l,
 		metadata: svc.metadata,
 		Repository: resourceSchema.NewRepository(

--- a/banyand/measure/service.go
+++ b/banyand/measure/service.go
@@ -53,7 +53,7 @@ type Service interface {
 var _ Service = (*service)(nil)
 
 type service struct {
-	schemaRepo    schemaRepo
+	schemaRepo    *schemaRepo
 	writeListener bus.MessageListener
 	metadata      metadata.Repo
 	pipeline      queue.Server
@@ -107,7 +107,7 @@ func (s *service) PreRun(_ context.Context) error {
 	s.schemaRepo = newSchemaRepo(path, s)
 	// run a serial watcher
 
-	s.writeListener = setUpWriteCallback(s.l, &s.schemaRepo)
+	s.writeListener = setUpWriteCallback(s.l, s.schemaRepo)
 	err := s.pipeline.Subscribe(data.TopicMeasureWrite, s.writeListener)
 	if err != nil {
 		return err

--- a/banyand/measure/write.go
+++ b/banyand/measure/write.go
@@ -102,7 +102,7 @@ func (w *writeCallback) handle(dst map[string]*dataPointsInGroup, writeEvent *me
 		return nil, fmt.Errorf("%s has no tag family", req.Metadata)
 	}
 	if fLen > len(stm.schema.GetTagFamilies()) {
-		return nil, fmt.Errorf("%s has more tag families than expected", req.Metadata)
+		return nil, fmt.Errorf("%s has more tag families than %s", req.Metadata, stm.schema)
 	}
 	series := &pbv1.Series{
 		Subject:      req.Metadata.Name,

--- a/banyand/stream/write.go
+++ b/banyand/stream/write.go
@@ -99,10 +99,10 @@ func (w *writeCallback) handle(dst map[string]*elementsInGroup, writeEvent *stre
 	}
 	fLen := len(req.Element.GetTagFamilies())
 	if fLen < 1 {
-		return nil, fmt.Errorf("%s has no tag family", req.Metadata)
+		return nil, fmt.Errorf("%s has no tag family", req)
 	}
 	if fLen > len(stm.schema.GetTagFamilies()) {
-		return nil, fmt.Errorf("%s has more tag families than expected", req.Metadata)
+		return nil, fmt.Errorf("%s has more tag families than %s", req.Metadata, stm.schema)
 	}
 	series := &pbv1.Series{
 		Subject:      req.Metadata.Name,

--- a/pkg/query/logical/index_filter.go
+++ b/pkg/query/logical/index_filter.go
@@ -102,6 +102,9 @@ func BuildLocalFilter(criteria *modelv1.Criteria, schema Schema, entityDict map[
 			and.append(left).append(right)
 			return and, entities, nil
 		case modelv1.LogicalExpression_LOGICAL_OP_OR:
+			if left == ENode || right == ENode {
+				return ENode, entities, nil
+			}
 			or := newOr(2)
 			or.append(left).append(right)
 			return or, entities, nil

--- a/pkg/schema/init.go
+++ b/pkg/schema/init.go
@@ -235,8 +235,7 @@ func (sr *schemaRepo) storeMeasure(m *databasev1.Measure, group *group, bindings
 	if aa, ok := aggMap[m.Metadata.GetName()]; ok {
 		topNAggr = append(topNAggr, aa...)
 	}
-	_, err := group.storeResource(m, indexRules, topNAggr)
-	if err != nil {
+	if err := sr.storeResource(group, m, indexRules, topNAggr); err != nil {
 		logger.Panicf("fails to store the measure: %v", err)
 	}
 }
@@ -267,8 +266,7 @@ func (sr *schemaRepo) storeStream(s *databasev1.Stream, group *group, bindings m
 			indexRules = append(indexRules, rules[r])
 		}
 	}
-	_, err := group.storeResource(s, indexRules, nil)
-	if err != nil {
+	if err := sr.storeResource(group, s, indexRules, nil); err != nil {
 		logger.Panicf("fails to store the stream: %v", err)
 	}
 }

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -49,7 +49,6 @@ const (
 // Group is the root node, allowing get resources from its sub nodes.
 type Group interface {
 	GetSchema() *commonv1.Group
-	LoadResource(name string) (Resource, bool)
 	SupplyTSDB() io.Closer
 }
 

--- a/test/cases/stream/data/input/filter_no_indexed_or.yaml
+++ b/test/cases/stream/data/input/filter_no_indexed_or.yaml
@@ -1,0 +1,53 @@
+# Licensed to Apache Software Foundation (ASF) under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Apache Software Foundation (ASF) licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: "sw"
+groups: ["default"]
+projection:
+  tagFamilies:
+  - name: "searchable"
+    tags: ["state", "trace_id", "span_id", "start_time"]
+criteria:
+  le:
+    op: "LOGICAL_OP_OR"
+    left:
+      condition:
+        name: "span_id"
+        op: "BINARY_OP_EQ"
+        value:
+          str:
+            value: "1"
+    right:
+      le:
+        op: "LOGICAL_OP_AND"
+        left:
+          condition:
+            name: "start_time"
+            op: "BINARY_OP_EQ"
+            value:
+              int:
+                value: 1622933202000000000
+        right:
+          le:
+            op: "LOGICAL_OP_AND"
+            left:
+              condition:
+                name: "state"
+                op: "BINARY_OP_EQ"
+                value:
+                  int:
+                    value: "0"

--- a/test/cases/stream/data/want/filter_no_indexed_or.yaml
+++ b/test/cases/stream/data/want/filter_no_indexed_or.yaml
@@ -1,0 +1,115 @@
+# Licensed to Apache Software Foundation (ASF) under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Apache Software Foundation (ASF) licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+elements:
+  - elementId: "0"
+    tagFamilies:
+    - name: searchable
+      tags:
+      - key: state
+        value:
+          int:
+            value: "1"
+      - key: trace_id
+        value:
+          str:
+            value: "1"
+      - key: span_id
+        value:
+          str:
+            value: "1"
+      - key: start_time
+        value:
+          int:
+            value: "1622933202000000000"
+  - elementId: "1"
+    tagFamilies:
+    - name: searchable
+      tags:
+      - key: state
+        value:
+          int:
+            value: "1"
+      - key: trace_id
+        value:
+          str:
+            value: "2"
+      - key: span_id
+        value:
+          str:
+            value: "1"
+      - key: start_time
+        value:
+          int:
+            value: "1622933202000000000"
+  - elementId: "2"
+    tagFamilies:
+    - name: searchable
+      tags:
+      - key: state
+        value:
+          int: {}
+      - key: trace_id
+        value:
+          str:
+            value: "3"
+      - key: span_id
+        value:
+          str:
+            value: "2"
+      - key: start_time
+        value:
+          int:
+            value: "1622933202000000000"
+  - elementId: "3"
+    tagFamilies:
+    - name: searchable
+      tags:
+      - key: state
+        value:
+          int: {}
+      - key: trace_id
+        value:
+          str:
+            value: "4"
+      - key: span_id
+        value:
+          str:
+            value: "2"
+      - key: start_time
+        value:
+          int:
+            value: "1622933202000000000"
+  - elementId: "4"
+    tagFamilies:
+    - name: searchable
+      tags:
+      - key: state
+        value:
+          int: {}
+      - key: trace_id
+        value:
+          str:
+            value: "5"
+      - key: span_id
+        value:
+          str:
+            value: "3"
+      - key: start_time
+        value:
+          int:
+            value: "1622933202000000000"

--- a/test/cases/stream/stream.go
+++ b/test/cases/stream/stream.go
@@ -75,4 +75,5 @@ var _ = g.DescribeTable("Scanning Streams", func(args helpers.Args) {
 	g.Entry("having non indexed array", helpers.Args{Input: "having_non_indexed_arr", Duration: 1 * time.Hour}),
 	g.Entry("full text searching", helpers.Args{Input: "search", Duration: 1 * time.Hour}),
 	g.Entry("indexed only tags", helpers.Args{Input: "indexed_only", Duration: 1 * time.Hour}),
+	g.Entry("filter by non-indexed tag with or", helpers.Args{Input: "filter_no_indexed_or", Duration: 1 * time.Hour}),
 )


### PR DESCRIPTION
Related to apache/skywalking#12219

From https://github.com/apache/skywalking/issues/12219#issuecomment-2109804745, we found that the schema cache is not synced correctly. After reviewing the codes, I found no explicit flaws. I tend to assume that it's the cache's hierarchy structure. 

In this patch, I flatten the cache structure by moving the resource cache from inside the group cache to the root. Furthermore, I opt to `sync.Map` for more reliable concurrent access to the cache.
