### PR TITLE
Add slow query logging

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,7 @@ Release Notes.
 - Optimize query performance of series index.
 - Add liaison, remote queue, storage(rotation), time-series tables, metadata cache and scheduler metrics.
 - Add HTTP health check endpoint for the data node.
+- Add slow query log for the distributed query and local query.
 
 ### Bugs
 
@@ -60,7 +61,7 @@ Release Notes.
 - Update CI to publish linux/amd64 and linux/arm64 Docker images.
 - Make the build system compiles the binary based on the platform which is running on.
 - Push "skywalking-banyandb-test" image for e2e and stress test. This image contains bydbctl to do a health check.
-- Set etcd-client log level to "error" and etcd-server log level to "warn".
+- Set etcd-client log level to "error" and etcd-server log level to "error".
 
 ## 0.6.1
 

--- a/banyand/dquery/dquery.go
+++ b/banyand/dquery/dquery.go
@@ -21,6 +21,7 @@ package dquery
 import (
 	"context"
 	"errors"
+	"time"
 
 	"go.uber.org/multierr"
 
@@ -60,6 +61,7 @@ type queryService struct {
 	tqp         *topNQueryProcessor
 	closer      *run.Closer
 	nodeID      string
+	slowQuery   time.Duration
 }
 
 // NewService return a new query service.
@@ -88,6 +90,16 @@ func NewService(metaService metadata.Repo, pipeline queue.Server, broadcaster bu
 
 func (q *queryService) Name() string {
 	return moduleName
+}
+
+func (q *queryService) FlagSet() *run.FlagSet {
+	fs := run.NewFlagSet("distributed-query")
+	fs.DurationVar(&q.slowQuery, "dst-slow-query", 0, "distributed slow query threshold, 0 means no slow query log")
+	return fs
+}
+
+func (q *queryService) Validate() error {
+	return nil
 }
 
 func (q *queryService) PreRun(ctx context.Context) error {

--- a/banyand/liaison/grpc/measure.go
+++ b/banyand/liaison/grpc/measure.go
@@ -71,7 +71,7 @@ func (ms *measureService) Write(measure measurev1.MeasureService_WriteServer) er
 		}
 		ms.metrics.totalStreamMsgReceived.Inc(1, metadata.Group, "measure", "write")
 		if errResp := measure.Send(&measurev1.WriteResponse{Metadata: metadata, Status: status, MessageId: messageId}); errResp != nil {
-			logger.Debug().Err(errResp).Msg("failed to send response")
+			logger.Debug().Err(errResp).Msg("failed to send measure write response")
 			ms.metrics.totalStreamMsgSentErr.Inc(1, metadata.Group, "measure", "write")
 		}
 	}

--- a/banyand/liaison/grpc/stream.go
+++ b/banyand/liaison/grpc/stream.go
@@ -71,7 +71,7 @@ func (s *streamService) Write(stream streamv1.StreamService_WriteServer) error {
 		}
 		s.metrics.totalStreamMsgReceived.Inc(1, metadata.Group, "stream", "write")
 		if errResp := stream.Send(&streamv1.WriteResponse{Metadata: metadata, Status: status, MessageId: messageId}); errResp != nil {
-			logger.Debug().Err(errResp).Msg("failed to send response")
+			logger.Debug().Err(errResp).Msg("failed to send stream write response")
 			s.metrics.totalStreamMsgSentErr.Inc(1, metadata.Group, "stream", "write")
 		}
 	}

