### PR TITLE
Add version to timestamp file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Release Notes.
 ### Bugs
 
 - Fix the filtering of stream in descending order by timestamp.
+- Fix querying old data points when the data is in a newer part. A version column is introduced to each data point and stored in the timestamp file.
 
 ## 0.6.1
 

--- a/api/proto/banyandb/measure/v1/query.proto
+++ b/api/proto/banyandb/measure/v1/query.proto
@@ -40,6 +40,8 @@ message DataPoint {
   }
   // fields contains fields selected in the projection
   repeated Field fields = 3;
+  // version is the version of the data point
+  int64 version = 4;
 }
 
 // QueryResponse is the response for a query to the Query module.

--- a/api/proto/banyandb/measure/v1/write.proto
+++ b/api/proto/banyandb/measure/v1/write.proto
@@ -36,6 +36,8 @@ message DataPointValue {
   repeated model.v1.TagFamilyForWrite tag_families = 2 [(validate.rules).repeated.min_items = 1];
   // the order of fields match the measure schema
   repeated model.v1.FieldValue fields = 3;
+  // the version of the data point
+  int64 version = 4;
 }
 
 // WriteRequest is the request contract for write

--- a/banyand/liaison/grpc/measure.go
+++ b/banyand/liaison/grpc/measure.go
@@ -108,6 +108,12 @@ func (ms *measureService) Write(measure measurev1.MeasureService_WriteServer) er
 			reply(writeRequest.GetMetadata(), modelv1.Status_STATUS_INTERNAL_ERROR, writeRequest.GetMessageId(), measure, ms.sampled)
 			continue
 		}
