### PR TITLE
Add benchmarks for stream filtering and sorting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ Release Notes.
 
 ## 0.7.0
 
+- Add benchmarks for stream filtering and sorting.
+
 ### Features
 
 ### Bugs

--- a/banyand/stream/benchmark_test.go
+++ b/banyand/stream/benchmark_test.go
@@ -1,0 +1,467 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package stream
+
+import (
+	"context"
+	"io"
+	"math"
+	"math/rand"
+	"path/filepath"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/apache/skywalking-banyandb/api/common"
+	commonv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/common/v1"
+	databasev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
+	modelv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/model/v1"
+	"github.com/apache/skywalking-banyandb/banyand/internal/storage"
+	"github.com/apache/skywalking-banyandb/pkg/fs"
+	"github.com/apache/skywalking-banyandb/pkg/index"
+	"github.com/apache/skywalking-banyandb/pkg/index/posting"
+	"github.com/apache/skywalking-banyandb/pkg/index/posting/roaring"
+	"github.com/apache/skywalking-banyandb/pkg/logger"
+	pbv1 "github.com/apache/skywalking-banyandb/pkg/pb/v1"
+	"github.com/apache/skywalking-banyandb/pkg/test"
+	"github.com/apache/skywalking-banyandb/pkg/timestamp"
+)
+
+const (
+	segmentMetadataFilename = "metadata"
+	version                 = "1.0.0"
+)
+
+type parameter struct {
+	batchCount     int
+	timestampCount int
+	seriesCount    int
+	tagCardinality int
+	startTimestamp int
+	endTimestamp   int
+}
+
+type invertedIndex map[string]map[common.SeriesID]posting.List
+
+func (index invertedIndex) insert(value string, seriesID common.SeriesID, timestamp int) {
+	if _, ok := index[value]; !ok {
+		index[value] = make(map[common.SeriesID]posting.List)
+	}
+	if _, ok := index[value][seriesID]; !ok {
+		index[value][seriesID] = roaring.NewPostingList()
+	}
+	index[value][seriesID].Insert(uint64(timestamp))
+}
+
+type filter struct {
+	index invertedIndex
+	value string
+}
+
+func (f filter) String() string {
+	return "filter"
+}
+
+func (f filter) Execute(getSearcher index.GetSearcher, seriesID common.SeriesID) (posting.List, error) {
+	return f.index[f.value][seriesID], nil
+}
+
+type databaseSupplier struct {
+	database atomic.Value
+}
+
+func (dbs *databaseSupplier) SupplyTSDB() io.Closer {
+	if v := dbs.database.Load(); v != nil {
+		return v.(io.Closer)
+	}
+	return nil
+}
+
+func generateData(p parameter) ([]*elements, []index.Documents, invertedIndex) {
+	esList := make([]*elements, 0)
+	docsList := make([]index.Documents, 0)
+	idx := make(invertedIndex)
+	src := rand.NewSource(time.Now().UnixNano())
+	rng := rand.New(src)
+	for i := 0; i < p.batchCount; i++ {
+		es := &elements{
+			seriesIDs:   []common.SeriesID{},
+			timestamps:  []int64{},
+			elementIDs:  []string{},
+			tagFamilies: [][]tagValues{},
+		}
+		var docs index.Documents
+		for j := 1; j <= p.timestampCount; j++ {
+			timestamp := i*p.timestampCount + j
+			unixTimestamp := time.Unix(int64(timestamp), 0).UnixNano()
+			for k := 1; k <= p.seriesCount; k++ {
+				elementID := strconv.Itoa(k) + strconv.Itoa(timestamp)
+				es.seriesIDs = append(es.seriesIDs, common.SeriesID(k))
+				es.elementIDs = append(es.elementIDs, elementID)
+				es.timestamps = append(es.timestamps, unixTimestamp)
+				num := rng.Intn(p.tagCardinality) + 1
+				tf := tagValues{
+					tag: "benchmark-family",
+					values: []*tagValue{{
+						tag:       "entity-tag",
+						value:     []byte("entity" + strconv.Itoa(k)),
+						valueType: pbv1.ValueTypeStr,
+					}, {
+						tag:       "filter-tag",
+						value:     []byte("value" + strconv.Itoa(num)),
+						valueType: pbv1.ValueTypeStr,
+					}},
+				}
+				tfs := []tagValues{tf}
+				es.tagFamilies = append(es.tagFamilies, tfs)
+				idx.insert("value"+strconv.Itoa(num), common.SeriesID(k), int(unixTimestamp))
+				var fields []index.Field
+				fields = append(fields, index.Field{
+					Key: index.FieldKey{
+						IndexRuleID: 1,
+						SeriesID:    common.SeriesID(k),
+					},
+					Term: []byte("value" + strconv.Itoa(num)),
+				})
+				docs = append(docs, index.Document{
+					DocID:  uint64(unixTimestamp),
+					Fields: fields,
+				})
+			}
+		}
+		esList = append(esList, es)
+		docsList = append(docsList, docs)
+	}
+	return esList, docsList, idx
+}
+
+func openDatabase(b *testing.B, path string) storage.TSDB[*tsTable, option] {
+	ir := storage.IntervalRule{
+		Unit: storage.DAY,
+		Num:  1,
+	}
+	opts := storage.TSDBOpts[*tsTable, option]{
+		ShardNum:        1,
+		Location:        path,
+		TSTableCreator:  newTSTable,
+		SegmentInterval: ir,
+		TTL:             ir,
+	}
+	db, err := storage.OpenTSDB(
+		common.SetPosition(context.Background(), func(p common.Position) common.Position {
+			p.Module = "stream"
+			p.Database = "benchmark"
+			return p
+		}),
+		opts)
+	require.NoError(b, err)
+	return db
+}
+
+func generateStream(db storage.TSDB[*tsTable, option]) *stream {
+	dbSupplier := &databaseSupplier{
+		database: atomic.Value{},
+	}
+	dbSupplier.database.Store(db)
+	entity := &databasev1.Entity{
+		TagNames: []string{"entity-tag"},
+	}
+	tagFamily := &databasev1.TagFamilySpec{
+		Name: "benchmark-family",
+		Tags: []*databasev1.TagSpec{
+			{
+				Name:        "entity-tag",
+				Type:        databasev1.TagType_TAG_TYPE_STRING,
+				IndexedOnly: false,
+			},
+			{
+				Name:        "filter-tag",
+				Type:        databasev1.TagType_TAG_TYPE_STRING,
+				IndexedOnly: false,
+			},
+		},
+	}
+	schema := &databasev1.Stream{
+		Entity:      entity,
+		TagFamilies: []*databasev1.TagFamilySpec{tagFamily},
+	}
+	return &stream{
+		databaseSupplier: dbSupplier,
+		schema:           schema,
+		l:                logger.GetLogger("benchmark"),
+	}
+}
+
+func generateStreamFilterOptions(p parameter, index invertedIndex) pbv1.StreamFilterOptions {
+	timeRange := timestamp.TimeRange{
+		Start:        time.Unix(int64(p.startTimestamp), 0),
+		End:          time.Unix(int64(p.endTimestamp), 0),
+		IncludeStart: true,
+		IncludeEnd:   true,
+	}
+	entities := make([][]*modelv1.TagValue, 0)
+	for i := 1; i <= p.seriesCount; i++ {
+		entity := []*modelv1.TagValue{
+			{
+				Value: &modelv1.TagValue_Str{
+					Str: &modelv1.Str{
+						Value: "entity" + strconv.Itoa(i),
+					},
+				},
+			},
+		}
+		entities = append(entities, entity)
+	}
+	src := rand.NewSource(time.Now().UnixNano())
+	rng := rand.New(src)
+	value := "value" + strconv.Itoa(rng.Intn(p.tagCardinality)+1)
+	filter := filter{
+		index: index,
+		value: value,
+	}
+	tagProjection := pbv1.TagProjection{
+		Family: "benchmark-family",
+		Names:  []string{"entity-tag", "filter-tag"},
+	}
+	return pbv1.StreamFilterOptions{
+		Name:           "benchmark",
+		TimeRange:      &timeRange,
+		Entities:       entities,
+		Filter:         filter,
+		TagProjection:  []pbv1.TagProjection{tagProjection},
+		MaxElementSize: math.MaxInt32,
+	}
+}
+
+func generateStreamSortOptions(p parameter, index invertedIndex) pbv1.StreamSortOptions {
+	timeRange := timestamp.TimeRange{
+		Start:        time.Unix(int64(p.startTimestamp), 0),
+		End:          time.Unix(int64(p.endTimestamp), 0),
+		IncludeStart: true,
+		IncludeEnd:   true,
+	}
+	entities := make([][]*modelv1.TagValue, 0)
+	for i := 1; i <= p.seriesCount; i++ {
+		entity := []*modelv1.TagValue{
+			{
+				Value: &modelv1.TagValue_Str{
+					Str: &modelv1.Str{
+						Value: "entity" + strconv.Itoa(i),
+					},
+				},
+			},
+		}
+		entities = append(entities, entity)
+	}
+	src := rand.NewSource(time.Now().UnixNano())
+	rng := rand.New(src)
+	value := "value" + strconv.Itoa(rng.Intn(p.tagCardinality)+1)
+	filter := filter{
+		index: index,
+		value: value,
+	}
+	indexRule := &databasev1.IndexRule{
+		Metadata: &commonv1.Metadata{
+			Id: uint32(1),
+		},
+		Tags: []string{"filter-tag"},
+		Type: databasev1.IndexRule_TYPE_INVERTED,
+	}
+	order := &pbv1.OrderBy{
+		Index: indexRule,
+		Sort:  modelv1.Sort_SORT_ASC,
+	}
+	tagProjection := pbv1.TagProjection{
+		Family: "benchmark-family",
+		Names:  []string{"entity-tag", "filter-tag"},
+	}
+	return pbv1.StreamSortOptions{
+		Name:           "benchmark",
+		TimeRange:      &timeRange,
+		Entities:       entities,
+		Filter:         filter,
+		Order:          order,
+		TagProjection:  []pbv1.TagProjection{tagProjection},
+		MaxElementSize: math.MaxInt32,
+	}
+}
+
+func BenchmarkFilter(b *testing.B) {
+	pList := []parameter{
+		{batchCount: 1, timestampCount: 10, seriesCount: 10, tagCardinality: 10, startTimestamp: 1, endTimestamp: 10},
+		{batchCount: 2, timestampCount: 500, seriesCount: 100, tagCardinality: 10, startTimestamp: 1, endTimestamp: 1000},
+	}
+
+	b.ReportAllocs()
+	for _, p := range pList {
+		esList, _, idx := generateData(p)
+
+		b.Run("file snapshot", func(b *testing.B) {
+			// Initialize a tstIter object.
+			tmpPath, defFn := test.Space(require.New(b))
+			segmentPath := filepath.Join(tmpPath, "shard-0", "seg-19700101")
+			fileSystem := fs.NewLocalFileSystem()
+			defer defFn()
+			tst, err := newTSTable(fileSystem, segmentPath, common.Position{},
+				// Since Stream deduplicate data in merging process, we need to disable the merging in the test.
+				logger.GetLogger("benchmark"), timestamp.TimeRange{}, option{flushTimeout: 0, mergePolicy: newDisabledMergePolicyForTesting()})
+			require.NoError(b, err)
+			for _, es := range esList {
+				tst.mustAddElements(es)
+				time.Sleep(100 * time.Millisecond)
+			}
+			// wait until the introducer is done
+			if len(esList) > 0 {
+				for {
+					snp := tst.currentSnapshot()
+					if snp == nil {
+						time.Sleep(100 * time.Millisecond)
+						continue
+					}
+					if snp.creator != snapshotCreatorMemPart && len(snp.parts) == len(esList) {
+						snp.decRef()
+						tst.Close()
+						break
+					}
+					snp.decRef()
+					time.Sleep(100 * time.Millisecond)
+				}
+			}
+			data := []byte(version)
+			metadataPath := filepath.Join(segmentPath, segmentMetadataFilename)
+			lf, err := fileSystem.CreateLockFile(metadataPath, filePermission)
+			require.NoError(b, err)
+			_, err = lf.Write(data)
+			require.NoError(b, err)
+			db := openDatabase(b, tmpPath)
+			var docs index.Documents
+			for i := 1; i <= p.seriesCount; i++ {
+				entity := []*modelv1.TagValue{
+					{
+						Value: &modelv1.TagValue_Str{
+							Str: &modelv1.Str{
+								Value: "entity" + strconv.Itoa(i),
+							},
+						},
+					},
+				}
+				series := &pbv1.Series{
+					Subject:      "benchmark",
+					EntityValues: entity,
+				}
+				err = series.Marshal()
+				require.NoError(b, err)
+				docs = append(docs, index.Document{
+					DocID:        uint64(i),
+					EntityValues: series.Buffer,
+				})
+			}
+			db.IndexDB().Write(docs)
+			s := generateStream(db)
+			sfo := generateStreamFilterOptions(p, idx)
+			b.ResetTimer()
+			_, err = s.Filter(context.TODO(), sfo)
+			require.NoError(b, err)
+			b.StopTimer()
+		})
+	}
+}
+
+func BenchmarkSort(b *testing.B) {
+	pList := []parameter{
+		{batchCount: 1, timestampCount: 10, seriesCount: 10, tagCardinality: 10, startTimestamp: 1, endTimestamp: 10},
+		{batchCount: 2, timestampCount: 500, seriesCount: 100, tagCardinality: 10, startTimestamp: 1, endTimestamp: 1000},
+	}
+
+	b.ReportAllocs()
+	for _, p := range pList {
+		esList, docsList, idx := generateData(p)
+
+		b.Run("file snapshot", func(b *testing.B) {
+			// Initialize a tstIter object.
+			tmpPath, defFn := test.Space(require.New(b))
+			segmentPath := filepath.Join(tmpPath, "shard-0", "seg-19700101")
+			fileSystem := fs.NewLocalFileSystem()
+			defer defFn()
+			tst, err := newTSTable(fileSystem, segmentPath, common.Position{},
+				// Since Stream deduplicate data in merging process, we need to disable the merging in the test.
+				logger.GetLogger("benchmark"), timestamp.TimeRange{}, option{flushTimeout: 0, mergePolicy: newDisabledMergePolicyForTesting()})
+			require.NoError(b, err)
+			for i := 0; i < len(esList); i++ {
+				tst.mustAddElements(esList[i])
+				tst.index.Write(docsList[i])
+				time.Sleep(100 * time.Millisecond)
+			}
+			// wait until the introducer is done
+			if len(esList) > 0 {
+				for {
+					snp := tst.currentSnapshot()
+					if snp == nil {
+						time.Sleep(100 * time.Millisecond)
+						continue
+					}
+					if snp.creator != snapshotCreatorMemPart && len(snp.parts) == len(esList) {
+						snp.decRef()
+						tst.Close()
+						break
+					}
+					snp.decRef()
+					time.Sleep(100 * time.Millisecond)
+				}
+			}
+			data := []byte(version)
+			metadataPath := filepath.Join(segmentPath, segmentMetadataFilename)
+			lf, err := fileSystem.CreateLockFile(metadataPath, filePermission)
+			require.NoError(b, err)
+			_, err = lf.Write(data)
+			require.NoError(b, err)
+			db := openDatabase(b, tmpPath)
+			var docs index.Documents
+			for i := 1; i <= p.seriesCount; i++ {
+				entity := []*modelv1.TagValue{
+					{
+						Value: &modelv1.TagValue_Str{
+							Str: &modelv1.Str{
+								Value: "entity" + strconv.Itoa(i),
+							},
+						},
+					},
+				}
+				series := &pbv1.Series{
+					Subject:      "benchmark",
+					EntityValues: entity,
+				}
+				err = series.Marshal()
+				require.NoError(b, err)
+				docs = append(docs, index.Document{
+					DocID:        uint64(i),
+					EntityValues: series.Buffer,
+				})
+			}
+			db.IndexDB().Write(docs)
+			s := generateStream(db)
+			sso := generateStreamSortOptions(p, idx)
+			b.ResetTimer()
+			_, err = s.Sort(context.TODO(), sso)
+			require.NoError(b, err)
+		})
+	}
+}

