### PR TITLE
Introduce more query tracing and node selector

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,9 @@ Release Notes.
 - Add the measure query trace.
 - Assign a separate lookup table to each group in the maglev selector.
 - Convert the async local pipeline to a sync pipeline.
+- Add the stream query trace.
+- Add the topN query trace.
+- Introduce the round-robin selector to Liaison Node.
 
 ### Bugs
 

--- a/api/proto/banyandb/measure/v1/topn.proto
+++ b/api/proto/banyandb/measure/v1/topn.proto
@@ -19,6 +19,7 @@ syntax = "proto3";
 
 package banyandb.measure.v1;
 
+import "banyandb/common/v1/trace.proto";
 import "banyandb/model/v1/common.proto";
 import "banyandb/model/v1/query.proto";
 import "google/protobuf/timestamp.proto";
@@ -44,6 +45,8 @@ message TopNResponse {
   // lists contain a series topN lists ranked by timestamp
   // if agg_func in query request is specified, lists' size should be one.
   repeated TopNList lists = 1;
+  // trace contains the trace information of the query when trace is enabled
+  common.v1.Trace trace = 2;
 }
 
 // TopNRequest is the request contract for query.
@@ -63,4 +66,6 @@ message TopNRequest {
   repeated model.v1.Condition conditions = 6;
   // field_value_sort indicates how to sort fields
   model.v1.Sort field_value_sort = 7;
+  // trace is used to enable trace for the query
+  bool trace = 8;
 }

--- a/banyand/dquery/stream.go
+++ b/banyand/dquery/stream.go
@@ -19,14 +19,17 @@ package dquery
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/apache/skywalking-banyandb/api/common"
 	commonv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/common/v1"
+	measurev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/measure/v1"
 	streamv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/stream/v1"
 	"github.com/apache/skywalking-banyandb/banyand/stream"
 	"github.com/apache/skywalking-banyandb/pkg/bus"
 	"github.com/apache/skywalking-banyandb/pkg/logger"
+	"github.com/apache/skywalking-banyandb/pkg/query"
 	"github.com/apache/skywalking-banyandb/pkg/query/executor"
 	logical_stream "github.com/apache/skywalking-banyandb/pkg/query/logical/stream"
 )