+		if writeRequest.DataPoint.Version == 0 {
+			if writeRequest.MessageId == 0 {
+				writeRequest.MessageId = uint64(time.Now().UnixNano())
+			}
+			writeRequest.DataPoint.Version = int64(writeRequest.MessageId)
+		}
 		if ms.ingestionAccessLog != nil {
 			if errAccessLog := ms.ingestionAccessLog.Write(writeRequest); errAccessLog != nil {
 				ms.sampled.Error().Err(errAccessLog).RawJSON("written", logger.Proto(writeRequest)).Msg("failed to write access log")

--- a/banyand/measure/block_metadata_test.go
+++ b/banyand/measure/block_metadata_test.go
@@ -80,9 +80,12 @@ func Test_timestampsMetadata_reset(t *testing.T) {
 			offset: 1,
 			size:   1,
 		},
-		min:        1,
-		max:        1,
-		encodeType: encoding.EncodeTypeConst,
+		min:               1,
+		max:               1,
+		encodeType:        encoding.EncodeTypeConst,
+		versionOffset:     1,
+		versionFirst:      1,
+		versionEncodeType: encoding.EncodeTypeDelta,
 	}
 
 	tm.reset()
@@ -92,6 +95,9 @@ func Test_timestampsMetadata_reset(t *testing.T) {
 	assert.Equal(t, int64(0), tm.min)
 	assert.Equal(t, int64(0), tm.max)
 	assert.Equal(t, encoding.EncodeTypeUnknown, tm.encodeType)
+	assert.Equal(t, uint64(0), tm.versionOffset)
+	assert.Equal(t, int64(0), tm.versionFirst)
+	assert.Equal(t, encoding.EncodeTypeUnknown, tm.versionEncodeType)
 }
 
 func Test_timestampsMetadata_copyFrom(t *testing.T) {
@@ -100,9 +106,12 @@ func Test_timestampsMetadata_copyFrom(t *testing.T) {
 			offset: 1,
 			size:   1,
 		},
-		min:        1,
-		max:        1,
-		encodeType: encoding.EncodeTypeConst,
+		min:               1,
+		max:               1,
+		encodeType:        encoding.EncodeTypeConst,
+		versionOffset:     1,
+		versionFirst:      1,
+		versionEncodeType: encoding.EncodeTypeDelta,
 	}
 
 	dest := &timestampsMetadata{
@@ -110,9 +119,12 @@ func Test_timestampsMetadata_copyFrom(t *testing.T) {
 			offset: 2,
 			size:   2,
 		},
-		min:        2,
-		max:        2,
-		encodeType: encoding.EncodeTypeDelta,
+		min:               2,
+		max:               2,
+		encodeType:        encoding.EncodeTypeDelta,
+		versionOffset:     2,
+		versionFirst:      2,
+		versionEncodeType: encoding.EncodeTypeDeltaOfDelta,
 	}
 
 	dest.copyFrom(src)
@@ -122,6 +134,9 @@ func Test_timestampsMetadata_copyFrom(t *testing.T) {
 	assert.Equal(t, src.min, dest.min)
 	assert.Equal(t, src.max, dest.max)
 	assert.Equal(t, src.encodeType, dest.encodeType)
+	assert.Equal(t, src.versionOffset, dest.versionOffset)
+	assert.Equal(t, src.versionFirst, dest.versionFirst)
+	assert.Equal(t, src.versionEncodeType, dest.versionEncodeType)
 }
 
 func Test_timestampsMetadata_marshal_unmarshal(t *testing.T) {
@@ -130,9 +145,12 @@ func Test_timestampsMetadata_marshal_unmarshal(t *testing.T) {
 			offset: 1,
 			size:   1,
 		},
-		min:        1,
-		max:        1,
-		encodeType: encoding.EncodeTypeConst,
+		min:               1,
+		max:               1,
+		encodeType:        encoding.EncodeTypeConst,
+		versionOffset:     1,
+		versionFirst:      1,
+		versionEncodeType: encoding.EncodeTypeDelta,
 	}
 
 	marshaled := original.marshal(nil)
@@ -147,6 +165,9 @@ func Test_timestampsMetadata_marshal_unmarshal(t *testing.T) {
 	assert.Equal(t, original.min, unmarshaled.min)
 	assert.Equal(t, original.max, unmarshaled.max)
 	assert.Equal(t, original.encodeType, unmarshaled.encodeType)
+	assert.Equal(t, original.versionOffset, unmarshaled.versionOffset)
+	assert.Equal(t, original.versionFirst, unmarshaled.versionFirst)
+	assert.Equal(t, original.versionEncodeType, unmarshaled.versionEncodeType)
 }
 
 func Test_blockMetadata_marshal_unmarshal(t *testing.T) {
@@ -201,6 +222,44 @@ func Test_blockMetadata_marshal_unmarshal(t *testing.T) {
 			},
 		},
 		{
+			name: "Non-zero values with versions",
+			original: &blockMetadata{
+				seriesID:              common.SeriesID(1),
+				uncompressedSizeBytes: 1,
+				count:                 1,
+				timestamps: timestampsMetadata{
+					dataBlock: dataBlock{
+						offset: 1,
+						size:   1,
+					},
+					min:               1,
+					max:               1,
+					encodeType:        encoding.EncodeTypeConst,
+					versionOffset:     1,
+					versionFirst:      1,
+					versionEncodeType: encoding.EncodeTypeDelta,
+				},
+				tagFamilies: map[string]*dataBlock{
+					"tag1": {
+						offset: 1,
+						size:   1,
+					},
+				},
+				field: columnFamilyMetadata{
+					columnMetadata: []columnMetadata{
+						{
+							dataBlock: dataBlock{
+								offset: 1,
+								size:   1,
+							},
+							name:      "field1",
+							valueType: pbv1.ValueTypeInt64,
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "Multiple tagFamilies and columnMetadata",
 			original: &blockMetadata{
 				seriesID:              common.SeriesID(2),
@@ -211,9 +270,12 @@ func Test_blockMetadata_marshal_unmarshal(t *testing.T) {
 						offset: 2,
 						size:   2,
 					},
-					min:        2,
-					max:        2,
-					encodeType: encoding.EncodeTypeConst,
+					min:               2,
+					max:               2,
+					encodeType:        encoding.EncodeTypeConst,
+					versionOffset:     2,
+					versionFirst:      2,
+					versionEncodeType: encoding.EncodeTypeDelta,
 				},
 				tagFamilies: map[string]*dataBlock{
 					"tag1": {

--- a/banyand/measure/block_writer.go
+++ b/banyand/measure/block_writer.go
@@ -186,14 +186,14 @@ func (bw *blockWriter) mustInitForFilePart(fileSystem fs.FileSystem, path string
 	bw.writers.fieldValuesWriter.init(fs.MustCreateFile(fileSystem, filepath.Join(path, fieldValuesFilename), filePermission))
 }
 
-func (bw *blockWriter) MustWriteDataPoints(sid common.SeriesID, timestamps []int64, tagFamilies [][]nameValues, fields []nameValues) {
+func (bw *blockWriter) MustWriteDataPoints(sid common.SeriesID, timestamps, versions []int64, tagFamilies [][]nameValues, fields []nameValues) {
 	if len(timestamps) == 0 {
 		return
 	}
 
 	b := generateBlock()
 	defer releaseBlock(b)
-	b.mustInitFromDataPoints(timestamps, tagFamilies, fields)
+	b.mustInitFromDataPoints(timestamps, versions, tagFamilies, fields)
 	bw.mustWriteBlock(sid, b)
 }
 

--- a/banyand/measure/datapoints.go
+++ b/banyand/measure/datapoints.go
@@ -118,6 +118,7 @@ type nameValues struct {
 type dataPoints struct {
 	seriesIDs   []common.SeriesID
 	timestamps  []int64
+	versions    []int64
 	tagFamilies [][]nameValues
 	fields      []nameValues
 }
@@ -136,6 +137,7 @@ func (d *dataPoints) Less(i, j int) bool {
 func (d *dataPoints) Swap(i, j int) {
 	d.seriesIDs[i], d.seriesIDs[j] = d.seriesIDs[j], d.seriesIDs[i]
 	d.timestamps[i], d.timestamps[j] = d.timestamps[j], d.timestamps[i]
+	d.versions[i], d.versions[j] = d.versions[j], d.versions[i]
 	d.tagFamilies[i], d.tagFamilies[j] = d.tagFamilies[j], d.tagFamilies[i]
 	d.fields[i], d.fields[j] = d.fields[j], d.fields[i]
 }

--- a/banyand/measure/measure.go
+++ b/banyand/measure/measure.go
@@ -35,7 +35,6 @@ import (
 
 const (
 	maxValuesBlockSize              = 8 * 1024 * 1024
-	maxTimestampsBlockSize          = 8 * 1024 * 1024
 	maxTagFamiliesMetadataSize      = 8 * 1024 * 1024
 	maxUncompressedBlockSize        = 2 * 1024 * 1024
 	maxUncompressedPrimaryBlockSize = 128 * 1024

--- a/banyand/measure/merger.go
+++ b/banyand/measure/merger.go
@@ -370,7 +370,7 @@ func mergeTwoBlocks(target, left, right *blockPointer) {
 			i++
 		}
 		if left.timestamps[i-1] == ts2 {
-			if left.lastPartID >= right.lastPartID {
+			if left.versions[i-1] >= right.versions[right.idx] {
 				target.append(left, i)
 			} else {
 				target.append(left, i-1) // skip left

--- a/banyand/measure/merger_test.go
+++ b/banyand/measure/merger_test.go
@@ -61,6 +61,7 @@ func Test_mergeTwoBlocks(t *testing.T) {
 			left: &blockPointer{
 				block: block{
 					timestamps: []int64{1, 2},
+					versions:   []int64{1, 4},
 					tagFamilies: []columnFamily{
 						{
 							name: "arrTag",
@@ -82,6 +83,7 @@ func Test_mergeTwoBlocks(t *testing.T) {
 			right: &blockPointer{
 				block: block{
 					timestamps: []int64{3, 4},
+					versions:   []int64{5, 6},
 					tagFamilies: []columnFamily{
 						{
 							name: "arrTag",
@@ -107,6 +109,7 @@ func Test_mergeTwoBlocks(t *testing.T) {
 			left: &blockPointer{
 				block: block{
 					timestamps: []int64{1, 3},
+					versions:   []int64{1, 5},
 					tagFamilies: []columnFamily{
 						{
 							name: "arrTag",
@@ -128,6 +131,7 @@ func Test_mergeTwoBlocks(t *testing.T) {
 			right: &blockPointer{
 				block: block{
 					timestamps: []int64{2, 4},
+					versions:   []int64{4, 6},
 					tagFamilies: []columnFamily{
 						{
 							name: "arrTag",
@@ -151,9 +155,9 @@ func Test_mergeTwoBlocks(t *testing.T) {
 		{
 			name: "Merge two non-empty blocks with duplicated timestamps",
 			left: &blockPointer{
-				lastPartID: 1, // the less partID will be skipped
 				block: block{
 					timestamps: []int64{1, 2, 3},
+					versions:   []int64{1, 2, 3},
 					tagFamilies: []columnFamily{
 						{
 							name: "arrTag",
@@ -177,9 +181,9 @@ func Test_mergeTwoBlocks(t *testing.T) {
 				},
 			},
 			right: &blockPointer{
-				lastPartID: 2, // the greater partID will be appended
 				block: block{
 					timestamps: []int64{2, 3, 4},
+					versions:   []int64{4, 5, 6},
 					tagFamilies: []columnFamily{
 						{
 							name: "arrTag",
@@ -201,7 +205,7 @@ func Test_mergeTwoBlocks(t *testing.T) {
 					},
 				},
 			},
-			want: &blockPointer{block: mergedBlock, lastPartID: 2, bm: blockMetadata{timestamps: timestampsMetadata{min: 1, max: 4}}},
+			want: &blockPointer{block: mergedBlock, bm: blockMetadata{timestamps: timestampsMetadata{min: 1, max: 4}}},
 		},
 	}
 
@@ -218,6 +222,7 @@ func Test_mergeTwoBlocks(t *testing.T) {
 
 var mergedBlock = block{
 	timestamps: []int64{1, 2, 3, 4},
+	versions:   []int64{1, 4, 5, 6},
 	tagFamilies: []columnFamily{
 		{
 			name: "arrTag",

--- a/banyand/measure/part.go
+++ b/banyand/measure/part.go
@@ -158,14 +158,14 @@ func (mp *memPart) mustInitFromDataPoints(dps *dataPoints) {
 
 		if uncompressedBlockSizeBytes >= maxUncompressedBlockSize ||
 			(i-indexPrev) > maxBlockLength || sid != sidPrev {
-			bsw.MustWriteDataPoints(sidPrev, dps.timestamps[indexPrev:i], dps.tagFamilies[indexPrev:i], dps.fields[indexPrev:i])
+			bsw.MustWriteDataPoints(sidPrev, dps.timestamps[indexPrev:i], dps.versions[indexPrev:i], dps.tagFamilies[indexPrev:i], dps.fields[indexPrev:i])
 			sidPrev = sid
 			indexPrev = i
 			uncompressedBlockSizeBytes = 0
 		}
 		uncompressedBlockSizeBytes += uncompressedDataPointSizeBytes(i, dps)
 	}
-	bsw.MustWriteDataPoints(sidPrev, dps.timestamps[indexPrev:], dps.tagFamilies[indexPrev:], dps.fields[indexPrev:])
+	bsw.MustWriteDataPoints(sidPrev, dps.timestamps[indexPrev:], dps.versions[indexPrev:], dps.tagFamilies[indexPrev:], dps.fields[indexPrev:])
 	bsw.Flush(&mp.partMetadata)
 	releaseBlockWriter(bsw)
 }

--- a/banyand/measure/part_iter.go
+++ b/banyand/measure/part_iter.go
@@ -315,8 +315,6 @@ func (pmi *partMergeIter) loadBlockMetadata() error {
 		pm := pmi.primaryBlockMetadata[pmi.primaryMetadataIdx-1]
 		return fmt.Errorf("can't read block metadata from primary at %d: %w", pm.offset, err)
 	}
-
-	pmi.block.lastPartID = pmi.partID
 	return nil
 }
 

--- a/banyand/measure/part_test.go
+++ b/banyand/measure/part_test.go
@@ -40,6 +40,7 @@ func TestMustInitFromDataPoints(t *testing.T) {
 			name: "Test with empty dataPoints",
 			dps: &dataPoints{
 				timestamps:  []int64{},
+				versions:    []int64{},
 				seriesIDs:   []common.SeriesID{},
 				tagFamilies: make([][]nameValues, 0),
 				fields:      make([]nameValues, 0),
@@ -50,6 +51,7 @@ func TestMustInitFromDataPoints(t *testing.T) {
 			name: "Test with one item in dataPoints",
 			dps: &dataPoints{
 				timestamps: []int64{1},
+				versions:   []int64{1},
 				seriesIDs:  []common.SeriesID{1},
 				tagFamilies: [][]nameValues{
 					{
@@ -126,6 +128,7 @@ func TestMustInitFromDataPoints(t *testing.T) {
 var dps = &dataPoints{
 	seriesIDs:  []common.SeriesID{1, 1, 2, 2, 3, 3},
 	timestamps: []int64{1, 2, 8, 10, 100, 220},
+	versions:   []int64{1, 2, 3, 4, 5, 6},
 	tagFamilies: [][]nameValues{
 		{
 			{

--- a/banyand/measure/query.go
+++ b/banyand/measure/query.go
@@ -438,8 +438,8 @@ func (qr queryResult) Len() int {
 func (qr queryResult) Less(i, j int) bool {
 	leftTS := qr.data[i].timestamps[qr.data[i].idx]
 	rightTS := qr.data[j].timestamps[qr.data[j].idx]
-	leftVersion := qr.data[i].p.partMetadata.ID
-	rightVersion := qr.data[j].p.partMetadata.ID
+	leftVersion := qr.data[i].versions[qr.data[i].idx]
+	rightVersion := qr.data[j].versions[qr.data[j].idx]
 	if qr.orderByTS {
 		if leftTS == rightTS {
 			if qr.data[i].bm.seriesID == qr.data[j].bm.seriesID {
@@ -495,7 +495,7 @@ func (qr *queryResult) merge(entityValuesAll map[common.SeriesID]map[string]*mod
 		step = -1
 	}
 	result := &pbv1.MeasureResult{}
-	var lastPartVersion uint64
+	var lastVersion int64
 	var lastSid common.SeriesID
 
 	for qr.Len() > 0 {
@@ -507,12 +507,12 @@ func (qr *queryResult) merge(entityValuesAll map[common.SeriesID]map[string]*mod
 
 		if len(result.Timestamps) > 0 &&
 			topBC.timestamps[topBC.idx] == result.Timestamps[len(result.Timestamps)-1] {
-			if topBC.p.partMetadata.ID > lastPartVersion {
+			if topBC.versions[topBC.idx] > lastVersion {
 				logger.Panicf("following parts version should be less or equal to the previous one")
 			}
 		} else {
 			topBC.copyTo(result, entityValuesAll, tagProjection)
-			lastPartVersion = topBC.p.partMetadata.ID
+			lastVersion = topBC.versions[topBC.idx]
 		}
 
 		topBC.idx += step

--- a/banyand/measure/query_test.go
+++ b/banyand/measure/query_test.go
@@ -59,6 +59,7 @@ func TestQueryResult(t *testing.T) {
 			want: []pbv1.MeasureResult{{
 				SID:        1,
 				Timestamps: []int64{1},
+				Versions:   []int64{1},
 				TagFamilies: []pbv1.TagFamily{
 					{Name: "arrTag", Tags: []pbv1.Tag{
 						{Name: "strArrTag", Values: []*modelv1.TagValue{strArrTagValue([]string{"value1", "value2"})}},
@@ -83,6 +84,7 @@ func TestQueryResult(t *testing.T) {
 			}, {
 				SID:        2,
 				Timestamps: []int64{1},
+				Versions:   []int64{2},
 				TagFamilies: []pbv1.TagFamily{
 					{Name: "arrTag", Tags: []pbv1.Tag{
 						{Name: "strArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
@@ -102,6 +104,7 @@ func TestQueryResult(t *testing.T) {
 			}, {
 				SID:        3,
 				Timestamps: []int64{1},
+				Versions:   []int64{3},
 				TagFamilies: []pbv1.TagFamily{
 					{Name: "arrTag", Tags: []pbv1.Tag{
 						{Name: "strArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
@@ -123,7 +126,157 @@ func TestQueryResult(t *testing.T) {
 			}},
 		},
 		{
-			name:         "Test with multiple parts with multiple data orderBy TS desc",
+			name:         "Test with multiple parts with duplicated data with different version order by TS 1",
+			dpsList:      []*dataPoints{dpsTS1, dpsTS11},
+			sids:         []common.SeriesID{1, 2, 3},
+			minTimestamp: 1,
+			maxTimestamp: 1,
+			want: []pbv1.MeasureResult{{
+				SID:        1,
+				Timestamps: []int64{1},
+				Versions:   []int64{1},
+				TagFamilies: []pbv1.TagFamily{
+					{Name: "arrTag", Tags: []pbv1.Tag{
+						{Name: "strArrTag", Values: []*modelv1.TagValue{strArrTagValue([]string{"value1", "value2"})}},
+						{Name: "intArrTag", Values: []*modelv1.TagValue{int64ArrTagValue([]int64{25, 30})}},
+					}},
+					{Name: "binaryTag", Tags: []pbv1.Tag{
+						{Name: "binaryTag", Values: []*modelv1.TagValue{binaryDataTagValue(longText)}},
+					}},
+					{Name: "singleTag", Tags: []pbv1.Tag{
+						{Name: "strTag", Values: []*modelv1.TagValue{strTagValue("value1")}},
+						{Name: "intTag", Values: []*modelv1.TagValue{int64TagValue(10)}},
+						{Name: "strTag1", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "strTag2", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+				},
+				Fields: []pbv1.Field{
+					{Name: "strField", Values: []*modelv1.FieldValue{strFieldValue("field1")}},
+					{Name: "intField", Values: []*modelv1.FieldValue{int64FieldValue(1110)}},
+					{Name: "floatField", Values: []*modelv1.FieldValue{float64FieldValue(1.221233343e+06)}},
+					{Name: "binaryField", Values: []*modelv1.FieldValue{binaryDataFieldValue(longText)}},
+				},
+			}, {
+				SID:        2,
+				Timestamps: []int64{1},
+				Versions:   []int64{2},
+				TagFamilies: []pbv1.TagFamily{
+					{Name: "arrTag", Tags: []pbv1.Tag{
+						{Name: "strArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "intArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+					{Name: "binaryTag", Tags: []pbv1.Tag{
+						{Name: "binaryTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+					{Name: "singleTag", Tags: []pbv1.Tag{
+						{Name: "strTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "intTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "strTag1", Values: []*modelv1.TagValue{strTagValue("tag1")}},
+						{Name: "strTag2", Values: []*modelv1.TagValue{strTagValue("tag2")}},
+					}},
+				},
+				Fields: nil,
+			}, {
+				SID:        3,
+				Timestamps: []int64{1},
+				Versions:   []int64{3},
+				TagFamilies: []pbv1.TagFamily{
+					{Name: "arrTag", Tags: []pbv1.Tag{
+						{Name: "strArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "intArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+					{Name: "binaryTag", Tags: []pbv1.Tag{
+						{Name: "binaryTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+					{Name: "singleTag", Tags: []pbv1.Tag{
+						{Name: "strTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "intTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "strTag1", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "strTag2", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+				},
+				Fields: []pbv1.Field{
+					{Name: "intField", Values: []*modelv1.FieldValue{int64FieldValue(1110)}},
+				},
+			}},
+		},
+		{
+			name:         "Test with multiple parts with duplicated data with different version order by TS 2",
+			dpsList:      []*dataPoints{dpsTS11, dpsTS1},
+			sids:         []common.SeriesID{1, 2, 3},
+			minTimestamp: 1,
+			maxTimestamp: 1,
+			want: []pbv1.MeasureResult{{
+				SID:        1,
+				Timestamps: []int64{1},
+				Versions:   []int64{1},
+				TagFamilies: []pbv1.TagFamily{
+					{Name: "arrTag", Tags: []pbv1.Tag{
+						{Name: "strArrTag", Values: []*modelv1.TagValue{strArrTagValue([]string{"value1", "value2"})}},
+						{Name: "intArrTag", Values: []*modelv1.TagValue{int64ArrTagValue([]int64{25, 30})}},
+					}},
+					{Name: "binaryTag", Tags: []pbv1.Tag{
+						{Name: "binaryTag", Values: []*modelv1.TagValue{binaryDataTagValue(longText)}},
+					}},
+					{Name: "singleTag", Tags: []pbv1.Tag{
+						{Name: "strTag", Values: []*modelv1.TagValue{strTagValue("value1")}},
+						{Name: "intTag", Values: []*modelv1.TagValue{int64TagValue(10)}},
+						{Name: "strTag1", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "strTag2", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+				},
+				Fields: []pbv1.Field{
+					{Name: "strField", Values: []*modelv1.FieldValue{strFieldValue("field1")}},
+					{Name: "intField", Values: []*modelv1.FieldValue{int64FieldValue(1110)}},
+					{Name: "floatField", Values: []*modelv1.FieldValue{float64FieldValue(1.221233343e+06)}},
+					{Name: "binaryField", Values: []*modelv1.FieldValue{binaryDataFieldValue(longText)}},
+				},
+			}, {
+				SID:        2,
+				Timestamps: []int64{1},
+				Versions:   []int64{2},
+				TagFamilies: []pbv1.TagFamily{
+					{Name: "arrTag", Tags: []pbv1.Tag{
+						{Name: "strArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "intArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+					{Name: "binaryTag", Tags: []pbv1.Tag{
+						{Name: "binaryTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+					{Name: "singleTag", Tags: []pbv1.Tag{
+						{Name: "strTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "intTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "strTag1", Values: []*modelv1.TagValue{strTagValue("tag1")}},
+						{Name: "strTag2", Values: []*modelv1.TagValue{strTagValue("tag2")}},
+					}},
+				},
+				Fields: nil,
+			}, {
+				SID:        3,
+				Timestamps: []int64{1},
+				Versions:   []int64{3},
+				TagFamilies: []pbv1.TagFamily{
+					{Name: "arrTag", Tags: []pbv1.Tag{
+						{Name: "strArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "intArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+					{Name: "binaryTag", Tags: []pbv1.Tag{
+						{Name: "binaryTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+					{Name: "singleTag", Tags: []pbv1.Tag{
+						{Name: "strTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "intTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "strTag1", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "strTag2", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+				},
+				Fields: []pbv1.Field{
+					{Name: "intField", Values: []*modelv1.FieldValue{int64FieldValue(1110)}},
+				},
+			}},
+		},
+		{
+			name:         "Test with multiple parts with multiple data orderBy TS desc 1",
 			dpsList:      []*dataPoints{dpsTS1, dpsTS2},
 			sids:         []common.SeriesID{1, 2, 3},
 			minTimestamp: 1,
@@ -131,6 +284,7 @@ func TestQueryResult(t *testing.T) {
 			want: []pbv1.MeasureResult{{
 				SID:        1,
 				Timestamps: []int64{2},
+				Versions:   []int64{4},
 				TagFamilies: []pbv1.TagFamily{
 					{Name: "arrTag", Tags: []pbv1.Tag{
 						{Name: "strArrTag", Values: []*modelv1.TagValue{strArrTagValue([]string{"value5", "value6"})}},
@@ -155,6 +309,7 @@ func TestQueryResult(t *testing.T) {
 			}, {
 				SID:        2,
 				Timestamps: []int64{2},
+				Versions:   []int64{5},
 				TagFamilies: []pbv1.TagFamily{
 					{Name: "arrTag", Tags: []pbv1.Tag{
 						{Name: "strArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
@@ -174,6 +329,7 @@ func TestQueryResult(t *testing.T) {
 			}, {
 				SID:        3,
 				Timestamps: []int64{2},
+				Versions:   []int64{6},
 				TagFamilies: []pbv1.TagFamily{
 					{Name: "arrTag", Tags: []pbv1.Tag{
 						{Name: "strArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
@@ -195,6 +351,7 @@ func TestQueryResult(t *testing.T) {
 			}, {
 				SID:        1,
 				Timestamps: []int64{1},
+				Versions:   []int64{1},
 				TagFamilies: []pbv1.TagFamily{
 					{Name: "arrTag", Tags: []pbv1.Tag{
 						{Name: "strArrTag", Values: []*modelv1.TagValue{strArrTagValue([]string{"value1", "value2"})}},
@@ -219,6 +376,7 @@ func TestQueryResult(t *testing.T) {
 			}, {
 				SID:        2,
 				Timestamps: []int64{1},
+				Versions:   []int64{2},
 				TagFamilies: []pbv1.TagFamily{
 					{Name: "arrTag", Tags: []pbv1.Tag{
 						{Name: "strArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
@@ -238,6 +396,7 @@ func TestQueryResult(t *testing.T) {
 			}, {
 				SID:        3,
 				Timestamps: []int64{1},
+				Versions:   []int64{3},
 				TagFamilies: []pbv1.TagFamily{
 					{Name: "arrTag", Tags: []pbv1.Tag{
 						{Name: "strArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
@@ -259,79 +418,15 @@ func TestQueryResult(t *testing.T) {
 			}},
 		},
 		{
-			name:         "Test with multiple parts with multiple data orderBy TS asc",
-			dpsList:      []*dataPoints{dpsTS1, dpsTS2},
+			name:         "Test with multiple parts with multiple data orderBy TS desc 2",
+			dpsList:      []*dataPoints{dpsTS2, dpsTS1},
 			sids:         []common.SeriesID{1, 2, 3},
-			ascTS:        true,
 			minTimestamp: 1,
 			maxTimestamp: 2,
 			want: []pbv1.MeasureResult{{
 				SID:        1,
-				Timestamps: []int64{1},
-				TagFamilies: []pbv1.TagFamily{
-					{Name: "arrTag", Tags: []pbv1.Tag{
-						{Name: "strArrTag", Values: []*modelv1.TagValue{strArrTagValue([]string{"value1", "value2"})}},
-						{Name: "intArrTag", Values: []*modelv1.TagValue{int64ArrTagValue([]int64{25, 30})}},
-					}},
-					{Name: "binaryTag", Tags: []pbv1.Tag{
-						{Name: "binaryTag", Values: []*modelv1.TagValue{binaryDataTagValue(longText)}},
-					}},
-					{Name: "singleTag", Tags: []pbv1.Tag{
-						{Name: "strTag", Values: []*modelv1.TagValue{strTagValue("value1")}},
-						{Name: "intTag", Values: []*modelv1.TagValue{int64TagValue(10)}},
-						{Name: "strTag1", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
-						{Name: "strTag2", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
-					}},
-				},
-				Fields: []pbv1.Field{
-					{Name: "strField", Values: []*modelv1.FieldValue{strFieldValue("field1")}},
-					{Name: "intField", Values: []*modelv1.FieldValue{int64FieldValue(1110)}},
-					{Name: "floatField", Values: []*modelv1.FieldValue{float64FieldValue(1221233.343)}},
-					{Name: "binaryField", Values: []*modelv1.FieldValue{binaryDataFieldValue(longText)}},
-				},
-			}, {
-				SID:        2,
-				Timestamps: []int64{1},
-				TagFamilies: []pbv1.TagFamily{
-					{Name: "arrTag", Tags: []pbv1.Tag{
-						{Name: "strArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
-						{Name: "intArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
-					}},
-					{Name: "binaryTag", Tags: []pbv1.Tag{
-						{Name: "binaryTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
-					}},
-					{Name: "singleTag", Tags: []pbv1.Tag{
-						{Name: "strTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
-						{Name: "intTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
-						{Name: "strTag1", Values: []*modelv1.TagValue{strTagValue("tag1")}},
-						{Name: "strTag2", Values: []*modelv1.TagValue{strTagValue("tag2")}},
-					}},
-				},
-				Fields: nil,
-			}, {
-				SID:        3,
-				Timestamps: []int64{1},
-				TagFamilies: []pbv1.TagFamily{
-					{Name: "arrTag", Tags: []pbv1.Tag{
-						{Name: "strArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
-						{Name: "intArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
-					}},
-					{Name: "binaryTag", Tags: []pbv1.Tag{
-						{Name: "binaryTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
-					}},
-					{Name: "singleTag", Tags: []pbv1.Tag{
-						{Name: "strTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
-						{Name: "intTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
-						{Name: "strTag1", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
-						{Name: "strTag2", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
-					}},
-				},
-				Fields: []pbv1.Field{
-					{Name: "intField", Values: []*modelv1.FieldValue{int64FieldValue(1110)}},
-				},
-			}, {
-				SID:        1,
 				Timestamps: []int64{2},
+				Versions:   []int64{4},
 				TagFamilies: []pbv1.TagFamily{
 					{Name: "arrTag", Tags: []pbv1.Tag{
 						{Name: "strArrTag", Values: []*modelv1.TagValue{strArrTagValue([]string{"value5", "value6"})}},
@@ -356,6 +451,7 @@ func TestQueryResult(t *testing.T) {
 			}, {
 				SID:        2,
 				Timestamps: []int64{2},
+				Versions:   []int64{5},
 				TagFamilies: []pbv1.TagFamily{
 					{Name: "arrTag", Tags: []pbv1.Tag{
 						{Name: "strArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
@@ -375,6 +471,360 @@ func TestQueryResult(t *testing.T) {
 			}, {
 				SID:        3,
 				Timestamps: []int64{2},
+				Versions:   []int64{6},
+				TagFamilies: []pbv1.TagFamily{
+					{Name: "arrTag", Tags: []pbv1.Tag{
+						{Name: "strArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "intArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+					{Name: "binaryTag", Tags: []pbv1.Tag{
+						{Name: "binaryTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+					{Name: "singleTag", Tags: []pbv1.Tag{
+						{Name: "strTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "intTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "strTag1", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "strTag2", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+				},
+				Fields: []pbv1.Field{
+					{Name: "intField", Values: []*modelv1.FieldValue{int64FieldValue(4440)}},
+				},
+			}, {
+				SID:        1,
+				Timestamps: []int64{1},
+				Versions:   []int64{1},
+				TagFamilies: []pbv1.TagFamily{
+					{Name: "arrTag", Tags: []pbv1.Tag{
+						{Name: "strArrTag", Values: []*modelv1.TagValue{strArrTagValue([]string{"value1", "value2"})}},
+						{Name: "intArrTag", Values: []*modelv1.TagValue{int64ArrTagValue([]int64{25, 30})}},
+					}},
+					{Name: "binaryTag", Tags: []pbv1.Tag{
+						{Name: "binaryTag", Values: []*modelv1.TagValue{binaryDataTagValue(longText)}},
+					}},
+					{Name: "singleTag", Tags: []pbv1.Tag{
+						{Name: "strTag", Values: []*modelv1.TagValue{strTagValue("value1")}},
+						{Name: "intTag", Values: []*modelv1.TagValue{int64TagValue(10)}},
+						{Name: "strTag1", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "strTag2", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+				},
+				Fields: []pbv1.Field{
+					{Name: "strField", Values: []*modelv1.FieldValue{strFieldValue("field1")}},
+					{Name: "intField", Values: []*modelv1.FieldValue{int64FieldValue(1110)}},
+					{Name: "floatField", Values: []*modelv1.FieldValue{float64FieldValue(1221233.343)}},
+					{Name: "binaryField", Values: []*modelv1.FieldValue{binaryDataFieldValue(longText)}},
+				},
+			}, {
+				SID:        2,
+				Timestamps: []int64{1},
+				Versions:   []int64{2},
+				TagFamilies: []pbv1.TagFamily{
+					{Name: "arrTag", Tags: []pbv1.Tag{
+						{Name: "strArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "intArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+					{Name: "binaryTag", Tags: []pbv1.Tag{
+						{Name: "binaryTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+					{Name: "singleTag", Tags: []pbv1.Tag{
+						{Name: "strTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "intTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "strTag1", Values: []*modelv1.TagValue{strTagValue("tag1")}},
+						{Name: "strTag2", Values: []*modelv1.TagValue{strTagValue("tag2")}},
+					}},
+				},
+				Fields: nil,
+			}, {
+				SID:        3,
+				Timestamps: []int64{1},
+				Versions:   []int64{3},
+				TagFamilies: []pbv1.TagFamily{
+					{Name: "arrTag", Tags: []pbv1.Tag{
+						{Name: "strArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "intArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+					{Name: "binaryTag", Tags: []pbv1.Tag{
+						{Name: "binaryTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+					{Name: "singleTag", Tags: []pbv1.Tag{
+						{Name: "strTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "intTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "strTag1", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "strTag2", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+				},
+				Fields: []pbv1.Field{
+					{Name: "intField", Values: []*modelv1.FieldValue{int64FieldValue(1110)}},
+				},
+			}},
+		},
+		{
+			name:         "Test with multiple parts with multiple data orderBy TS asc 1",
+			dpsList:      []*dataPoints{dpsTS1, dpsTS2},
+			sids:         []common.SeriesID{1, 2, 3},
+			ascTS:        true,
+			minTimestamp: 1,
+			maxTimestamp: 2,
+			want: []pbv1.MeasureResult{{
+				SID:        1,
+				Timestamps: []int64{1},
+				Versions:   []int64{1},
+				TagFamilies: []pbv1.TagFamily{
+					{Name: "arrTag", Tags: []pbv1.Tag{
+						{Name: "strArrTag", Values: []*modelv1.TagValue{strArrTagValue([]string{"value1", "value2"})}},
+						{Name: "intArrTag", Values: []*modelv1.TagValue{int64ArrTagValue([]int64{25, 30})}},
+					}},
+					{Name: "binaryTag", Tags: []pbv1.Tag{
+						{Name: "binaryTag", Values: []*modelv1.TagValue{binaryDataTagValue(longText)}},
+					}},
+					{Name: "singleTag", Tags: []pbv1.Tag{
+						{Name: "strTag", Values: []*modelv1.TagValue{strTagValue("value1")}},
+						{Name: "intTag", Values: []*modelv1.TagValue{int64TagValue(10)}},
+						{Name: "strTag1", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "strTag2", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+				},
+				Fields: []pbv1.Field{
+					{Name: "strField", Values: []*modelv1.FieldValue{strFieldValue("field1")}},
+					{Name: "intField", Values: []*modelv1.FieldValue{int64FieldValue(1110)}},
+					{Name: "floatField", Values: []*modelv1.FieldValue{float64FieldValue(1221233.343)}},
+					{Name: "binaryField", Values: []*modelv1.FieldValue{binaryDataFieldValue(longText)}},
+				},
+			}, {
+				SID:        2,
+				Timestamps: []int64{1},
+				Versions:   []int64{2},
+				TagFamilies: []pbv1.TagFamily{
+					{Name: "arrTag", Tags: []pbv1.Tag{
+						{Name: "strArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "intArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+					{Name: "binaryTag", Tags: []pbv1.Tag{
+						{Name: "binaryTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+					{Name: "singleTag", Tags: []pbv1.Tag{
+						{Name: "strTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "intTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "strTag1", Values: []*modelv1.TagValue{strTagValue("tag1")}},
+						{Name: "strTag2", Values: []*modelv1.TagValue{strTagValue("tag2")}},
+					}},
+				},
+				Fields: nil,
+			}, {
+				SID:        3,
+				Timestamps: []int64{1},
+				Versions:   []int64{3},
+				TagFamilies: []pbv1.TagFamily{
+					{Name: "arrTag", Tags: []pbv1.Tag{
+						{Name: "strArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "intArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+					{Name: "binaryTag", Tags: []pbv1.Tag{
+						{Name: "binaryTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+					{Name: "singleTag", Tags: []pbv1.Tag{
+						{Name: "strTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "intTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "strTag1", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "strTag2", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+				},
+				Fields: []pbv1.Field{
+					{Name: "intField", Values: []*modelv1.FieldValue{int64FieldValue(1110)}},
+				},
+			}, {
+				SID:        1,
+				Timestamps: []int64{2},
+				Versions:   []int64{4},
+				TagFamilies: []pbv1.TagFamily{
+					{Name: "arrTag", Tags: []pbv1.Tag{
+						{Name: "strArrTag", Values: []*modelv1.TagValue{strArrTagValue([]string{"value5", "value6"})}},
+						{Name: "intArrTag", Values: []*modelv1.TagValue{int64ArrTagValue([]int64{35, 40})}},
+					}},
+					{Name: "binaryTag", Tags: []pbv1.Tag{
+						{Name: "binaryTag", Values: []*modelv1.TagValue{binaryDataTagValue(longText)}},
+					}},
+					{Name: "singleTag", Tags: []pbv1.Tag{
+						{Name: "strTag", Values: []*modelv1.TagValue{strTagValue("value3")}},
+						{Name: "intTag", Values: []*modelv1.TagValue{int64TagValue(30)}},
+						{Name: "strTag1", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "strTag2", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+				},
+				Fields: []pbv1.Field{
+					{Name: "strField", Values: []*modelv1.FieldValue{strFieldValue("field3")}},
+					{Name: "intField", Values: []*modelv1.FieldValue{int64FieldValue(3330)}},
+					{Name: "floatField", Values: []*modelv1.FieldValue{float64FieldValue(3663699.029)}},
+					{Name: "binaryField", Values: []*modelv1.FieldValue{binaryDataFieldValue(longText)}},
+				},
+			}, {
+				SID:        2,
+				Timestamps: []int64{2},
+				Versions:   []int64{5},
+				TagFamilies: []pbv1.TagFamily{
+					{Name: "arrTag", Tags: []pbv1.Tag{
+						{Name: "strArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "intArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+					{Name: "binaryTag", Tags: []pbv1.Tag{
+						{Name: "binaryTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+					{Name: "singleTag", Tags: []pbv1.Tag{
+						{Name: "strTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "intTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "strTag1", Values: []*modelv1.TagValue{strTagValue("tag3")}},
+						{Name: "strTag2", Values: []*modelv1.TagValue{strTagValue("tag4")}},
+					}},
+				},
+				Fields: nil,
+			}, {
+				SID:        3,
+				Timestamps: []int64{2},
+				Versions:   []int64{6},
+				TagFamilies: []pbv1.TagFamily{
+					{Name: "arrTag", Tags: []pbv1.Tag{
+						{Name: "strArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "intArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+					{Name: "binaryTag", Tags: []pbv1.Tag{
+						{Name: "binaryTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+					{Name: "singleTag", Tags: []pbv1.Tag{
+						{Name: "strTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "intTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "strTag1", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "strTag2", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+				},
+				Fields: []pbv1.Field{
+					{Name: "intField", Values: []*modelv1.FieldValue{int64FieldValue(4440)}},
+				},
+			}},
+		},
+		{
+			name:         "Test with multiple parts with multiple data orderBy TS asc 2",
+			dpsList:      []*dataPoints{dpsTS2, dpsTS1},
+			sids:         []common.SeriesID{1, 2, 3},
+			ascTS:        true,
+			minTimestamp: 1,
+			maxTimestamp: 2,
+			want: []pbv1.MeasureResult{{
+				SID:        1,
+				Timestamps: []int64{1},
+				Versions:   []int64{1},
+				TagFamilies: []pbv1.TagFamily{
+					{Name: "arrTag", Tags: []pbv1.Tag{
+						{Name: "strArrTag", Values: []*modelv1.TagValue{strArrTagValue([]string{"value1", "value2"})}},
+						{Name: "intArrTag", Values: []*modelv1.TagValue{int64ArrTagValue([]int64{25, 30})}},
+					}},
+					{Name: "binaryTag", Tags: []pbv1.Tag{
+						{Name: "binaryTag", Values: []*modelv1.TagValue{binaryDataTagValue(longText)}},
+					}},
+					{Name: "singleTag", Tags: []pbv1.Tag{
+						{Name: "strTag", Values: []*modelv1.TagValue{strTagValue("value1")}},
+						{Name: "intTag", Values: []*modelv1.TagValue{int64TagValue(10)}},
+						{Name: "strTag1", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "strTag2", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+				},
+				Fields: []pbv1.Field{
+					{Name: "strField", Values: []*modelv1.FieldValue{strFieldValue("field1")}},
+					{Name: "intField", Values: []*modelv1.FieldValue{int64FieldValue(1110)}},
+					{Name: "floatField", Values: []*modelv1.FieldValue{float64FieldValue(1221233.343)}},
+					{Name: "binaryField", Values: []*modelv1.FieldValue{binaryDataFieldValue(longText)}},
+				},
+			}, {
+				SID:        2,
+				Timestamps: []int64{1},
+				Versions:   []int64{2},
+				TagFamilies: []pbv1.TagFamily{
+					{Name: "arrTag", Tags: []pbv1.Tag{
+						{Name: "strArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "intArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+					{Name: "binaryTag", Tags: []pbv1.Tag{
+						{Name: "binaryTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+					{Name: "singleTag", Tags: []pbv1.Tag{
+						{Name: "strTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "intTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "strTag1", Values: []*modelv1.TagValue{strTagValue("tag1")}},
+						{Name: "strTag2", Values: []*modelv1.TagValue{strTagValue("tag2")}},
+					}},
+				},
+				Fields: nil,
+			}, {
+				SID:        3,
+				Timestamps: []int64{1},
+				Versions:   []int64{3},
+				TagFamilies: []pbv1.TagFamily{
+					{Name: "arrTag", Tags: []pbv1.Tag{
+						{Name: "strArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "intArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+					{Name: "binaryTag", Tags: []pbv1.Tag{
+						{Name: "binaryTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+					{Name: "singleTag", Tags: []pbv1.Tag{
+						{Name: "strTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "intTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "strTag1", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "strTag2", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+				},
+				Fields: []pbv1.Field{
+					{Name: "intField", Values: []*modelv1.FieldValue{int64FieldValue(1110)}},
+				},
+			}, {
+				SID:        1,
+				Timestamps: []int64{2},
+				Versions:   []int64{4},
+				TagFamilies: []pbv1.TagFamily{
+					{Name: "arrTag", Tags: []pbv1.Tag{
+						{Name: "strArrTag", Values: []*modelv1.TagValue{strArrTagValue([]string{"value5", "value6"})}},
+						{Name: "intArrTag", Values: []*modelv1.TagValue{int64ArrTagValue([]int64{35, 40})}},
+					}},
+					{Name: "binaryTag", Tags: []pbv1.Tag{
+						{Name: "binaryTag", Values: []*modelv1.TagValue{binaryDataTagValue(longText)}},
+					}},
+					{Name: "singleTag", Tags: []pbv1.Tag{
+						{Name: "strTag", Values: []*modelv1.TagValue{strTagValue("value3")}},
+						{Name: "intTag", Values: []*modelv1.TagValue{int64TagValue(30)}},
+						{Name: "strTag1", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "strTag2", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+				},
+				Fields: []pbv1.Field{
+					{Name: "strField", Values: []*modelv1.FieldValue{strFieldValue("field3")}},
+					{Name: "intField", Values: []*modelv1.FieldValue{int64FieldValue(3330)}},
+					{Name: "floatField", Values: []*modelv1.FieldValue{float64FieldValue(3663699.029)}},
+					{Name: "binaryField", Values: []*modelv1.FieldValue{binaryDataFieldValue(longText)}},
+				},
+			}, {
+				SID:        2,
+				Timestamps: []int64{2},
+				Versions:   []int64{5},
+				TagFamilies: []pbv1.TagFamily{
+					{Name: "arrTag", Tags: []pbv1.Tag{
+						{Name: "strArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "intArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+					{Name: "binaryTag", Tags: []pbv1.Tag{
+						{Name: "binaryTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+					{Name: "singleTag", Tags: []pbv1.Tag{
+						{Name: "strTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "intTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "strTag1", Values: []*modelv1.TagValue{strTagValue("tag3")}},
+						{Name: "strTag2", Values: []*modelv1.TagValue{strTagValue("tag4")}},
+					}},
+				},
+				Fields: nil,
+			}, {
+				SID:        3,
+				Timestamps: []int64{2},
+				Versions:   []int64{6},
 				TagFamilies: []pbv1.TagFamily{
 					{Name: "arrTag", Tags: []pbv1.Tag{
 						{Name: "strArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
@@ -405,6 +855,7 @@ func TestQueryResult(t *testing.T) {
 			want: []pbv1.MeasureResult{{
 				SID:        1,
 				Timestamps: []int64{1},
+				Versions:   []int64{1},
 				TagFamilies: []pbv1.TagFamily{
 					{Name: "arrTag", Tags: []pbv1.Tag{
 						{Name: "strArrTag", Values: []*modelv1.TagValue{strArrTagValue([]string{"value1", "value2"})}},
@@ -429,6 +880,7 @@ func TestQueryResult(t *testing.T) {
 			}, {
 				SID:        2,
 				Timestamps: []int64{1},
+				Versions:   []int64{2},
 				TagFamilies: []pbv1.TagFamily{
 					{Name: "arrTag", Tags: []pbv1.Tag{
 						{Name: "strArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
@@ -448,6 +900,7 @@ func TestQueryResult(t *testing.T) {
 			}, {
 				SID:        3,
 				Timestamps: []int64{1},
+				Versions:   []int64{3},
 				TagFamilies: []pbv1.TagFamily{
 					{Name: "arrTag", Tags: []pbv1.Tag{
 						{Name: "strArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
@@ -469,7 +922,159 @@ func TestQueryResult(t *testing.T) {
 			}},
 		},
 		{
-			name:          "Test with multiple parts with multiple data order by Series",
+			name:          "Test with multiple parts with duplicated data with different versions order by Series 1",
+			dpsList:       []*dataPoints{dpsTS11, dpsTS1},
+			sids:          []common.SeriesID{1, 2, 3},
+			orderBySeries: true,
+			minTimestamp:  1,
+			maxTimestamp:  1,
+			want: []pbv1.MeasureResult{{
+				SID:        1,
+				Timestamps: []int64{1},
+				Versions:   []int64{1},
+				TagFamilies: []pbv1.TagFamily{
+					{Name: "arrTag", Tags: []pbv1.Tag{
+						{Name: "strArrTag", Values: []*modelv1.TagValue{strArrTagValue([]string{"value1", "value2"})}},
+						{Name: "intArrTag", Values: []*modelv1.TagValue{int64ArrTagValue([]int64{25, 30})}},
+					}},
+					{Name: "binaryTag", Tags: []pbv1.Tag{
+						{Name: "binaryTag", Values: []*modelv1.TagValue{binaryDataTagValue(longText)}},
+					}},
+					{Name: "singleTag", Tags: []pbv1.Tag{
+						{Name: "strTag", Values: []*modelv1.TagValue{strTagValue("value1")}},
+						{Name: "intTag", Values: []*modelv1.TagValue{int64TagValue(10)}},
+						{Name: "strTag1", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "strTag2", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+				},
+				Fields: []pbv1.Field{
+					{Name: "strField", Values: []*modelv1.FieldValue{strFieldValue("field1")}},
+					{Name: "intField", Values: []*modelv1.FieldValue{int64FieldValue(1110)}},
+					{Name: "floatField", Values: []*modelv1.FieldValue{float64FieldValue(1.221233343e+06)}},
+					{Name: "binaryField", Values: []*modelv1.FieldValue{binaryDataFieldValue(longText)}},
+				},
+			}, {
+				SID:        2,
+				Timestamps: []int64{1},
+				Versions:   []int64{2},
+				TagFamilies: []pbv1.TagFamily{
+					{Name: "arrTag", Tags: []pbv1.Tag{
+						{Name: "strArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "intArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+					{Name: "binaryTag", Tags: []pbv1.Tag{
+						{Name: "binaryTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+					{Name: "singleTag", Tags: []pbv1.Tag{
+						{Name: "strTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "intTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "strTag1", Values: []*modelv1.TagValue{strTagValue("tag1")}},
+						{Name: "strTag2", Values: []*modelv1.TagValue{strTagValue("tag2")}},
+					}},
+				},
+				Fields: nil,
+			}, {
+				SID:        3,
+				Timestamps: []int64{1},
+				Versions:   []int64{3},
+				TagFamilies: []pbv1.TagFamily{
+					{Name: "arrTag", Tags: []pbv1.Tag{
+						{Name: "strArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "intArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+					{Name: "binaryTag", Tags: []pbv1.Tag{
+						{Name: "binaryTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+					{Name: "singleTag", Tags: []pbv1.Tag{
+						{Name: "strTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "intTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "strTag1", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "strTag2", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+				},
+				Fields: []pbv1.Field{
+					{Name: "intField", Values: []*modelv1.FieldValue{int64FieldValue(1110)}},
+				},
+			}},
+		},
+		{
+			name:          "Test with multiple parts with duplicated data with different versions order by Series 2",
+			dpsList:       []*dataPoints{dpsTS1, dpsTS11},
+			sids:          []common.SeriesID{1, 2, 3},
+			orderBySeries: true,
+			minTimestamp:  1,
+			maxTimestamp:  1,
+			want: []pbv1.MeasureResult{{
+				SID:        1,
+				Timestamps: []int64{1},
+				Versions:   []int64{1},
+				TagFamilies: []pbv1.TagFamily{
+					{Name: "arrTag", Tags: []pbv1.Tag{
+						{Name: "strArrTag", Values: []*modelv1.TagValue{strArrTagValue([]string{"value1", "value2"})}},
+						{Name: "intArrTag", Values: []*modelv1.TagValue{int64ArrTagValue([]int64{25, 30})}},
+					}},
+					{Name: "binaryTag", Tags: []pbv1.Tag{
+						{Name: "binaryTag", Values: []*modelv1.TagValue{binaryDataTagValue(longText)}},
+					}},
+					{Name: "singleTag", Tags: []pbv1.Tag{
+						{Name: "strTag", Values: []*modelv1.TagValue{strTagValue("value1")}},
+						{Name: "intTag", Values: []*modelv1.TagValue{int64TagValue(10)}},
+						{Name: "strTag1", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "strTag2", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+				},
+				Fields: []pbv1.Field{
+					{Name: "strField", Values: []*modelv1.FieldValue{strFieldValue("field1")}},
+					{Name: "intField", Values: []*modelv1.FieldValue{int64FieldValue(1110)}},
+					{Name: "floatField", Values: []*modelv1.FieldValue{float64FieldValue(1.221233343e+06)}},
+					{Name: "binaryField", Values: []*modelv1.FieldValue{binaryDataFieldValue(longText)}},
+				},
+			}, {
+				SID:        2,
+				Timestamps: []int64{1},
+				Versions:   []int64{2},
+				TagFamilies: []pbv1.TagFamily{
+					{Name: "arrTag", Tags: []pbv1.Tag{
+						{Name: "strArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "intArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+					{Name: "binaryTag", Tags: []pbv1.Tag{
+						{Name: "binaryTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+					{Name: "singleTag", Tags: []pbv1.Tag{
+						{Name: "strTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "intTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "strTag1", Values: []*modelv1.TagValue{strTagValue("tag1")}},
+						{Name: "strTag2", Values: []*modelv1.TagValue{strTagValue("tag2")}},
+					}},
+				},
+				Fields: nil,
+			}, {
+				SID:        3,
+				Timestamps: []int64{1},
+				Versions:   []int64{3},
+				TagFamilies: []pbv1.TagFamily{
+					{Name: "arrTag", Tags: []pbv1.Tag{
+						{Name: "strArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "intArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+					{Name: "binaryTag", Tags: []pbv1.Tag{
+						{Name: "binaryTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+					{Name: "singleTag", Tags: []pbv1.Tag{
+						{Name: "strTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "intTag", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "strTag1", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+						{Name: "strTag2", Values: []*modelv1.TagValue{pbv1.NullTagValue}},
+					}},
+				},
+				Fields: []pbv1.Field{
+					{Name: "intField", Values: []*modelv1.FieldValue{int64FieldValue(1110)}},
+				},
+			}},
+		},
+		{
+			name:          "Test with multiple parts with multiple data order by Series 1",
 			dpsList:       []*dataPoints{dpsTS1, dpsTS2},
 			sids:          []common.SeriesID{2, 1, 3},
 			orderBySeries: true,
@@ -478,6 +1083,7 @@ func TestQueryResult(t *testing.T) {
 			want: []pbv1.MeasureResult{{
 				SID:        2,
 				Timestamps: []int64{1, 2},
+				Versions:   []int64{2, 5},
 				TagFamilies: []pbv1.TagFamily{
 					{Name: "arrTag", Tags: []pbv1.Tag{
 						{Name: "strArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue, pbv1.NullTagValue}},
@@ -497,6 +1103,7 @@ func TestQueryResult(t *testing.T) {
 			}, {
 				SID:        1,
 				Timestamps: []int64{1, 2},
+				Versions:   []int64{1, 4},
 				TagFamilies: []pbv1.TagFamily{
 					{Name: "arrTag", Tags: []pbv1.Tag{
 						{Name: "strArrTag", Values: []*modelv1.TagValue{strArrTagValue([]string{"value1", "value2"}), strArrTagValue([]string{"value5", "value6"})}},
@@ -521,6 +1128,83 @@ func TestQueryResult(t *testing.T) {
 			}, {
 				SID:        3,
 				Timestamps: []int64{1, 2},
+				Versions:   []int64{3, 6},
+				TagFamilies: []pbv1.TagFamily{
+					{Name: "arrTag", Tags: []pbv1.Tag{
+						{Name: "strArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue, pbv1.NullTagValue}},
+						{Name: "intArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue, pbv1.NullTagValue}},
+					}},
+					{Name: "binaryTag", Tags: []pbv1.Tag{
+						{Name: "binaryTag", Values: []*modelv1.TagValue{pbv1.NullTagValue, pbv1.NullTagValue}},
+					}},
+					{Name: "singleTag", Tags: []pbv1.Tag{
+						{Name: "strTag", Values: []*modelv1.TagValue{pbv1.NullTagValue, pbv1.NullTagValue}},
+						{Name: "intTag", Values: []*modelv1.TagValue{pbv1.NullTagValue, pbv1.NullTagValue}},
+						{Name: "strTag1", Values: []*modelv1.TagValue{pbv1.NullTagValue, pbv1.NullTagValue}},
+						{Name: "strTag2", Values: []*modelv1.TagValue{pbv1.NullTagValue, pbv1.NullTagValue}},
+					}},
+				},
+				Fields: []pbv1.Field{
+					{Name: "intField", Values: []*modelv1.FieldValue{int64FieldValue(1110), int64FieldValue(4440)}},
+				},
+			}},
+		},
+		{
+			name:          "Test with multiple parts with multiple data order by Series 2",
+			dpsList:       []*dataPoints{dpsTS2, dpsTS1},
+			sids:          []common.SeriesID{2, 1, 3},
+			orderBySeries: true,
+			minTimestamp:  1,
+			maxTimestamp:  2,
+			want: []pbv1.MeasureResult{{
+				SID:        2,
+				Timestamps: []int64{1, 2},
+				Versions:   []int64{2, 5},
+				TagFamilies: []pbv1.TagFamily{
+					{Name: "arrTag", Tags: []pbv1.Tag{
+						{Name: "strArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue, pbv1.NullTagValue}},
+						{Name: "intArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue, pbv1.NullTagValue}},
+					}},
+					{Name: "binaryTag", Tags: []pbv1.Tag{
+						{Name: "binaryTag", Values: []*modelv1.TagValue{pbv1.NullTagValue, pbv1.NullTagValue}},
+					}},
+					{Name: "singleTag", Tags: []pbv1.Tag{
+						{Name: "strTag", Values: []*modelv1.TagValue{pbv1.NullTagValue, pbv1.NullTagValue}},
+						{Name: "intTag", Values: []*modelv1.TagValue{pbv1.NullTagValue, pbv1.NullTagValue}},
+						{Name: "strTag1", Values: []*modelv1.TagValue{strTagValue("tag1"), strTagValue("tag3")}},
+						{Name: "strTag2", Values: []*modelv1.TagValue{strTagValue("tag2"), strTagValue("tag4")}},
+					}},
+				},
+				Fields: nil,
+			}, {
+				SID:        1,
+				Timestamps: []int64{1, 2},
+				Versions:   []int64{1, 4},
+				TagFamilies: []pbv1.TagFamily{
+					{Name: "arrTag", Tags: []pbv1.Tag{
+						{Name: "strArrTag", Values: []*modelv1.TagValue{strArrTagValue([]string{"value1", "value2"}), strArrTagValue([]string{"value5", "value6"})}},
+						{Name: "intArrTag", Values: []*modelv1.TagValue{int64ArrTagValue([]int64{25, 30}), int64ArrTagValue([]int64{35, 40})}},
+					}},
+					{Name: "binaryTag", Tags: []pbv1.Tag{
+						{Name: "binaryTag", Values: []*modelv1.TagValue{binaryDataTagValue(longText), binaryDataTagValue(longText)}},
+					}},
+					{Name: "singleTag", Tags: []pbv1.Tag{
+						{Name: "strTag", Values: []*modelv1.TagValue{strTagValue("value1"), strTagValue("value3")}},
+						{Name: "intTag", Values: []*modelv1.TagValue{int64TagValue(10), int64TagValue(30)}},
+						{Name: "strTag1", Values: []*modelv1.TagValue{pbv1.NullTagValue, pbv1.NullTagValue}},
+						{Name: "strTag2", Values: []*modelv1.TagValue{pbv1.NullTagValue, pbv1.NullTagValue}},
+					}},
+				},
+				Fields: []pbv1.Field{
+					{Name: "strField", Values: []*modelv1.FieldValue{strFieldValue("field1"), strFieldValue("field3")}},
+					{Name: "intField", Values: []*modelv1.FieldValue{int64FieldValue(1110), int64FieldValue(3330)}},
+					{Name: "floatField", Values: []*modelv1.FieldValue{float64FieldValue(1.221233343e+06), float64FieldValue(3663699.029)}},
+					{Name: "binaryField", Values: []*modelv1.FieldValue{binaryDataFieldValue(longText), binaryDataFieldValue(longText)}},
+				},
+			}, {
+				SID:        3,
+				Timestamps: []int64{1, 2},
+				Versions:   []int64{3, 6},
 				TagFamilies: []pbv1.TagFamily{
 					{Name: "arrTag", Tags: []pbv1.Tag{
 						{Name: "strArrTag", Values: []*modelv1.TagValue{pbv1.NullTagValue, pbv1.NullTagValue}},

--- a/banyand/measure/write.go
+++ b/banyand/measure/write.go
@@ -93,6 +93,7 @@ func (w *writeCallback) handle(dst map[string]*dataPointsInGroup, writeEvent *me
 		dpg.tables = append(dpg.tables, dpt)
 	}
 	dpt.dataPoints.timestamps = append(dpt.dataPoints.timestamps, ts)
+	dpt.dataPoints.versions = append(dpt.dataPoints.versions, req.DataPoint.Version)
 	stm, ok := w.schemaRepo.loadMeasure(req.GetMetadata())
 	if !ok {
 		return nil, fmt.Errorf("cannot find measure definition: %s", req.GetMetadata())

--- a/banyand/stream/block.go
+++ b/banyand/stream/block.go
@@ -66,7 +66,7 @@ func (b *block) mustInitFromElements(timestamps []int64, elementIDs []string, ta
 func assertTimestampsSorted(timestamps []int64) {
 	for i := range timestamps {
 		if i > 0 && timestamps[i-1] > timestamps[i] {
-			logger.Panicf("log entries must be sorted by timestamp; got the previous entry with bigger timestamp %d than the current entry with timestamp %d",
+			logger.Panicf("elements must be sorted by timestamp; got the previous element with bigger timestamp %d than the current element with timestamp %d",
 				timestamps[i-1], timestamps[i])
 		}
 	}

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2363,6 +2363,7 @@ DataPoint is stored in Measures
 | timestamp | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  | timestamp is in the timeunit of milliseconds. |
 | tag_families | [banyandb.model.v1.TagFamily](#banyandb-model-v1-TagFamily) | repeated | tag_families contains tags selected in the projection |
 | fields | [DataPoint.Field](#banyandb-measure-v1-DataPoint-Field) | repeated | fields contains fields selected in the projection |
+| version | [int64](#int64) |  | version is the version of the data point |
 
 
 
@@ -2635,6 +2636,7 @@ DataPointValue is the data point for writing. It only contains values.
 | timestamp | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  | timestamp is in the timeunit of milliseconds. |
 | tag_families | [banyandb.model.v1.TagFamilyForWrite](#banyandb-model-v1-TagFamilyForWrite) | repeated | the order of tag_families&#39; items match the measure schema |
 | fields | [banyandb.model.v1.FieldValue](#banyandb-model-v1-FieldValue) | repeated | the order of fields match the measure schema |
+| version | [int64](#int64) |  | the version of the data point |
 
 
 

--- a/pkg/encoding/encoding.go
+++ b/pkg/encoding/encoding.go
@@ -89,5 +89,40 @@ const (
 	EncodeTypeDeltaConst
 	EncodeTypeDelta
 	EncodeTypeDeltaOfDelta
-	EncodeTypeXOR
+	EncodeTypeConstWithVersion
+	EncodeTypeDeltaConstWithVersion
+	EncodeTypeDeltaWithVersion
+	EncodeTypeDeltaOfDeltaWithVersion
 )
+
+// GetVersionType returns the version type of the given encoding type.
+func GetVersionType(et EncodeType) EncodeType {
+	switch et {
+	case EncodeTypeConst:
+		return EncodeTypeConstWithVersion
+	case EncodeTypeDeltaConst:
+		return EncodeTypeDeltaConstWithVersion
+	case EncodeTypeDelta:
+		return EncodeTypeDeltaWithVersion
+	case EncodeTypeDeltaOfDelta:
+		return EncodeTypeDeltaOfDeltaWithVersion
+	default:
+		return EncodeTypeUnknown
+	}
+}
+
+// GetCommonType returns the common type of the given encoding type.
+func GetCommonType(et EncodeType) EncodeType {
+	switch et {
+	case EncodeTypeConstWithVersion:
+		return EncodeTypeConst
+	case EncodeTypeDeltaConstWithVersion:
+		return EncodeTypeDeltaConst
+	case EncodeTypeDeltaWithVersion:
+		return EncodeTypeDelta
+	case EncodeTypeDeltaOfDeltaWithVersion:
+		return EncodeTypeDeltaOfDelta
+	default:
+		return EncodeTypeUnknown
+	}
+}

--- a/pkg/encoding/int_list.go
+++ b/pkg/encoding/int_list.go
@@ -55,7 +55,7 @@ func Int64ListToBytes(dst []byte, a []int64) (result []byte, mt EncodeType, firs
 
 // BytesToInt64List decodes bytes into a list of int64.
 func BytesToInt64List(dst []int64, src []byte, mt EncodeType, firstValue int64, itemsCount int) ([]int64, error) {
-	dst = extendInt64ListCapacity(dst, itemsCount)
+	dst = ExtendInt64ListCapacity(dst, itemsCount)
 
 	var err error
 	switch mt {
@@ -100,7 +100,8 @@ func BytesToInt64List(dst []int64, src []byte, mt EncodeType, firstValue int64, 
 	}
 }
 
-func extendInt64ListCapacity(dst []int64, additionalItems int) []int64 {
+// ExtendInt64ListCapacity extends the capacity of the int64 list.
+func ExtendInt64ListCapacity(dst []int64, additionalItems int) []int64 {
 	dstLen := len(dst)
 	if n := dstLen + additionalItems - cap(dst); n > 0 {
 		dst = append(dst[:cap(dst)], make([]int64, n)...)

--- a/pkg/pb/v1/metadata.go
+++ b/pkg/pb/v1/metadata.go
@@ -104,6 +104,7 @@ type Field struct {
 // MeasureResult is the result of a query.
 type MeasureResult struct {
 	Timestamps  []int64
+	Versions    []int64
 	TagFamilies []TagFamily
 	Fields      []Field
 	SID         common.SeriesID

--- a/pkg/query/logical/measure/measure_plan_indexscan_local.go
+++ b/pkg/query/logical/measure/measure_plan_indexscan_local.go
@@ -223,6 +223,7 @@ func (ei *resultMIterator) Next() bool {
 	for i := range r.Timestamps {
 		dp := &measurev1.DataPoint{
 			Timestamp: timestamppb.New(time.Unix(0, r.Timestamps[i])),
+			Version:   r.Versions[i],
 		}
 
 		for _, tf := range r.TagFamilies {

--- a/test/cases/measure/data/data.go
+++ b/test/cases/measure/data/data.go
@@ -75,9 +75,15 @@ var VerifyFn = func(innerGm gm.Gomega, sharedContext helpers.SharedContext, args
 	innerGm.Expect(err).NotTo(gm.HaveOccurred())
 	want := &measurev1.QueryResponse{}
 	helpers.UnmarshalYAML(ww, want)
+	for i := range resp.DataPoints {
+		if resp.DataPoints[i].Timestamp != nil {
+			innerGm.Expect(resp.DataPoints[i].Version).Should(gm.BeNumerically(">", 0))
+		}
+	}
 	innerGm.Expect(cmp.Equal(resp, want,
 		protocmp.IgnoreUnknown(),
 		protocmp.IgnoreFields(&measurev1.DataPoint{}, "timestamp"),
+		protocmp.IgnoreFields(&measurev1.DataPoint{}, "version"),
 		protocmp.Transform())).
 		To(gm.BeTrue(), func() string {
 			j, err := protojson.Marshal(resp)

--- a/test/cases/measure/data/testdata/service_instance_endpoint_cpm_minute_data1.json
+++ b/test/cases/measure/data/testdata/service_instance_endpoint_cpm_minute_data1.json
@@ -5,6 +5,44 @@
         "tags": [
           {
             "str": {
+              "value": "12"
+            }
+          },
+          {
+            "str": {
+              "value": "entity_1"
+            }
+          },
+          {
+            "str": {
+              "value": ""
+            }
+          },
+          {
+            "null": 0
+          }
+        ]
+      }
+    ],
+    "fields": [
+      {
+        "int": {
+          "value": 300
+        }
+      },
+      {
+        "int": {
+          "value": 7
+        }
+      }
+    ]
+  },
+  {
+    "tag_families": [
+      {
+        "tags": [
+          {
+            "str": {
               "value": "7"
             }
           },
@@ -183,44 +221,6 @@
       {
         "int": {
           "value": 12
-        }
-      }
-    ]
-  },
-  {
-    "tag_families": [
-      {
-        "tags": [
-          {
-            "str": {
-              "value": "12"
-            }
-          },
-          {
-            "str": {
-              "value": "entity_1"
-            }
-          },
-          {
-            "str": {
-              "value": ""
-            }
-          },
-          {
-            "null": 0
-          }
-        ]
-      }
-    ],
-    "fields": [
-      {
-        "int": {
-          "value": 300
-        }
-      },
-      {
-        "int": {
-          "value": 7
         }
       }
     ]


### PR DESCRIPTION

### Fix querying old data points 

A version column is introduced to each data point and stored in the timestamp file.

Even the file format is changed, the banyandb server has the capability to operate the previous files.

- [x] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.
- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Fixes apache/skywalking#12302.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-banyandb/blob/main/CHANGES.md).
