### PR TITLE
Fix the filtering of stream in descending order by timestamp

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ Release Notes.
 - Fix duplicated items in the query aggregation top-n list.
 - Fix non-"value" field in topN pre-calculation result measure is lack of data.
 - Encode escaped characters to int64 bytes to fix the malformed data.
+- Fix the filtering of stream in descending order by timestamp.
 
 ## 0.6.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,14 +2,20 @@
 
 Release Notes.
 
-## 0.6.1
+## 0.7.0
 
-- Add benchmarks for stream filtering and sorting.
+### Bugs
+
+- Fix the filtering of stream in descending order by timestamp.
+
+## 0.6.1
 
 ### Features
 
 - Limit the max pre-calculation result flush interval to 1 minute.
 - Use both datapoint timestamp and server time to trigger the flush of topN pre-calculation result.
+- Add benchmarks for stream filtering and sorting.
+- Improve filtering performance of stream.
 
 ### Bugs
 
@@ -19,7 +25,6 @@ Release Notes.
 - Fix duplicated items in the query aggregation top-n list.
 - Fix non-"value" field in topN pre-calculation result measure is lack of data.
 - Encode escaped characters to int64 bytes to fix the malformed data.
-- Fix the filtering of stream in descending order by timestamp.
 
 ## 0.6.0
 

--- a/banyand/stream/index.go
+++ b/banyand/stream/index.go
@@ -75,7 +75,9 @@ func (e *elementIndex) Write(docs index.Documents) error {
 	return nil
 }
 