@@ -38,7 +41,8 @@ type streamQueryProcessor struct {
 }
 
 func (p *streamQueryProcessor) Rev(message bus.Message) (resp bus.Message) {
-	now := time.Now().UnixNano()
+	n := time.Now()
+	now := n.UnixNano()
 	queryCriteria, ok := message.Data().(*streamv1.QueryRequest)
 	if !ok {
 		resp = bus.NewMessage(bus.MessageID(now), common.NewError("invalid event data type"))
@@ -76,9 +80,30 @@ func (p *streamQueryProcessor) Rev(message bus.Message) (resp bus.Message) {
 	if p.log.Debug().Enabled() {
 		p.log.Debug().Str("plan", plan.String()).Msg("query plan")
 	}
+	ctx := context.Background()
+	var tracer *query.Tracer
+	var span *query.Span
+	if queryCriteria.Trace {
+		tracer, ctx = query.NewTracer(ctx, n.Format(time.RFC3339Nano))
+		span, ctx = tracer.StartSpan(ctx, "distributed-%s", p.queryService.nodeID)
+		span.Tag("plan", plan.String())
+		defer func() {
+			data := resp.Data()
+			switch d := data.(type) {
+			case *streamv1.QueryResponse:
+				d.Trace = tracer.ToProto()
+			case common.Error:
+				span.Error(errors.New(d.Msg()))
+				resp = bus.NewMessage(bus.MessageID(now), &measurev1.QueryResponse{Trace: tracer.ToProto()})
+			default:
+				panic("unexpected data type")
+			}
+			span.Stop()
+		}()
+	}
 	se := plan.(executor.StreamExecutable)
 	defer se.Close()
-	entities, err := se.Execute(executor.WithDistributedExecutionContext(context.Background(), &distributedContext{
+	entities, err := se.Execute(executor.WithDistributedExecutionContext(ctx, &distributedContext{
 		Broadcaster: p.broadcaster,
 		timeRange:   queryCriteria.TimeRange,
 	}))

--- a/banyand/query/processor.go
+++ b/banyand/query/processor.go
@@ -71,7 +71,8 @@ type streamQueryProcessor struct {
 }
 
 func (p *streamQueryProcessor) Rev(message bus.Message) (resp bus.Message) {
-	now := time.Now().UnixNano()
+	n := time.Now()
+	now := n.UnixNano()
 	queryCriteria, ok := message.Data().(*streamv1.QueryRequest)
 	if !ok {
 		resp = bus.NewMessage(bus.MessageID(now), common.NewError("invalid event data type"))
@@ -115,9 +116,30 @@ func (p *streamQueryProcessor) Rev(message bus.Message) (resp bus.Message) {
 	if p.log.Debug().Enabled() {
 		p.log.Debug().Str("plan", plan.String()).Msg("query plan")
 	}
+	ctx := context.Background()
+	var tracer *query.Tracer
+	var span *query.Span
+	if queryCriteria.Trace {
+		tracer, ctx = query.NewTracer(ctx, n.Format(time.RFC3339Nano))
+		span, ctx = tracer.StartSpan(ctx, "data-%s", p.queryService.nodeID)
+		span.Tag("plan", plan.String())
+		defer func() {
+			data := resp.Data()
+			switch d := data.(type) {
+			case *streamv1.QueryResponse:
+				d.Trace = tracer.ToProto()
+			case common.Error:
+				span.Error(errors.New(d.Msg()))
+				resp = bus.NewMessage(bus.MessageID(now), &measurev1.QueryResponse{Trace: tracer.ToProto()})
+			default:
+				panic("unexpected data type")
+			}
+			span.Stop()
+		}()
+	}
 	se := plan.(executor.StreamExecutable)
 	defer se.Close()
-	entities, err := se.Execute(executor.WithStreamExecutionContext(context.Background(), ec))
+	entities, err := se.Execute(executor.WithStreamExecutionContext(ctx, ec))
 	if err != nil {
 		p.log.Error().Err(err).RawJSON("req", logger.Proto(queryCriteria)).Msg("fail to execute the query plan")
 		resp = bus.NewMessage(bus.MessageID(now), common.NewError("execute the query plan for stream %s: %v", meta.GetName(), err))

--- a/banyand/stream/benchmark_test.go
+++ b/banyand/stream/benchmark_test.go
@@ -344,6 +344,7 @@ func generateStreamQueryOptions(p parameter, index mockIndex) pbv1.StreamQueryOp
 
 func BenchmarkFilter(b *testing.B) {
 	b.ReportAllocs()
+	ctx := context.TODO()
 	for _, p := range pList {
 		esList, docsList, idx := generateData(p)
 		db := write(b, p, esList, docsList)
@@ -351,24 +352,25 @@ func BenchmarkFilter(b *testing.B) {
 		sqo := generateStreamQueryOptions(p, idx)
 		sqo.Order = nil
 		b.Run("filter-"+p.scenario, func(b *testing.B) {
-			res, err := s.Query(context.TODO(), sqo)
+			res, err := s.Query(ctx, sqo)
 			require.NoError(b, err)
-			logicalstream.BuildElementsFromStreamResult(res)
+			logicalstream.BuildElementsFromStreamResult(ctx, res)
 		})
 	}
 }
 
 func BenchmarkSort(b *testing.B) {
 	b.ReportAllocs()
+	ctx := context.TODO()
 	for _, p := range pList {
 		esList, docsList, idx := generateData(p)
 		db := write(b, p, esList, docsList)
 		s := generateStream(db)
 		sqo := generateStreamQueryOptions(p, idx)
 		b.Run("sort-"+p.scenario, func(b *testing.B) {
-			res, err := s.Query(context.TODO(), sqo)
+			res, err := s.Query(ctx, sqo)
 			require.NoError(b, err)
-			logicalstream.BuildElementsFromStreamResult(res)
+			logicalstream.BuildElementsFromStreamResult(ctx, res)
 		})
 	}
 }

--- a/banyand/stream/query_test.go
+++ b/banyand/stream/query_test.go
@@ -315,8 +315,9 @@ func TestQueryResult(t *testing.T) {
 					result.asc = tt.ascTS
 				}
 				var got []pbv1.StreamResult
+				ctx := context.Background()
 				for {
-					r := result.Pull()
+					r := result.Pull(ctx)
 					if r == nil {
 						break
 					}

--- a/banyand/stream/trace.go
+++ b/banyand/stream/trace.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package measure
+package stream
 
 import (
 	"context"
@@ -57,6 +57,9 @@ func startBlockScanSpan(ctx context.Context, sids int, parts []*part, qr *queryR
 	}
 
 	span, _ := tracer.StartSpan(ctx, "scan-blocks")
+	if qr.qo.elementFilter != nil {
+		span.Tag("filter_size", fmt.Sprintf("%d", qr.qo.elementFilter.Len()))
+	}
 	span.Tag("series_num", fmt.Sprintf("%d", sids))
 	span.Tag("part_header", partMetadataHeader)
 	span.Tag("part_num", fmt.Sprintf("%d", len(parts)))

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2561,6 +2561,7 @@ TopNRequest is the request contract for query.
 | agg | [banyandb.model.v1.AggregationFunction](#banyandb-model-v1-AggregationFunction) |  | agg aggregates lists grouped by field names in the time_range TODO validate enum defined_only |
 | conditions | [banyandb.model.v1.Condition](#banyandb-model-v1-Condition) | repeated | criteria select counters. Only equals are acceptable. |
 | field_value_sort | [banyandb.model.v1.Sort](#banyandb-model-v1-Sort) |  | field_value_sort indicates how to sort fields |
+| trace | [bool](#bool) |  | trace is used to enable trace for the query |
 
 
 
@@ -2576,6 +2577,7 @@ TopNResponse is the response for a query to the Query module.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | lists | [TopNList](#banyandb-measure-v1-TopNList) | repeated | lists contain a series topN lists ranked by timestamp if agg_func in query request is specified, lists&#39; size should be one. |
+| trace | [banyandb.common.v1.Trace](#banyandb-common-v1-Trace) |  | trace contains the trace information of the query when trace is enabled |
 
 
 

--- a/pkg/cmdsetup/liaison.go
+++ b/pkg/cmdsetup/liaison.go
@@ -46,7 +46,7 @@ func newLiaisonCmd(runners ...run.Unit) *cobra.Command {
 	}
 	pipeline := pub.New(metaSvc)
 	localPipeline := queue.Local()
-	nodeSel := node.NewMaglevSelector()
+	nodeSel := node.NewRoundRobinSelector()
 	nodeRegistry := grpc.NewClusterNodeRegistry(pipeline, nodeSel)
 	grpcServer := grpc.NewServer(ctx, pipeline, localPipeline, metaSvc, nodeRegistry)
 	profSvc := observability.NewProfService()
@@ -77,6 +77,7 @@ func newLiaisonCmd(runners ...run.Unit) *cobra.Command {
 		Version: version.Build(),
 		Short:   "Run as the liaison server",
 		RunE: func(_ *cobra.Command, _ []string) (err error) {
+			defer nodeSel.Close()
 			node, err := common.GenerateNode(grpcServer.GetPort(), httpServer.GetPort())
 			if err != nil {
 				return err

--- a/pkg/node/interface.go
+++ b/pkg/node/interface.go
@@ -39,6 +39,7 @@ type Selector interface {
 	AddNode(node *databasev1.Node)
 	RemoveNode(node *databasev1.Node)
 	Pick(group, name string, shardID uint32) (string, error)
+	Close()
 }
 
 // NewPickFirstSelector returns a simple selector that always returns the first node if exists.
@@ -54,6 +55,8 @@ type pickFirstSelector struct {
 	nodeIDs   []string
 	mu        sync.RWMutex
 }
+
+func (p *pickFirstSelector) Close() {}
 
 func (p *pickFirstSelector) AddNode(node *databasev1.Node) {
 	nodeID := node.GetMetadata().GetName()

--- a/pkg/node/maglev.go
+++ b/pkg/node/maglev.go
@@ -37,6 +37,8 @@ type maglevSelector struct {
 	mutex   sync.RWMutex
 }
 
+func (m *maglevSelector) Close() {}
+
 func (m *maglevSelector) AddNode(node *databasev1.Node) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()

--- a/pkg/node/round_robin.go
+++ b/pkg/node/round_robin.go
@@ -1,0 +1,177 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package node
+
+import (
+	"fmt"
+	"slices"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/pkg/errors"
+
+	databasev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
+	"github.com/apache/skywalking-banyandb/pkg/timestamp"
+)
+
+const (
+	expiredKeyCleanupInterval = 1 * time.Hour
+	keyTTL                    = 24 * time.Hour
+)
+
+type roundRobinSelector struct {
+	clock       timestamp.Clock
+	closeCh     chan struct{}
+	lookupTable sync.Map
+	nodes       []string
+	mu          sync.RWMutex
+	once        sync.Once
+	tMu         sync.Mutex
+}
+
+func (r *roundRobinSelector) Close() {
+	close(r.closeCh)
+}
+
+// NewRoundRobinSelector creates a new round-robin selector.
+func NewRoundRobinSelector() Selector {
+	rrs := &roundRobinSelector{
+		nodes:   make([]string, 0),
+		clock:   timestamp.NewClock(),
+		closeCh: make(chan struct{}),
+	}
+	return rrs
+}
+
+func (r *roundRobinSelector) AddNode(node *databasev1.Node) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.nodes = append(r.nodes, node.Metadata.Name)
+	sort.StringSlice(r.nodes).Sort()
+}
+
+func (r *roundRobinSelector) RemoveNode(node *databasev1.Node) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for i, n := range r.nodes {
+		if n == node.Metadata.Name {
+			r.nodes = append(r.nodes[:i], r.nodes[i+1:]...)
+			break
+		}
+	}
+}
+
+func (r *roundRobinSelector) Pick(group, _ string, shardID uint32) (string, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	k := key{group: group, shardID: shardID}
+	if len(r.nodes) == 0 {
+		return "", errors.New("no nodes available")
+	}
+	entry, ok := r.lookupTable.Load(k)
+	if ok {
+		return r.selectNode(entry), nil
+	}
+	r.tMu.Lock()
+	defer r.tMu.Unlock()
+	if entry, ok := r.lookupTable.Load(k); ok {
+		return r.selectNode(entry), nil
+	}
+
+	keys := []key{k}
+	r.lookupTable.Range(func(k, _ any) bool {
+		keys = append(keys, k.(key))
+		return true
+	})
+	slices.SortFunc(keys, func(a, b key) int {
+		n := strings.Compare(a.group, b.group)
+		if n != 0 {
+			return n
+		}
+		return int(a.shardID) - int(b.shardID)
+	})
+	for i := range keys {
+		if entry, ok := r.lookupTable.Load(keys[i]); ok {
+			entry.(*tableEntry).index = i
+		} else {
+			r.lookupTable.Store(keys[i], r.newTableEntry(i))
+		}
+	}
+	r.once.Do(r.startCleanupTicker)
+	if entry, ok := r.lookupTable.Load(k); ok {
+		return r.selectNode(entry), nil
+	}
+	panic(fmt.Sprintf("key %v not found", k))
+}
+
+func (r *roundRobinSelector) selectNode(entry any) string {
+	e := entry.(*tableEntry)
+	now := r.clock.Now()
+	e.lastAccess.Store(&now)
+	return r.nodes[e.index%len(r.nodes)]
+}
+
+type key struct {
+	group   string
+	shardID uint32
+}
+
+type tableEntry struct {
+	lastAccess *atomic.Pointer[time.Time]
+	index      int
+}
+
+func (r *roundRobinSelector) newTableEntry(index int) *tableEntry {
+	p := atomic.Pointer[time.Time]{}
+	now := r.clock.Now()
+	p.Store(&now)
+	return &tableEntry{
+		index:      index,
+		lastAccess: &p,
+	}
+}
+
+func (r *roundRobinSelector) cleanupExpiredEntries() {
+	now := r.clock.Now()
+	r.tMu.Lock()
+	defer r.tMu.Unlock()
+
+	r.lookupTable.Range(func(k, value any) bool {
+		e := value.(*tableEntry)
+		if now.Sub(*e.lastAccess.Load()) > keyTTL {
+			r.lookupTable.Delete(k)
+		}
+		return true
+	})
+}
+
+func (r *roundRobinSelector) startCleanupTicker() {
+	ticker := r.clock.Ticker(expiredKeyCleanupInterval)
+	go func() {
+		select {
+		case <-r.closeCh:
+			ticker.Stop()
+			return
+		case <-ticker.C:
+			r.cleanupExpiredEntries()
+		}
+	}()
+}

--- a/pkg/node/round_robin_test.go
+++ b/pkg/node/round_robin_test.go
@@ -1,0 +1,112 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package node
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	commonv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/common/v1"
+	databasev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
+	"github.com/apache/skywalking-banyandb/pkg/timestamp"
+)
+
+func TestPickEmptySelector(t *testing.T) {
+	selector := NewRoundRobinSelector()
+	_, err := selector.Pick("group1", "", 0)
+	assert.Error(t, err)
+}
+
+func TestPickSingleSelection(t *testing.T) {
+	selector := NewRoundRobinSelector()
+	selector.AddNode(&databasev1.Node{Metadata: &commonv1.Metadata{Name: "node1"}})
+	node, err := selector.Pick("group1", "", 0)
+	assert.NoError(t, err)
+	assert.Equal(t, "node1", node)
+}
+
+func TestPickMultipleSelections(t *testing.T) {
+	selector := NewRoundRobinSelector()
+	selector.AddNode(&databasev1.Node{Metadata: &commonv1.Metadata{Name: "node1"}})
+	selector.AddNode(&databasev1.Node{Metadata: &commonv1.Metadata{Name: "node2"}})
+	// load data
+	_, err := selector.Pick("group1", "", 0)
+	assert.NoError(t, err)
+	_, err = selector.Pick("group1", "", 1)
+	assert.NoError(t, err)
+	node1, err := selector.Pick("group1", "", 0)
+	assert.NoError(t, err)
+	node2, err := selector.Pick("group1", "", 1)
+	assert.NoError(t, err)
+	assert.NotEqual(t, node1, node2, "Different shardIDs in the same group should not result in the same node")
+}
+
+func TestPickNodeRemoval(t *testing.T) {
+	selector := NewRoundRobinSelector()
+	selector.AddNode(&databasev1.Node{Metadata: &commonv1.Metadata{Name: "node1"}})
+	selector.AddNode(&databasev1.Node{Metadata: &commonv1.Metadata{Name: "node2"}})
+	selector.RemoveNode(&databasev1.Node{Metadata: &commonv1.Metadata{Name: "node1"}})
+	node, err := selector.Pick("group1", "", 0)
+	assert.NoError(t, err)
+	assert.Equal(t, "node2", node)
+}
+
+func TestPickConsistentSelectionAfterRemoval(t *testing.T) {
+	selector := NewRoundRobinSelector()
+	selector.AddNode(&databasev1.Node{Metadata: &commonv1.Metadata{Name: "node1"}})
+	selector.AddNode(&databasev1.Node{Metadata: &commonv1.Metadata{Name: "node2"}})
+	selector.AddNode(&databasev1.Node{Metadata: &commonv1.Metadata{Name: "node3"}})
+	_, err := selector.Pick("group1", "", 0)
+	assert.NoError(t, err)
+	_, err = selector.Pick("group1", "", 1)
+	assert.NoError(t, err)
+	node, err := selector.Pick("group1", "", 1)
+	assert.NoError(t, err)
+	assert.Equal(t, "node2", node)
+	selector.RemoveNode(&databasev1.Node{Metadata: &commonv1.Metadata{Name: "node2"}})
+	node, err = selector.Pick("group1", "", 1)
+	assert.NoError(t, err)
+	assert.Equal(t, "node3", node)
+}
+
+func TestCleanupExpiredEntries(t *testing.T) {
+	mc := timestamp.NewMockClock()
+	mc.Set(time.Date(1970, 0o1, 0o1, 0, 0, 0, 0, time.Local))
+	selector := &roundRobinSelector{
+		nodes: make([]string, 0),
+		clock: mc,
+	}
+	selector.AddNode(&databasev1.Node{Metadata: &commonv1.Metadata{Name: "node1"}})
+	selector.AddNode(&databasev1.Node{Metadata: &commonv1.Metadata{Name: "node2"}})
+	_, err := selector.Pick("group1", "", 0)
+	assert.NoError(t, err)
+	_, ok := selector.lookupTable.Load(key{group: "group1", shardID: 0})
+	assert.True(t, ok)
+	mc.Add(25 * time.Hour)
+	_, err = selector.Pick("group1", "", 1)
+	assert.NoError(t, err)
+	_, ok = selector.lookupTable.Load(key{group: "group1", shardID: 1})
+	assert.True(t, ok)
+	selector.cleanupExpiredEntries()
+	_, ok = selector.lookupTable.Load(key{group: "group1", shardID: 0})
+	assert.False(t, ok)
+	_, ok = selector.lookupTable.Load(key{group: "group1", shardID: 1})
+	assert.True(t, ok)
+}

--- a/pkg/pb/v1/metadata.go
+++ b/pkg/pb/v1/metadata.go
@@ -19,6 +19,8 @@
 package v1
 
 import (
+	"context"
+
 	"github.com/apache/skywalking-banyandb/api/common"
 	databasev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
 	modelv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/model/v1"
@@ -138,7 +140,7 @@ type StreamQueryOptions struct {
 
 // StreamQueryResult is the result of a stream query.
 type StreamQueryResult interface {
-	Pull() *StreamResult
+	Pull(context.Context) *StreamResult
 	Release()
 }
 

--- a/pkg/query/logical/stream/stream_plan_indexscan_local.go
+++ b/pkg/query/logical/stream/stream_plan_indexscan_local.go
@@ -74,7 +74,7 @@ func (i *localIndexScan) Sort(order *logical.OrderBy) {
 
 func (i *localIndexScan) Execute(ctx context.Context) ([]*streamv1.Element, error) {
 	if i.result != nil {
-		return BuildElementsFromStreamResult(i.result), nil
+		return BuildElementsFromStreamResult(ctx, i.result), nil
 	}
 	var orderBy *pbv1.OrderBy
 	if i.order != nil {
@@ -99,7 +99,7 @@ func (i *localIndexScan) Execute(ctx context.Context) ([]*streamv1.Element, erro
 	if i.result == nil {
 		return nil, nil
 	}
-	return BuildElementsFromStreamResult(i.result), nil
+	return BuildElementsFromStreamResult(ctx, i.result), nil
 }
 
 func (i *localIndexScan) String() string {
@@ -120,8 +120,8 @@ func (i *localIndexScan) Schema() logical.Schema {
 }
 
 // BuildElementsFromStreamResult builds a slice of elements from the given stream query result.
-func BuildElementsFromStreamResult(result pbv1.StreamQueryResult) (elements []*streamv1.Element) {
-	r := result.Pull()
+func BuildElementsFromStreamResult(ctx context.Context, result pbv1.StreamQueryResult) (elements []*streamv1.Element) {
+	r := result.Pull(ctx)
 	if r == nil {
 		return nil
 	}


### PR DESCRIPTION

### Add more query tracing
- Add the stream query trace.
- Add the topN query trace.

### Introduce the round-robin selector to Liaison Node.

The round-robin selector ensures that shards in the same group are distributed across different nodes to prevent shard-0 from being assigned to the same node, ensuring an equal distribution of shards across all nodes.

- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-banyandb/blob/main/CHANGES.md).
