### PR TITLE
Improve the description of the memory in observability doc

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ Release Notes.
 
 ## 0.8.0
 
+### Documentation
+
+- Improve the description of the memory in observability doc.
+
 ### Chores
 
 - Fix metrics system typo.

--- a/docs/operation/grafana-cluster.json
+++ b/docs/operation/grafana-cluster.json
@@ -143,7 +143,7 @@
         "type": "prometheus",
         "uid": "${DS_PROMETHEUS}"
       },
-      "description": "The total memory is the total memory available on the system.",
+      "description": "The total memory is the total physical memory available on the system, which means total amount of RAM on the system.",
       "fieldConfig": {
         "defaults": {
           "color": {

--- a/docs/operation/observability.md
+++ b/docs/operation/observability.md
@@ -40,7 +40,7 @@ The write rate is the number of write operations per second. It is calculated by
 
 #### Total Memory
 
-The total memory is the total memory available on the system.
+The total memory is the total physical memory available on the system, which means total amount of RAM on the system.
 
 **Expression**: `sum(banyandb_system_memory_state{job=~\"$job\", instance=~\"$instance\",kind=\"total\"})`
 


### PR DESCRIPTION
- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Fixes apache/skywalking#<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-banyandb/blob/main/CHANGES.md).

When I read Observability.md, this question confuses me, what does total memory represent? Is it total amount of RAM on the system or included swap memory? So I submitted this PR to improve the document description.