--- a/banyand/metadata/embeddedetcd/server.go
+++ b/banyand/metadata/embeddedetcd/server.go
@@ -100,7 +100,7 @@ func NewServer(options ...Option) (Server, error) {
 	for _, opt := range options {
 		opt(conf)
 	}
-	zapCfg := logger.GetLogger("etcd-server").DefaultLevel(zerolog.WarnLevel).ToZapConfig()
+	zapCfg := logger.GetLogger("etcd-server").DefaultLevel(zerolog.ErrorLevel).ToZapConfig()
 
 	var l *zap.Logger
 	var err error

--- a/banyand/metadata/schema/watcher.go
+++ b/banyand/metadata/schema/watcher.go
@@ -127,7 +127,7 @@ OUTER:
 		for {
 			select {
 			case <-w.closer.CloseNotify():
-				w.l.Warn().Msgf("watcher closed")
+				w.l.Info().Msgf("watcher closed")
 				return
 			case watchResp, ok := <-wch:
 				if !ok {

--- a/banyand/query/processor_topn.go
+++ b/banyand/query/processor_topn.go
@@ -171,6 +171,12 @@ func (t *topNQueryProcessor) Rev(message bus.Message) (resp bus.Message) {
 	}()
 
 	resp = bus.NewMessage(bus.MessageID(now), toTopNResponse(result))
+	if !request.Trace && t.slowQuery > 0 {
+		latency := time.Since(n)
+		if latency > t.slowQuery {
+			t.log.Warn().Dur("latency", latency).RawJSON("req", logger.Proto(request)).Int("resp_count", len(result)).Msg("top_n slow query")
+		}
+	}
 	return
 }
 

--- a/banyand/query/query.go
+++ b/banyand/query/query.go
@@ -20,13 +20,31 @@ package query
 
 import (
 	"context"
+	"errors"
+	"time"
 
+	"go.uber.org/multierr"
+
+	"github.com/apache/skywalking-banyandb/api/common"
+	"github.com/apache/skywalking-banyandb/api/data"
 	"github.com/apache/skywalking-banyandb/banyand/measure"
 	"github.com/apache/skywalking-banyandb/banyand/metadata"
 	"github.com/apache/skywalking-banyandb/banyand/queue"
 	"github.com/apache/skywalking-banyandb/banyand/stream"
+	"github.com/apache/skywalking-banyandb/pkg/logger"
 	"github.com/apache/skywalking-banyandb/pkg/run"
 )
+
+type queryService struct {
+	metaService metadata.Repo
+	pipeline    queue.Server
+	log         *logger.Logger
+	sqp         *streamQueryProcessor
+	mqp         *measureQueryProcessor
+	tqp         *topNQueryProcessor
+	nodeID      string
+	slowQuery   time.Duration
+}
 
 // NewService return a new query service.
 func NewService(_ context.Context, streamService stream.Service, measureService measure.Service,
@@ -52,4 +70,33 @@ func NewService(_ context.Context, streamService stream.Service, measureService 
 		queryService:   svc,
 	}
 	return svc, nil
+}
+
+func (q *queryService) Name() string {
+	return moduleName
+}
+
+func (q *queryService) PreRun(ctx context.Context) error {
+	val := ctx.Value(common.ContextNodeKey)
+	if val == nil {
+		return errors.New("node id is empty")
+	}
+	node := val.(common.Node)
+	q.nodeID = node.NodeID
+	q.log = logger.GetLogger(moduleName)
+	return multierr.Combine(
+		q.pipeline.Subscribe(data.TopicStreamQuery, q.sqp),
+		q.pipeline.Subscribe(data.TopicMeasureQuery, q.mqp),
+		q.pipeline.Subscribe(data.TopicTopNQuery, q.tqp),
+	)
+}
+
+func (q *queryService) FlagSet() *run.FlagSet {
+	fs := run.NewFlagSet("query")
+	fs.DurationVar(&q.slowQuery, "slow-query", 0, "slow query threshold, 0 means no slow query log")
+	return fs
+}
+
+func (q *queryService) Validate() error {
+	return nil
 }

--- a/docs/operation/configuration.md
+++ b/docs/operation/configuration.md
@@ -87,6 +87,8 @@ The following flags are used to configure the embedded etcd storage engine which
 - `--observability-listener-addr string`: Listen address for observability (default: ":2121").
 - `--observability-modes strings`: Modes for observability (default: [prometheus]).
 - `--pprof-listener-addr string`: Listen address for pprof (default: ":6060").
+- `--dst-slow-query duration`: distributed slow query threshold, 0 means no slow query log. This is only used for the liaison server (default: 0).
+- `--slow-query duration`: slow query threshold, 0 means no slow query log. This is only used for the data and standalone server (default: 0).
 
 ### Other
 

--- a/docs/operation/observability.md
+++ b/docs/operation/observability.md
@@ -14,6 +14,14 @@ BanyanDB uses the [zerolo](https://github.com/rs/zerolog) library for logging. T
 --logging-modules=storage --logging-levels=debug
 ```
 
+### Slow Query Logging
+
+BanyanDB supports slow query logging. The `slow-query` flag is used to set the slow query threshold. If a query takes longer than the threshold, it will be logged as a slow query. The default value is `0`, which means no slow query logging. This flag is only used for the data and standalone servers.
+
+The `dst-slow-query` flag is used to set the distributed slow query threshold. This flag is only used for the liaison server. The default value is `0`, which means no distributed slow query logging.
+
+When query tracing is enabled, the slow query log won't be generated.
+
 ## Metrics
 
 BanyanDB has built-in support for metrics collection. Currently, there are two supported metrics provider: `prometheus` and `native`. These can be enabled through `observability-modes` flag, allowing you to activate one or both of them.

--- a/pkg/query/logical/stream/stream_plan_distributed.go
+++ b/pkg/query/logical/stream/stream_plan_distributed.go
@@ -38,7 +38,7 @@ import (
 	"github.com/apache/skywalking-banyandb/pkg/query/logical"
 )
 
-const defaultQueryTimeout = 10 * time.Second
+const defaultQueryTimeout = 30 * time.Second
 
 var _ logical.UnresolvedPlan = (*unresolvedDistributed)(nil)
 


### PR DESCRIPTION
This PR introduces slow query logging to BanyanDB. Slow query logging records the slow query before its execution latency times out. This will remind users to analyze the query by using query tracing. When the query takes a long time to execute, the query tracing result may not provide enough information to analyze the root cause. With this feature, users will have a better chance of identifying and troubleshooting slow queries.

- [x] Update the documentation to include this new feature.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-banyandb/blob/main/CHANGES.md).
