### PR TITLE
Assign a separate lookup table to each group

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Release Notes.
 - Check unregistered nodes in background.
 - Improve sorting performance of stream.
 - Add the measure query trace.
+- Assign a separate lookup table to each group in the maglev selector.
 
 ### Bugs
 

--- a/pkg/cmdsetup/liaison.go
+++ b/pkg/cmdsetup/liaison.go
@@ -46,10 +46,7 @@ func newLiaisonCmd(runners ...run.Unit) *cobra.Command {
 	}
 	pipeline := pub.New(metaSvc)
 	localPipeline := queue.Local()
-	nodeSel, err := node.NewMaglevSelector()
-	if err != nil {
-		l.Fatal().Err(err).Msg("failed to initiate required node selector")
-	}
+	nodeSel := node.NewMaglevSelector()
 	nodeRegistry := grpc.NewClusterNodeRegistry(pipeline, nodeSel)
 	grpcServer := grpc.NewServer(ctx, pipeline, localPipeline, metaSvc, nodeRegistry)
 	profSvc := observability.NewProfService()

--- a/pkg/node/interface.go
+++ b/pkg/node/interface.go
@@ -19,7 +19,6 @@
 package node
 
 import (
-	"strconv"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -96,8 +95,4 @@ func (p *pickFirstSelector) Pick(_, _ string, _ uint32) (string, error) {
 		return "", ErrNoAvailableNode
 	}
 	return p.nodeIDs[0], nil
-}
-
-func formatSearchKey(group, name string, shardID uint32) string {
-	return group + "/" + name + "#" + strconv.FormatUint(uint64(shardID), 10)
 }

--- a/pkg/node/maglev_test.go
+++ b/pkg/node/maglev_test.go
@@ -34,8 +34,7 @@ const (
 )
 
 func TestMaglevSelector(t *testing.T) {
-	sel, err := NewMaglevSelector()
-	assert.NoError(t, err)
+	sel := NewMaglevSelector()
 	sel.AddNode(&databasev1.Node{
 		Metadata: &commonv1.Metadata{
 			Name: "data-node-1",
@@ -55,8 +54,7 @@ func TestMaglevSelector(t *testing.T) {
 }
 
 func TestMaglevSelector_EvenDistribution(t *testing.T) {
-	sel, err := NewMaglevSelector()
-	assert.NoError(t, err)
+	sel := NewMaglevSelector()
 	dataNodeNum := 10
 	for i := 0; i < dataNodeNum; i++ {
 		sel.AddNode(&databasev1.Node{
@@ -83,8 +81,8 @@ func TestMaglevSelector_EvenDistribution(t *testing.T) {
 }
 
 func TestMaglevSelector_DiffNode(t *testing.T) {
-	fullSel, _ := NewMaglevSelector()
-	brokenSel, _ := NewMaglevSelector()
+	fullSel := NewMaglevSelector()
+	brokenSel := NewMaglevSelector()
 	dataNodeNum := 10
 	for i := 0; i < dataNodeNum; i++ {
 		fullSel.AddNode(&databasev1.Node{
@@ -114,7 +112,7 @@ func TestMaglevSelector_DiffNode(t *testing.T) {
 }
 
 func BenchmarkMaglevSelector_Pick(b *testing.B) {
-	sel, _ := NewMaglevSelector()
+	sel := NewMaglevSelector()
 	dataNodeNum := 10
 	for i := 0; i < dataNodeNum; i++ {
 		sel.AddNode(&databasev1.Node{


### PR DESCRIPTION
As the title indicates, I separate the single maglev hash table into several entities by the group name. The shards in a group should be spread across the nodes. 

- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Fixes apache/skywalking#12241.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-banyandb/blob/main/CHANGES.md).