--- a/banyand/stream/index.go
+++ b/banyand/stream/index.go
@@ -62,9 +62,16 @@ func (e *elementIndex) Sort(sids []common.SeriesID, fieldKey index.FieldKey, ord
 }
 
 func (e *elementIndex) Write(docs index.Documents) error {
-	return e.store.Batch(index.Batch{
+	applied := make(chan struct{})
+	err := e.store.Batch(index.Batch{
 		Documents: docs,
+		Applied:   applied,
 	})
+	if err != nil {
+		return err
+	}
+	<-applied
+	return nil
 }
 
 func (e *elementIndex) Search(_ context.Context, seriesList pbv1.SeriesList, filter index.Filter) ([]elementRef, error) {

--- a/banyand/stream/index.go
+++ b/banyand/stream/index.go
@@ -31,6 +31,7 @@ import (
 	"github.com/apache/skywalking-banyandb/pkg/index/posting/roaring"
 	"github.com/apache/skywalking-banyandb/pkg/logger"
 	pbv1 "github.com/apache/skywalking-banyandb/pkg/pb/v1"
+	"github.com/apache/skywalking-banyandb/pkg/timestamp"
 )
 
 type elementIndex struct {
@@ -74,7 +75,7 @@ func (e *elementIndex) Write(docs index.Documents) error {
 	return nil
 }
 
-func (e *elementIndex) Search(_ context.Context, seriesList pbv1.SeriesList, filter index.Filter) ([]elementRef, error) {
+func (e *elementIndex) Search(_ context.Context, seriesList pbv1.SeriesList, filter index.Filter, timeRange *timestamp.TimeRange) ([]elementRef, error) {
 	pm := make(map[common.SeriesID][]uint64)
 	for _, series := range seriesList {
 		pl, err := filter.Execute(func(_ databasev1.IndexRule_Type) (index.Searcher, error) {
@@ -90,7 +91,12 @@ func (e *elementIndex) Search(_ context.Context, seriesList pbv1.SeriesList, fil
 		sort.Slice(timestamps, func(i, j int) bool {
 			return timestamps[i] < timestamps[j]
 		})
-		pm[series.ID] = timestamps
+		start, end, ok := timestamp.FindRange(timestamps, uint64(timeRange.Start.UnixNano()), uint64(timeRange.End.UnixNano()))
+		if !ok {
+			pm[series.ID] = []uint64{}
+		} else {
+			pm[series.ID] = timestamps[start : end+1]
+		}
 	}
 	return merge(pm), nil
 }

--- a/banyand/stream/iter.go
+++ b/banyand/stream/iter.go
@@ -87,9 +87,6 @@ func (s *searcherIterator) Next() bool {
 			return s.Next()
 		}
 	}
-	if e := s.l.Debug(); e.Enabled() {
-		e.Uint64("series_id", uint64(seriesID)).Uint64("item_id", itemID).Msg("got an item")
-	}
 	e, c, err := s.table.getElement(seriesID, int64(itemID), s.tagProjection)
 	if err != nil {
 		s.err = err

--- a/banyand/stream/query.go
+++ b/banyand/stream/query.go
@@ -387,7 +387,7 @@ func (s *stream) Filter(ctx context.Context, sfo pbv1.StreamFilterOptions) (sfr 
 			break
 		}
 		index := tw.Table().Index()
-		erl, err := index.Search(ctx, seriesList, sfo.Filter)
+		erl, err := index.Search(ctx, seriesList, sfo.Filter, sfo.TimeRange)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/timestamp/range.go
+++ b/pkg/timestamp/range.go
@@ -122,7 +122,7 @@ func NewTimeRangeDuration(start time.Time, duration time.Duration, includeStart,
 }
 
 // FindRange returns the indices of the first and last elements in a sorted 'timestamps' slice that are within the min and max range.
-func FindRange(timestamps []int64, min, max int64) (int, int, bool) {
+func FindRange[T int64 | uint64](timestamps []T, min, max T) (int, int, bool) {
 	if len(timestamps) == 0 {
 		return -1, -1, false
 	}


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

<!-- ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👇 ====
### Fix <bug description or the bug issue number or bug issue link>
- [ ] Add a unit test to verify that the fix works.
- [ ] Explain briefly why the bug exists and how to fix it.
     ==== 🐛 Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist 👆 ==== -->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->
The parameters for the benchmark test are: 
{batchCount: 2, timestampCount: 500, seriesCount: 100, tagCardinality: 10, startTimestamp: 1, endTimestamp: 1000}
{batchCount: 2, timestampCount: 500, seriesCount: 100, tagCardinality: 10, startTimestamp: 900, endTimestamp: 1000}
{batchCount: 2, timestampCount: 500, seriesCount: 100, tagCardinality: 10, startTimestamp: 300, endTimestamp: 400}
The results of the benchmark test are:
BenchmarkFilter/filter-4                   1    12072188068 ns/op   2214986960 B/op  9846997 allocs/op
BenchmarkFilter/filter#01-4                1    2256799939 ns/op    229778280 B/op   1028123 allocs/op
BenchmarkFilter/filter#02-4                1    1054368170 ns/op    224286248 B/op   1003823 allocs/op
BenchmarkSort/sort-4                   1    9581582830 ns/op    2303692664 B/op 11621270 allocs/op
BenchmarkSort/sort#01-4                1    3009325642 ns/op    357511432 B/op   2962751 allocs/op
BenchmarkSort/sort#02-4                1    2891067250 ns/op    360656360 B/op   2976483 allocs/op

- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-banyandb/blob/main/CHANGES.md).
