### PR TITLE
Deduplicate data points in distributed query

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Release Notes.
 
 - Fix the filtering of stream in descending order by timestamp.
 - Fix querying old data points when the data is in a newer part. A version column is introduced to each data point and stored in the timestamp file.
+- Fix the bug that duplicated data points from different data nodes are returned.
 
 ## 0.6.1
 

--- a/api/proto/banyandb/measure/v1/query.proto
+++ b/api/proto/banyandb/measure/v1/query.proto
@@ -40,8 +40,11 @@ message DataPoint {
   }
   // fields contains fields selected in the projection
   repeated Field fields = 3;
-  // version is the version of the data point
-  int64 version = 4;
+  // sid is the series id of the data point
+  uint64 sid = 4;
+  // version is the version of the data point in a series
+  // sid, timestamp and version are used to identify a data point
+  int64 version = 5;
 }
 
 // QueryResponse is the response for a query to the Query module.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2364,7 +2364,8 @@ DataPoint is stored in Measures
 | timestamp | [google.protobuf.Timestamp](#google-protobuf-Timestamp) |  | timestamp is in the timeunit of milliseconds. |
 | tag_families | [banyandb.model.v1.TagFamily](#banyandb-model-v1-TagFamily) | repeated | tag_families contains tags selected in the projection |
 | fields | [DataPoint.Field](#banyandb-measure-v1-DataPoint-Field) | repeated | fields contains fields selected in the projection |
-| version | [int64](#int64) |  | version is the version of the data point |
+| sid | [uint64](#uint64) |  | sid is the series id of the data point |
+| version | [int64](#int64) |  | version is the version of the data point in a series sid, timestamp and version are used to identify a data point |
 
 
 

--- a/pkg/query/logical/measure/measure_plan_distributed_test.go
+++ b/pkg/query/logical/measure/measure_plan_distributed_test.go
@@ -1,0 +1,160 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package measure
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
+
+	measurev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/measure/v1"
+)
+
+type mockIterator struct {
+	data []*comparableDataPoint
+	idx  int
+}
+
+func (m *mockIterator) Next() bool {
+	m.idx++
+	return m.idx < len(m.data)
+}
+
+func (m *mockIterator) Val() *comparableDataPoint {
+	return m.data[m.idx]
+}
+
+func (m *mockIterator) Close() error {
+	return nil
+}
+
+func TestSortedMIterator(t *testing.T) {
+	testCases := []struct {
+		name string
+		data []*comparableDataPoint
+		want []*measurev1.DataPoint
+	}{
+		{
+			name: "empty data",
+			data: []*comparableDataPoint{},
+			want: []*measurev1.DataPoint{},
+		},
+		{
+			name: "all data points are the same",
+			data: []*comparableDataPoint{
+				{DataPoint: &measurev1.DataPoint{Sid: 1, Timestamp: &timestamppb.Timestamp{Seconds: 1, Nanos: 1}, Version: 1}, sortField: []byte{1}},
+				{DataPoint: &measurev1.DataPoint{Sid: 1, Timestamp: &timestamppb.Timestamp{Seconds: 1, Nanos: 1}, Version: 1}, sortField: []byte{1}},
+			},
+			want: []*measurev1.DataPoint{
+				{Sid: 1, Timestamp: &timestamppb.Timestamp{Seconds: 1, Nanos: 1}, Version: 1},
+			},
+		},
+		{
+			name: "identical data points with different sort fields",
+			data: []*comparableDataPoint{
+				{DataPoint: &measurev1.DataPoint{Sid: 1, Timestamp: &timestamppb.Timestamp{Seconds: 1, Nanos: 1}, Version: 1}, sortField: []byte{1}},
+				{DataPoint: &measurev1.DataPoint{Sid: 1, Timestamp: &timestamppb.Timestamp{Seconds: 1, Nanos: 1}, Version: 1}, sortField: []byte{2}},
+			},
+			want: []*measurev1.DataPoint{
+				{Sid: 1, Timestamp: &timestamppb.Timestamp{Seconds: 1, Nanos: 1}, Version: 1},
+				{Sid: 1, Timestamp: &timestamppb.Timestamp{Seconds: 1, Nanos: 1}, Version: 1},
+			},
+		},
+		{
+			name: "different data points with different sort fields",
+			data: []*comparableDataPoint{
+				{DataPoint: &measurev1.DataPoint{Sid: 1, Timestamp: &timestamppb.Timestamp{Seconds: 1, Nanos: 1}, Version: 1}, sortField: []byte{1}},
+				{DataPoint: &measurev1.DataPoint{Sid: 1, Timestamp: &timestamppb.Timestamp{Seconds: 2, Nanos: 2}, Version: 1}, sortField: []byte{2}},
+			},
+			want: []*measurev1.DataPoint{
+				{Sid: 1, Timestamp: &timestamppb.Timestamp{Seconds: 1, Nanos: 1}, Version: 1},
+				{Sid: 1, Timestamp: &timestamppb.Timestamp{Seconds: 2, Nanos: 2}, Version: 1},
+			},
+		},
+		{
+			name: "identical data points with different versions",
+			data: []*comparableDataPoint{
+				{DataPoint: &measurev1.DataPoint{Sid: 1, Timestamp: &timestamppb.Timestamp{Seconds: 1, Nanos: 1}, Version: 1}, sortField: []byte{1}},
+				{DataPoint: &measurev1.DataPoint{Sid: 1, Timestamp: &timestamppb.Timestamp{Seconds: 2, Nanos: 2}, Version: 1}, sortField: []byte{1}},
+				{DataPoint: &measurev1.DataPoint{Sid: 1, Timestamp: &timestamppb.Timestamp{Seconds: 1, Nanos: 1}, Version: 2}, sortField: []byte{1}},
+			},
+			want: []*measurev1.DataPoint{
+				{Sid: 1, Timestamp: &timestamppb.Timestamp{Seconds: 1, Nanos: 1}, Version: 2},
+				{Sid: 1, Timestamp: &timestamppb.Timestamp{Seconds: 2, Nanos: 2}, Version: 1},
+			},
+		},
+		{
+			name: "identical data points with different versions",
+			data: []*comparableDataPoint{
+				{DataPoint: &measurev1.DataPoint{Sid: 1, Timestamp: &timestamppb.Timestamp{Seconds: 1, Nanos: 1}, Version: 1}, sortField: []byte{1}},
+				{DataPoint: &measurev1.DataPoint{Sid: 2, Timestamp: &timestamppb.Timestamp{Seconds: 1, Nanos: 1}, Version: 1}, sortField: []byte{1}},
+				{DataPoint: &measurev1.DataPoint{Sid: 1, Timestamp: &timestamppb.Timestamp{Seconds: 1, Nanos: 1}, Version: 2}, sortField: []byte{1}},
+				{DataPoint: &measurev1.DataPoint{Sid: 1, Timestamp: &timestamppb.Timestamp{Seconds: 2, Nanos: 2}, Version: 2}, sortField: []byte{2}},
+				{DataPoint: &measurev1.DataPoint{Sid: 1, Timestamp: &timestamppb.Timestamp{Seconds: 2, Nanos: 2}, Version: 1}, sortField: []byte{2}},
+				{DataPoint: &measurev1.DataPoint{Sid: 2, Timestamp: &timestamppb.Timestamp{Seconds: 2, Nanos: 2}, Version: 2}, sortField: []byte{2}},
+				{DataPoint: &measurev1.DataPoint{Sid: 1, Timestamp: &timestamppb.Timestamp{Seconds: 3, Nanos: 3}, Version: 1}, sortField: []byte{3}},
+				{DataPoint: &measurev1.DataPoint{Sid: 1, Timestamp: &timestamppb.Timestamp{Seconds: 3, Nanos: 3}, Version: 2}, sortField: []byte{3}},
+				{DataPoint: &measurev1.DataPoint{Sid: 3, Timestamp: &timestamppb.Timestamp{Seconds: 3, Nanos: 3}, Version: 2}, sortField: []byte{3}},
+			},
+			want: []*measurev1.DataPoint{
+				{Sid: 1, Timestamp: &timestamppb.Timestamp{Seconds: 1, Nanos: 1}, Version: 2},
+				{Sid: 1, Timestamp: &timestamppb.Timestamp{Seconds: 2, Nanos: 2}, Version: 2},
+				{Sid: 1, Timestamp: &timestamppb.Timestamp{Seconds: 3, Nanos: 3}, Version: 2},
+				{Sid: 2, Timestamp: &timestamppb.Timestamp{Seconds: 1, Nanos: 1}, Version: 1},
+				{Sid: 2, Timestamp: &timestamppb.Timestamp{Seconds: 2, Nanos: 2}, Version: 2},
+				{Sid: 3, Timestamp: &timestamppb.Timestamp{Seconds: 3, Nanos: 3}, Version: 2},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			iter := &sortedMIterator{
+				Iterator: &mockIterator{data: tc.data, idx: -1},
+			}
+
+			iter.init()
+
+			got := make([]*measurev1.DataPoint, 0)
+			for iter.Next() {
+				got = append(got, iter.Current()[0])
+			}
+
+			slices.SortFunc(got, func(a, b *measurev1.DataPoint) int {
+				if diff := a.Sid - b.Sid; diff != 0 {
+					return int(diff)
+				}
+				if diff := a.Timestamp.Seconds - b.Timestamp.Seconds; diff != 0 {
+					return int(diff)
+				}
+				if diff := a.Timestamp.Nanos - b.Timestamp.Nanos; diff != 0 {
+					return int(diff)
+				}
+				return int(a.Version - b.Version)
+			})
+
+			if diff := cmp.Diff(tc.want, got,
+				protocmp.Transform(), protocmp.IgnoreUnknown()); diff != "" {
+				t.Errorf("sortedMIterator mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/query/logical/measure/measure_plan_indexscan_local.go
+++ b/pkg/query/logical/measure/measure_plan_indexscan_local.go
@@ -223,6 +223,7 @@ func (ei *resultMIterator) Next() bool {
 	for i := range r.Timestamps {
 		dp := &measurev1.DataPoint{
 			Timestamp: timestamppb.New(time.Unix(0, r.Timestamps[i])),
+			Sid:       uint64(r.SID),
 			Version:   r.Versions[i],
 		}
 

--- a/test/cases/measure/data/data.go
+++ b/test/cases/measure/data/data.go
@@ -78,12 +78,14 @@ var VerifyFn = func(innerGm gm.Gomega, sharedContext helpers.SharedContext, args
 	for i := range resp.DataPoints {
 		if resp.DataPoints[i].Timestamp != nil {
 			innerGm.Expect(resp.DataPoints[i].Version).Should(gm.BeNumerically(">", 0))
+			innerGm.Expect(resp.DataPoints[i].Sid).Should(gm.BeNumerically(">", 0))
 		}
 	}
 	innerGm.Expect(cmp.Equal(resp, want,
 		protocmp.IgnoreUnknown(),
 		protocmp.IgnoreFields(&measurev1.DataPoint{}, "timestamp"),
 		protocmp.IgnoreFields(&measurev1.DataPoint{}, "version"),
+		protocmp.IgnoreFields(&measurev1.DataPoint{}, "sid"),
 		protocmp.Transform())).
 		To(gm.BeTrue(), func() string {
 			j, err := protojson.Marshal(resp)


### PR DESCRIPTION

### Fix the bug that duplicated data points from different data nodes are returned

Each data point includes a new field, "sid," to assist the distributed query module in deduplication.

- [x] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.
- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Fixes apache/skywalking#12255.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-banyandb/blob/main/CHANGES.md).