-func (e *elementIndex) Search(_ context.Context, seriesList pbv1.SeriesList, filter index.Filter, timeRange *timestamp.TimeRange, order *pbv1.OrderBy) ([]elementRef, error) {
+func (e *elementIndex) Search(_ context.Context, seriesList pbv1.SeriesList, filter index.Filter,
+	timeRange *timestamp.TimeRange, order *pbv1.OrderBy,
+) ([]elementRef, error) {
 	pm := make(map[common.SeriesID][]uint64)
 	for _, series := range seriesList {
 		pl, err := filter.Execute(func(_ databasev1.IndexRule_Type) (index.Searcher, error) {

--- a/banyand/stream/index.go
+++ b/banyand/stream/index.go
@@ -75,7 +75,7 @@ func (e *elementIndex) Write(docs index.Documents) error {
 	return nil
 }
 
-func (e *elementIndex) Search(_ context.Context, seriesList pbv1.SeriesList, filter index.Filter, timeRange *timestamp.TimeRange) ([]elementRef, error) {
+func (e *elementIndex) Search(_ context.Context, seriesList pbv1.SeriesList, filter index.Filter, timeRange *timestamp.TimeRange, order *pbv1.OrderBy) ([]elementRef, error) {
 	pm := make(map[common.SeriesID][]uint64)
 	for _, series := range seriesList {
 		pl, err := filter.Execute(func(_ databasev1.IndexRule_Type) (index.Searcher, error) {
@@ -91,9 +91,15 @@ func (e *elementIndex) Search(_ context.Context, seriesList pbv1.SeriesList, fil
 			continue
 		}
 		timestamps := pl.ToSlice()
-		sort.Slice(timestamps, func(i, j int) bool {
-			return timestamps[i] < timestamps[j]
-		})
+		if order != nil && order.Index == nil && order.Sort == modelv1.Sort_SORT_DESC {
+			sort.Slice(timestamps, func(i, j int) bool {
+				return timestamps[i] > timestamps[j]
+			})
+		} else {
+			sort.Slice(timestamps, func(i, j int) bool {
+				return timestamps[i] < timestamps[j]
+			})
+		}
 		start, end, ok := timestamp.FindRange(timestamps, uint64(timeRange.Start.UnixNano()), uint64(timeRange.End.UnixNano()))
 		if !ok {
 			pm[series.ID] = []uint64{}

--- a/banyand/stream/query.go
+++ b/banyand/stream/query.go
@@ -579,7 +579,7 @@ func (s *stream) Filter(ctx context.Context, sqo pbv1.StreamQueryOptions) (sqr p
 	var elementRefList []elementRef
 	for _, tw := range tabWrappers {
 		index := tw.Table().Index()
-		erl, err := index.Search(ctx, seriesList, sqo.Filter, sqo.TimeRange)
+		erl, err := index.Search(ctx, seriesList, sqo.Filter, sqo.TimeRange, sqo.Order)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/timestamp/range.go
+++ b/pkg/timestamp/range.go
@@ -126,23 +126,24 @@ func FindRange[T int64 | uint64](timestamps []T, min, max T) (int, int, bool) {
 	if len(timestamps) == 0 {
 		return -1, -1, false
 	}
-	if timestamps[0] > max {
+	isAsc := timestamps[0] <= timestamps[len(timestamps)-1]
+	if isAsc && (timestamps[0] > max || timestamps[len(timestamps)-1] < min) {
 		return -1, -1, false
 	}
-	if timestamps[len(timestamps)-1] < min {
+	if !isAsc && (timestamps[0] < min || timestamps[len(timestamps)-1] > max) {
 		return -1, -1, false
 	}
 
 	start, end := -1, len(timestamps)
 	for start < len(timestamps)-1 {
 		start++
-		if timestamps[start] >= min {
+		if isAsc && timestamps[start] >= min || !isAsc && timestamps[start] <= max {
 			break
 		}
 	}
 	for end > 0 {
 		end--
-		if timestamps[end] <= max {
+		if isAsc && timestamps[end] <= max || !isAsc && timestamps[end] >= min {
 			break
 		}
 	}

--- a/pkg/timestamp/range_test.go
+++ b/pkg/timestamp/range_test.go
@@ -77,6 +77,17 @@ func Test_findRange(t *testing.T) {
 			wantExist: true,
 		},
 		{
+			name: "Test with range in timestamps desc",
+			args: args{
+				timestamps: []int64{5, 4, 3, 2, 1},
+				min:        2,
+				max:        4,
+			},
+			wantStart: 1,
+			wantEnd:   3,
+			wantExist: true,
+		},
+		{
 			name: "Test with range as timestamps",
 			args: args{
 				timestamps: []int64{1, 2, 3, 4, 5},

--- a/test/cases/stream/data/input/filter_order_desc.yaml
+++ b/test/cases/stream/data/input/filter_order_desc.yaml
@@ -1,0 +1,35 @@
+# Licensed to Apache Software Foundation (ASF) under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Apache Software Foundation (ASF) licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: "sw"
+groups: ["default"]
+projection:
+  tagFamilies:
+  - name: "searchable"
+    tags: ["trace_id", "duration"]
+  - name: "data"
+    tags: ["data_binary"]
+criteria:
+  condition:
+    name: "duration"
+    op: "BINARY_OP_LT"
+    value:
+      int:
+        value: 500
+orderBy:
+  sort: "SORT_DESC"
+limit: 2

--- a/test/cases/stream/data/want/filter_order_desc.yaml
+++ b/test/cases/stream/data/want/filter_order_desc.yaml
@@ -1,0 +1,52 @@
+# Licensed to Apache Software Foundation (ASF) under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Apache Software Foundation (ASF) licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+elements:
+  - elementId: "4"
+    tagFamilies:
+    - name: searchable
+      tags:
+      - key: trace_id
+        value:
+          str:
+            value: "5"
+      - key: duration
+        value:
+          int:
+            value: "300"
+    - name: data
+      tags:
+      - key: data_binary
+        value:
+          binaryData: YWJjMTIzIT8kKiYoKSctPUB+
+  - elementId: "3"
+    tagFamilies:
+    - name: searchable
+      tags:
+      - key: trace_id
+        value:
+          str:
+            value: "4"
+      - key: duration
+        value:
+          int:
+            value: "60"
+    - name: data
+      tags:
+      - key: data_binary
+        value:
+          binaryData: YWJjMTIzIT8kKiYoKSctPUB+

--- a/test/cases/stream/stream.go
+++ b/test/cases/stream/stream.go
@@ -78,4 +78,5 @@ var _ = g.DescribeTable("Scanning Streams", func(args helpers.Args) {
 	g.Entry("full text searching", helpers.Args{Input: "search", Duration: 1 * time.Hour}),
 	g.Entry("indexed only tags", helpers.Args{Input: "indexed_only", Duration: 1 * time.Hour}),
 	g.Entry("filter by non-indexed tag with or", helpers.Args{Input: "filter_no_indexed_or", Duration: 1 * time.Hour}),
+	g.Entry("filter with desc order", helpers.Args{Input: "filter_order_desc", Duration: 1 * time.Hour}),
 )


### PR DESCRIPTION
<!--
    ⚠️ Please make sure to read this template first, pull requests that don't accord with this template
    maybe closed without notice.
    Texts surrounded by `<` and `>` are meant to be replaced by you, e.g. <framework name>, <issue number>.
    Put an `x` in the `[ ]` to mark the item as CHECKED. `[x]`
-->

<!-- ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👇 ====
### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [ ] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.
     ==== 🆕 Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist 👆 ==== -->

When filtering according to the indexRule while sorting in descending order by timestamp,  the elements remaining after applying the limit are incorrect.

- [x] Explain briefly why the bug exists and how to fix it.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-banyandb/blob/main/CHANGES.md).
