### PR TITLE
Fix the bug that TopN processing item leak

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@ Release Notes.
 
 ## 0.8.0
 
+### Bug Fixes
+
+- Fix the bug that TopN processing item leak. The item can not be updated but as a new item.
+
 ### Documentation
 
 - Improve the description of the memory in observability doc.

--- a/banyand/measure/write.go
+++ b/banyand/measure/write.go
@@ -193,7 +193,7 @@ func (w *writeCallback) handle(dst map[string]*dataPointsInGroup, writeEvent *me
 	dpt.dataPoints.tagFamilies = append(dpt.dataPoints.tagFamilies, tagFamilies)
 
 	if stm.processorManager != nil {
-		stm.processorManager.onMeasureWrite(&measurev1.InternalWriteRequest{
+		stm.processorManager.onMeasureWrite(uint64(series.ID), &measurev1.InternalWriteRequest{
 			Request: &measurev1.WriteRequest{
 				Metadata:  stm.GetSchema().Metadata,
 				DataPoint: req.DataPoint,

--- a/pkg/flow/streaming/topn_test.go
+++ b/pkg/flow/streaming/topn_test.go
@@ -28,106 +28,261 @@ import (
 	"github.com/apache/skywalking-banyandb/pkg/logger"
 )
 
+type testCase struct {
+	expected map[string][]*Tuple2
+	name     string
+	sort     TopNSort
+}
+
 func TestFlow_TopN_Aggregator(t *testing.T) {
-	input := []flow.StreamRecord{
-		// 1. group by values
-		// 2. number
-		// 3. slices of groupBy values
-		flow.NewStreamRecordWithoutTS(flow.Data{"e2e-service-provider", 10000, []interface{}{"e2e-service-provider"}}),
-		flow.NewStreamRecordWithoutTS(flow.Data{"e2e-service-consumer", 9900, []interface{}{"e2e-service-consumer"}}),
-		flow.NewStreamRecordWithoutTS(flow.Data{"e2e-service-provider", 9800, []interface{}{"e2e-service-provider"}}),
-		flow.NewStreamRecordWithoutTS(flow.Data{"e2e-service-consumer", 9700, []interface{}{"e2e-service-consumer"}}),
-		flow.NewStreamRecordWithoutTS(flow.Data{"e2e-service-provider", 9700, []interface{}{"e2e-service-provider"}}),
-		flow.NewStreamRecordWithoutTS(flow.Data{"e2e-service-consumer", 9600, []interface{}{"e2e-service-consumer"}}),
-		flow.NewStreamRecordWithoutTS(flow.Data{"e2e-service-consumer", 9800, []interface{}{"e2e-service-consumer"}}),
-		flow.NewStreamRecordWithoutTS(flow.Data{"e2e-service-consumer", 9500, []interface{}{"e2e-service-consumer"}}),
-	}
-	tests := []struct {
-		expected map[string][]*Tuple2
-		name     string
-		sort     TopNSort
-	}{
-		{
-			name: "DESC",
-			sort: DESC,
-			expected: map[string][]*Tuple2{
-				"e2e-service-provider": {
-					{int64(10000), flow.NewStreamRecordWithoutTS(flow.Data{"e2e-service-provider", 10000, []interface{}{"e2e-service-provider"}})},
-					{int64(9800), flow.NewStreamRecordWithoutTS(flow.Data{"e2e-service-provider", 9800, []interface{}{"e2e-service-provider"}})},
-					{int64(9700), flow.NewStreamRecordWithoutTS(flow.Data{"e2e-service-provider", 9700, []interface{}{"e2e-service-provider"}})},
-				},
-				"e2e-service-consumer": {
-					{int64(9900), flow.NewStreamRecordWithoutTS(flow.Data{"e2e-service-consumer", 9900, []interface{}{"e2e-service-consumer"}})},
-					{int64(9800), flow.NewStreamRecordWithoutTS(flow.Data{"e2e-service-consumer", 9800, []interface{}{"e2e-service-consumer"}})},
-					{int64(9700), flow.NewStreamRecordWithoutTS(flow.Data{"e2e-service-consumer", 9700, []interface{}{"e2e-service-consumer"}})},
-				},
-			},
-		},
-		{
-			name: "DESC by default",
-			sort: 0,
-			expected: map[string][]*Tuple2{
-				"e2e-service-provider": {
-					{int64(10000), flow.NewStreamRecordWithoutTS(flow.Data{"e2e-service-provider", 10000, []interface{}{"e2e-service-provider"}})},
-					{int64(9800), flow.NewStreamRecordWithoutTS(flow.Data{"e2e-service-provider", 9800, []interface{}{"e2e-service-provider"}})},
-					{int64(9700), flow.NewStreamRecordWithoutTS(flow.Data{"e2e-service-provider", 9700, []interface{}{"e2e-service-provider"}})},
-				},
-				"e2e-service-consumer": {
-					{int64(9900), flow.NewStreamRecordWithoutTS(flow.Data{"e2e-service-consumer", 9900, []interface{}{"e2e-service-consumer"}})},
-					{int64(9800), flow.NewStreamRecordWithoutTS(flow.Data{"e2e-service-consumer", 9800, []interface{}{"e2e-service-consumer"}})},
-					{int64(9700), flow.NewStreamRecordWithoutTS(flow.Data{"e2e-service-consumer", 9700, []interface{}{"e2e-service-consumer"}})},
-				},
-			},
-		},
-		{
-			name: "ASC",
-			sort: ASC,
-			expected: map[string][]*Tuple2{
-				"e2e-service-consumer": {
-					{int64(9500), flow.NewStreamRecordWithoutTS(flow.Data{"e2e-service-consumer", 9500, []interface{}{"e2e-service-consumer"}})},
-					{int64(9600), flow.NewStreamRecordWithoutTS(flow.Data{"e2e-service-consumer", 9600, []interface{}{"e2e-service-consumer"}})},
-					{int64(9700), flow.NewStreamRecordWithoutTS(flow.Data{"e2e-service-consumer", 9700, []interface{}{"e2e-service-consumer"}})},
-				},
-				"e2e-service-provider": {
-					{int64(9700), flow.NewStreamRecordWithoutTS(flow.Data{"e2e-service-provider", 9700, []interface{}{"e2e-service-provider"}})},
-					{int64(9800), flow.NewStreamRecordWithoutTS(flow.Data{"e2e-service-provider", 9800, []interface{}{"e2e-service-provider"}})},
-					{int64(10000), flow.NewStreamRecordWithoutTS(flow.Data{"e2e-service-provider", 10000, []interface{}{"e2e-service-provider"}})},
-				},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			require := require.New(t)
-			var comparator utils.Comparator
-			if tt.sort == DESC {
-				comparator = func(a, b interface{}) int {
-					return utils.Int64Comparator(b, a)
+	verifyFn := func(t *testing.T, input []flow.StreamRecord, tests []testCase) {
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				require := require.New(t)
+				var comparator utils.Comparator
+				if tt.sort == DESC {
+					comparator = func(a, b interface{}) int {
+						return utils.Int64Comparator(b, a)
+					}
+				} else {
+					comparator = utils.Int64Comparator
 				}
-			} else {
-				comparator = utils.Int64Comparator
-			}
-			topN := &topNAggregatorGroup{
-				cacheSize:       3,
-				sort:            tt.sort,
-				comparator:      comparator,
-				aggregatorGroup: make(map[string]*topNAggregator),
-				sortKeyExtractor: func(record flow.StreamRecord) int64 {
-					return int64(record.Data().(flow.Data)[1].(int))
-				},
-				groupKeyExtractor: func(record flow.StreamRecord) string {
-					return record.Data().(flow.Data)[0].(string)
-				},
-				l: logger.GetLogger("test"),
-			}
-			topN.Add(input)
-			snapshot := topN.Snapshot()
-			require.Len(snapshot, 2)
-			require.Contains(snapshot, "e2e-service-provider") // provider group
-			require.Contains(snapshot, "e2e-service-consumer") // consumer group
-			if diff := cmp.Diff(tt.expected, snapshot); diff != "" {
-				t.Errorf("Snapshot() mismatch (-want +got):\n%s", diff)
-			}
-		})
+				topN := &topNAggregatorGroup{
+					cacheSize:       3,
+					sort:            tt.sort,
+					comparator:      comparator,
+					aggregatorGroup: make(map[string]*topNAggregator),
+					keyExtractor: func(record flow.StreamRecord) uint64 {
+						return uint64(record.Data().(flow.Data)[0].(int))
+					},
+					sortKeyExtractor: func(record flow.StreamRecord) int64 {
+						return int64(record.Data().(flow.Data)[2].(int))
+					},
+					groupKeyExtractor: func(record flow.StreamRecord) string {
+						return record.Data().(flow.Data)[1].(string)
+					},
+					l: logger.GetLogger("test"),
+				}
+				topN.Add(input)
+				topN.leakCheck()
+				snapshot := topN.Snapshot()
+				require.Len(snapshot, 2)
+				require.Contains(snapshot, "e2e-service-provider") // provider group
+				require.Contains(snapshot, "e2e-service-consumer") // consumer group
+				if diff := cmp.Diff(tt.expected, snapshot); diff != "" {
+					t.Errorf("Snapshot() mismatch (-want +got):\n%s", diff)
+				}
+			})
+		}
 	}
+
+	t.Run("normal", func(t *testing.T) {
+		verifyFn(t,
+			[]flow.StreamRecord{
+				// 1. series id
+				// 2. group by values
+				// 3. number
+				// 4. slices of groupBy values
+				flow.NewStreamRecordWithoutTS(flow.Data{1, "e2e-service-provider", 10000, []interface{}{"e2e-service-provider"}}),
+				flow.NewStreamRecordWithoutTS(flow.Data{2, "e2e-service-consumer", 9900, []interface{}{"e2e-service-consumer"}}),
+				flow.NewStreamRecordWithoutTS(flow.Data{3, "e2e-service-provider", 9800, []interface{}{"e2e-service-provider"}}),
+				flow.NewStreamRecordWithoutTS(flow.Data{4, "e2e-service-consumer", 9700, []interface{}{"e2e-service-consumer"}}),
+				flow.NewStreamRecordWithoutTS(flow.Data{5, "e2e-service-provider", 9700, []interface{}{"e2e-service-provider"}}),
+				flow.NewStreamRecordWithoutTS(flow.Data{6, "e2e-service-consumer", 9600, []interface{}{"e2e-service-consumer"}}),
+				flow.NewStreamRecordWithoutTS(flow.Data{7, "e2e-service-consumer", 9800, []interface{}{"e2e-service-consumer"}}),
+				flow.NewStreamRecordWithoutTS(flow.Data{8, "e2e-service-consumer", 9500, []interface{}{"e2e-service-consumer"}}),
+			},
+			[]testCase{
+				{
+					name: "DESC",
+					sort: DESC,
+					expected: map[string][]*Tuple2{
+						"e2e-service-provider": {
+							{int64(10000), flow.NewStreamRecordWithoutTS(flow.Data{1, "e2e-service-provider", 10000, []interface{}{"e2e-service-provider"}})},
+							{int64(9800), flow.NewStreamRecordWithoutTS(flow.Data{3, "e2e-service-provider", 9800, []interface{}{"e2e-service-provider"}})},
+							{int64(9700), flow.NewStreamRecordWithoutTS(flow.Data{5, "e2e-service-provider", 9700, []interface{}{"e2e-service-provider"}})},
+						},
+						"e2e-service-consumer": {
+							{int64(9900), flow.NewStreamRecordWithoutTS(flow.Data{2, "e2e-service-consumer", 9900, []interface{}{"e2e-service-consumer"}})},
+							{int64(9800), flow.NewStreamRecordWithoutTS(flow.Data{7, "e2e-service-consumer", 9800, []interface{}{"e2e-service-consumer"}})},
+							{int64(9700), flow.NewStreamRecordWithoutTS(flow.Data{4, "e2e-service-consumer", 9700, []interface{}{"e2e-service-consumer"}})},
+						},
+					},
+				},
+				{
+					name: "DESC by default",
+					sort: 0,
+					expected: map[string][]*Tuple2{
+						"e2e-service-provider": {
+							{int64(10000), flow.NewStreamRecordWithoutTS(flow.Data{1, "e2e-service-provider", 10000, []interface{}{"e2e-service-provider"}})},
+							{int64(9800), flow.NewStreamRecordWithoutTS(flow.Data{3, "e2e-service-provider", 9800, []interface{}{"e2e-service-provider"}})},
+							{int64(9700), flow.NewStreamRecordWithoutTS(flow.Data{5, "e2e-service-provider", 9700, []interface{}{"e2e-service-provider"}})},
+						},
+						"e2e-service-consumer": {
+							{int64(9900), flow.NewStreamRecordWithoutTS(flow.Data{2, "e2e-service-consumer", 9900, []interface{}{"e2e-service-consumer"}})},
+							{int64(9800), flow.NewStreamRecordWithoutTS(flow.Data{7, "e2e-service-consumer", 9800, []interface{}{"e2e-service-consumer"}})},
+							{int64(9700), flow.NewStreamRecordWithoutTS(flow.Data{4, "e2e-service-consumer", 9700, []interface{}{"e2e-service-consumer"}})},
+						},
+					},
+				},
+				{
+					name: "ASC",
+					sort: ASC,
+					expected: map[string][]*Tuple2{
+						"e2e-service-consumer": {
+							{int64(9500), flow.NewStreamRecordWithoutTS(flow.Data{8, "e2e-service-consumer", 9500, []interface{}{"e2e-service-consumer"}})},
+							{int64(9600), flow.NewStreamRecordWithoutTS(flow.Data{6, "e2e-service-consumer", 9600, []interface{}{"e2e-service-consumer"}})},
+							{int64(9700), flow.NewStreamRecordWithoutTS(flow.Data{4, "e2e-service-consumer", 9700, []interface{}{"e2e-service-consumer"}})},
+						},
+						"e2e-service-provider": {
+							{int64(9700), flow.NewStreamRecordWithoutTS(flow.Data{5, "e2e-service-provider", 9700, []interface{}{"e2e-service-provider"}})},
+							{int64(9800), flow.NewStreamRecordWithoutTS(flow.Data{3, "e2e-service-provider", 9800, []interface{}{"e2e-service-provider"}})},
+							{int64(10000), flow.NewStreamRecordWithoutTS(flow.Data{1, "e2e-service-provider", 10000, []interface{}{"e2e-service-provider"}})},
+						},
+					},
+				},
+			},
+		)
+	})
+	t.Run("duplicated with different sort key", func(t *testing.T) {
+		verifyFn(t,
+			[]flow.StreamRecord{
+				// 1. series id
+				// 2. group by values
+				// 3. number
+				// 4. slices of groupBy values
+				flow.NewStreamRecordWithoutTS(flow.Data{1, "e2e-service-provider", 10000, []interface{}{"e2e-service-provider"}}),
+				flow.NewStreamRecordWithoutTS(flow.Data{2, "e2e-service-consumer", 9900, []interface{}{"e2e-service-consumer"}}),
+				flow.NewStreamRecordWithoutTS(flow.Data{3, "e2e-service-provider", 9800, []interface{}{"e2e-service-provider"}}),
+				flow.NewStreamRecordWithoutTS(flow.Data{4, "e2e-service-consumer", 9700, []interface{}{"e2e-service-consumer"}}),
+				flow.NewStreamRecordWithoutTS(flow.Data{5, "e2e-service-provider", 9700, []interface{}{"e2e-service-provider"}}),
+				flow.NewStreamRecordWithoutTS(flow.Data{6, "e2e-service-consumer", 9600, []interface{}{"e2e-service-consumer"}}),
+				flow.NewStreamRecordWithoutTS(flow.Data{7, "e2e-service-consumer", 9800, []interface{}{"e2e-service-consumer"}}),
+				flow.NewStreamRecordWithoutTS(flow.Data{8, "e2e-service-consumer", 9500, []interface{}{"e2e-service-consumer"}}),
+				flow.NewStreamRecordWithoutTS(flow.Data{3, "e2e-service-provider", 9801, []interface{}{"e2e-service-provider"}}),
+				flow.NewStreamRecordWithoutTS(flow.Data{4, "e2e-service-consumer", 9701, []interface{}{"e2e-service-consumer"}}),
+			},
+			[]testCase{
+				{
+					name: "DESC",
+					sort: DESC,
+					expected: map[string][]*Tuple2{
+						"e2e-service-provider": {
+							{int64(10000), flow.NewStreamRecordWithoutTS(flow.Data{1, "e2e-service-provider", 10000, []interface{}{"e2e-service-provider"}})},
+							{int64(9801), flow.NewStreamRecordWithoutTS(flow.Data{3, "e2e-service-provider", 9801, []interface{}{"e2e-service-provider"}})},
+							{int64(9700), flow.NewStreamRecordWithoutTS(flow.Data{5, "e2e-service-provider", 9700, []interface{}{"e2e-service-provider"}})},
+						},
+						"e2e-service-consumer": {
+							{int64(9900), flow.NewStreamRecordWithoutTS(flow.Data{2, "e2e-service-consumer", 9900, []interface{}{"e2e-service-consumer"}})},
+							{int64(9800), flow.NewStreamRecordWithoutTS(flow.Data{7, "e2e-service-consumer", 9800, []interface{}{"e2e-service-consumer"}})},
+							{int64(9701), flow.NewStreamRecordWithoutTS(flow.Data{4, "e2e-service-consumer", 9701, []interface{}{"e2e-service-consumer"}})},
+						},
+					},
+				},
+				{
+					name: "DESC by default",
+					sort: 0,
+					expected: map[string][]*Tuple2{
+						"e2e-service-provider": {
+							{int64(10000), flow.NewStreamRecordWithoutTS(flow.Data{1, "e2e-service-provider", 10000, []interface{}{"e2e-service-provider"}})},
+							{int64(9801), flow.NewStreamRecordWithoutTS(flow.Data{3, "e2e-service-provider", 9801, []interface{}{"e2e-service-provider"}})},
+							{int64(9700), flow.NewStreamRecordWithoutTS(flow.Data{5, "e2e-service-provider", 9700, []interface{}{"e2e-service-provider"}})},
+						},
+						"e2e-service-consumer": {
+							{int64(9900), flow.NewStreamRecordWithoutTS(flow.Data{2, "e2e-service-consumer", 9900, []interface{}{"e2e-service-consumer"}})},
+							{int64(9800), flow.NewStreamRecordWithoutTS(flow.Data{7, "e2e-service-consumer", 9800, []interface{}{"e2e-service-consumer"}})},
+							{int64(9701), flow.NewStreamRecordWithoutTS(flow.Data{4, "e2e-service-consumer", 9701, []interface{}{"e2e-service-consumer"}})},
+						},
+					},
+				},
+				{
+					name: "ASC",
+					sort: ASC,
+					expected: map[string][]*Tuple2{
+						"e2e-service-consumer": {
+							{int64(9500), flow.NewStreamRecordWithoutTS(flow.Data{8, "e2e-service-consumer", 9500, []interface{}{"e2e-service-consumer"}})},
+							{int64(9600), flow.NewStreamRecordWithoutTS(flow.Data{6, "e2e-service-consumer", 9600, []interface{}{"e2e-service-consumer"}})},
+							{int64(9701), flow.NewStreamRecordWithoutTS(flow.Data{4, "e2e-service-consumer", 9701, []interface{}{"e2e-service-consumer"}})},
+						},
+						"e2e-service-provider": {
+							{int64(9700), flow.NewStreamRecordWithoutTS(flow.Data{5, "e2e-service-provider", 9700, []interface{}{"e2e-service-provider"}})},
+							{int64(9801), flow.NewStreamRecordWithoutTS(flow.Data{3, "e2e-service-provider", 9801, []interface{}{"e2e-service-provider"}})},
+							{int64(10000), flow.NewStreamRecordWithoutTS(flow.Data{1, "e2e-service-provider", 10000, []interface{}{"e2e-service-provider"}})},
+						},
+					},
+				},
+			},
+		)
+	})
+
+	t.Run("duplicated with identical sort key", func(t *testing.T) {
+		verifyFn(t,
+			[]flow.StreamRecord{
+				// 1. series id
+				// 2. group by values
+				// 3. number
+				// 4. slices of groupBy values
+				flow.NewStreamRecordWithoutTS(flow.Data{1, "e2e-service-provider", 10000, []interface{}{"e2e-service-provider"}}),
+				flow.NewStreamRecordWithoutTS(flow.Data{2, "e2e-service-consumer", 9900, []interface{}{"e2e-service-consumer"}}),
+				flow.NewStreamRecordWithoutTS(flow.Data{3, "e2e-service-provider", 9800, []interface{}{"e2e-service-provider"}}),
+				flow.NewStreamRecordWithoutTS(flow.Data{4, "e2e-service-consumer", 9700, []interface{}{"e2e-service-consumer"}}),
+				flow.NewStreamRecordWithoutTS(flow.Data{5, "e2e-service-provider", 9800, []interface{}{"e2e-service-provider"}}),
+				flow.NewStreamRecordWithoutTS(flow.Data{6, "e2e-service-consumer", 9700, []interface{}{"e2e-service-consumer"}}),
+				flow.NewStreamRecordWithoutTS(flow.Data{7, "e2e-service-consumer", 9800, []interface{}{"e2e-service-consumer"}}),
+				flow.NewStreamRecordWithoutTS(flow.Data{8, "e2e-service-consumer", 9500, []interface{}{"e2e-service-consumer"}}),
+				flow.NewStreamRecordWithoutTS(flow.Data{3, "e2e-service-provider", 9801, []interface{}{"e2e-service-provider"}}),
+				flow.NewStreamRecordWithoutTS(flow.Data{4, "e2e-service-consumer", 9701, []interface{}{"e2e-service-consumer"}}),
+			},
+			[]testCase{
+				{
+					name: "DESC",
+					sort: DESC,
+					expected: map[string][]*Tuple2{
+						"e2e-service-provider": {
+							{int64(10000), flow.NewStreamRecordWithoutTS(flow.Data{1, "e2e-service-provider", 10000, []interface{}{"e2e-service-provider"}})},
+							{int64(9801), flow.NewStreamRecordWithoutTS(flow.Data{3, "e2e-service-provider", 9801, []interface{}{"e2e-service-provider"}})},
+							{int64(9800), flow.NewStreamRecordWithoutTS(flow.Data{5, "e2e-service-provider", 9800, []interface{}{"e2e-service-provider"}})},
+						},
+						"e2e-service-consumer": {
+							{int64(9900), flow.NewStreamRecordWithoutTS(flow.Data{2, "e2e-service-consumer", 9900, []interface{}{"e2e-service-consumer"}})},
+							{int64(9800), flow.NewStreamRecordWithoutTS(flow.Data{7, "e2e-service-consumer", 9800, []interface{}{"e2e-service-consumer"}})},
+							{int64(9701), flow.NewStreamRecordWithoutTS(flow.Data{4, "e2e-service-consumer", 9701, []interface{}{"e2e-service-consumer"}})},
+						},
+					},
+				},
+				{
+					name: "DESC by default",
+					sort: 0,
+					expected: map[string][]*Tuple2{
+						"e2e-service-provider": {
+							{int64(10000), flow.NewStreamRecordWithoutTS(flow.Data{1, "e2e-service-provider", 10000, []interface{}{"e2e-service-provider"}})},
+							{int64(9801), flow.NewStreamRecordWithoutTS(flow.Data{3, "e2e-service-provider", 9801, []interface{}{"e2e-service-provider"}})},
+							{int64(9800), flow.NewStreamRecordWithoutTS(flow.Data{5, "e2e-service-provider", 9800, []interface{}{"e2e-service-provider"}})},
+						},
+						"e2e-service-consumer": {
+							{int64(9900), flow.NewStreamRecordWithoutTS(flow.Data{2, "e2e-service-consumer", 9900, []interface{}{"e2e-service-consumer"}})},
+							{int64(9800), flow.NewStreamRecordWithoutTS(flow.Data{7, "e2e-service-consumer", 9800, []interface{}{"e2e-service-consumer"}})},
+							{int64(9701), flow.NewStreamRecordWithoutTS(flow.Data{4, "e2e-service-consumer", 9701, []interface{}{"e2e-service-consumer"}})},
+						},
+					},
+				},
+				{
+					name: "ASC",
+					sort: ASC,
+					expected: map[string][]*Tuple2{
+						"e2e-service-consumer": {
+							{int64(9500), flow.NewStreamRecordWithoutTS(flow.Data{8, "e2e-service-consumer", 9500, []interface{}{"e2e-service-consumer"}})},
+							{int64(9700), flow.NewStreamRecordWithoutTS(flow.Data{6, "e2e-service-consumer", 9700, []interface{}{"e2e-service-consumer"}})},
+							{int64(9701), flow.NewStreamRecordWithoutTS(flow.Data{4, "e2e-service-consumer", 9701, []interface{}{"e2e-service-consumer"}})},
+						},
+						"e2e-service-provider": {
+							{int64(9800), flow.NewStreamRecordWithoutTS(flow.Data{5, "e2e-service-provider", 9800, []interface{}{"e2e-service-provider"}})},
+							{int64(9801), flow.NewStreamRecordWithoutTS(flow.Data{3, "e2e-service-provider", 9801, []interface{}{"e2e-service-provider"}})},
+							{int64(10000), flow.NewStreamRecordWithoutTS(flow.Data{1, "e2e-service-provider", 10000, []interface{}{"e2e-service-provider"}})},
+						},
+					},
+				},
+			},
+		)
+	})
 }


### PR DESCRIPTION

### Fix the bug that TopN processing item leak

OAP measures will be updated in the same time bucket. The TopN processing failed to update the identical item but added it as a new item, which caused the aggregation queue leak. 

- [x] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-banyandb/blob/main/CHANGES.md).
