### PR TITLE
Fix the bug when adding tags or fields to measuer or stream

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,8 @@ Release Notes.
 
 - Fix the bug that TopN processing item leak. The item can not be updated but as a new item.
 - Resolve data race in Stats methods of the inverted index.
+- Fix the bug when adding new tags or fields to the measure, the querying crashes or returns wrong results.
+- Fix the bug that adding new tags to the stream, the querying crashes or returns wrong results.
 
 ### Documentation
 

--- a/banyand/measure/block_test.go
+++ b/banyand/measure/block_test.go
@@ -328,7 +328,7 @@ func Test_marshalAndUnmarshalTagFamily(t *testing.T) {
 	unmarshaled.timestamps = make([]int64, len(b.timestamps))
 	unmarshaled.resizeTagFamilies(1)
 
-	unmarshaled.unmarshalTagFamily(decoder, tfIndex, name, bm.getTagFamilyMetadata(name), tagProjection[name], metaBuffer, dataBuffer)
+	unmarshaled.unmarshalTagFamily(decoder, tfIndex, name, bm.getTagFamilyMetadata(name), tagProjection[name], metaBuffer, dataBuffer, 1)
 
 	if diff := cmp.Diff(unmarshaled.tagFamilies[0], b.tagFamilies[0],
 		cmp.AllowUnexported(columnFamily{}, column{}),

--- a/banyand/measure/column.go
+++ b/banyand/measure/column.go
@@ -73,6 +73,12 @@ func (c *column) mustWriteTo(cm *columnMetadata, columnWriter *writer) {
 func (c *column) mustReadValues(decoder *encoding.BytesBlockDecoder, reader fs.Reader, cm columnMetadata, count uint64) {
 	c.name = cm.name
 	c.valueType = cm.valueType
+	if c.valueType == pbv1.ValueTypeUnknown {
+		for i := uint64(0); i < count; i++ {
+			c.values = append(c.values, nil)
+		}
+		return
+	}
 
 	bb := bigValuePool.Generate()
 	defer bigValuePool.Release(bb)

--- a/banyand/measure/measure_suite_test.go
+++ b/banyand/measure/measure_suite_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/apache/skywalking-banyandb/banyand/metadata"
 	"github.com/apache/skywalking-banyandb/banyand/metadata/embeddedserver"
 	"github.com/apache/skywalking-banyandb/banyand/observability"
+	"github.com/apache/skywalking-banyandb/banyand/query"
 	"github.com/apache/skywalking-banyandb/banyand/queue"
 	"github.com/apache/skywalking-banyandb/pkg/logger"
 	"github.com/apache/skywalking-banyandb/pkg/test"
@@ -78,6 +79,9 @@ func setUp() (*services, func()) {
 	measureService, err := measure.NewService(context.TODO(), metadataService, pipeline, nil, metricSvc)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	preloadMeasureSvc := &preloadMeasureService{metaSvc: metadataService}
+	querySvc, err := query.NewService(context.TODO(), nil, measureService, metadataService, pipeline)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
 	var flags []string
 	metaPath, metaDeferFunc, err := test.NewSpace()
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -94,6 +98,7 @@ func setUp() (*services, func()) {
 		metadataService,
 		preloadMeasureSvc,
 		measureService,
+		querySvc,
 	)
 	return &services{
 			measure:         measureService,

--- a/banyand/measure/metadata_test.go
+++ b/banyand/measure/metadata_test.go
@@ -272,6 +272,7 @@ var _ = Describe("Metadata", func() {
 						dp := queryAllMeasurements(svcs, size*2, []string{"new_tag"}, nil)
 						for i := 0; i < size; i++ {
 							if dp[i].TagFamilies[0].Tags[2].Value.GetStr() == nil {
+								GinkgoWriter.Printf("actual: %s", dp[i].TagFamilies[0].Tags[2])
 								return false
 							}
 							Expect(dp[i].TagFamilies[0].Tags[2].Key).Should(Equal("new_tag"))
@@ -280,6 +281,7 @@ var _ = Describe("Metadata", func() {
 						for i := size; i < size*2; i++ {
 							Expect(dp[i].TagFamilies[0].Tags[2].Key).Should(Equal("new_tag"))
 							if dp[i].TagFamilies[0].Tags[2].Value.GetStr() == nil {
+								GinkgoWriter.Printf("actual: %s", dp[i].TagFamilies[0].Tags[2])
 								return false
 							}
 							Expect(dp[i].TagFamilies[0].Tags[2].Value.GetStr().Value).Should(Equal("test" + strconv.Itoa(i%3+1)))

--- a/banyand/measure/metadata_test.go
+++ b/banyand/measure/metadata_test.go
@@ -19,15 +19,24 @@ package measure_test
 
 import (
 	"context"
+	"strconv"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gleak"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/apache/skywalking-banyandb/api/common"
+	"github.com/apache/skywalking-banyandb/api/data"
 	commonv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/common/v1"
 	databasev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
+	measurev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/measure/v1"
+	modelv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/model/v1"
 	"github.com/apache/skywalking-banyandb/banyand/measure"
+	"github.com/apache/skywalking-banyandb/pkg/bus"
 	"github.com/apache/skywalking-banyandb/pkg/test/flags"
+	"github.com/apache/skywalking-banyandb/pkg/timestamp"
 )
 
 var _ = Describe("Metadata", func() {
@@ -116,11 +125,33 @@ var _ = Describe("Metadata", func() {
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(measureSchema).ShouldNot(BeNil())
 			})
+		})
 
-			It("should update a new measure", func() {
-				// Remove the first tag from the entity
-				newEntityTag := measureSchema.Entity.TagNames[0] + "_updated"
-				measureSchema.Entity.TagNames[0] = newEntityTag
+		Context("Add tags and fields to the measure", func() {
+			var measureSchema *databasev1.Measure
+			size := 3
+
+			BeforeEach(func() {
+				var err error
+				measureSchema, err = svcs.metadataService.MeasureRegistry().GetMeasure(context.TODO(), &commonv1.Metadata{
+					Name:  "service_cpm_minute",
+					Group: "sw_metric",
+				})
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(measureSchema).ShouldNot(BeNil())
+				writeData(svcs, size, nil, nil)
+				_ = queryAllMeasurements(svcs, size, nil, nil)
+
+				measureSchema.TagFamilies[0].Tags = append(measureSchema.TagFamilies[0].Tags, &databasev1.TagSpec{
+					Name: "new_tag",
+					Type: databasev1.TagType_TAG_TYPE_STRING,
+				})
+				measureSchema.Fields = append(measureSchema.Fields, &databasev1.FieldSpec{
+					Name:              "new_field",
+					FieldType:         databasev1.FieldType_FIELD_TYPE_INT,
+					CompressionMethod: databasev1.CompressionMethod_COMPRESSION_METHOD_ZSTD,
+					EncodingMethod:    databasev1.EncodingMethod_ENCODING_METHOD_GORILLA,
+				})
 
 				modRevision, err := svcs.metadataService.MeasureRegistry().UpdateMeasure(context.TODO(), measureSchema)
 				Expect(err).ShouldNot(HaveOccurred())
@@ -135,9 +166,216 @@ var _ = Describe("Metadata", func() {
 						return false
 					}
 
-					return newEntityTag == val.GetSchema().Entity.TagNames[0]
+					return len(val.GetSchema().TagFamilies[0].Tags) == 3 && len(val.GetSchema().Fields) == 3
 				}).WithTimeout(flags.EventuallyTimeout).Should(BeTrue())
+			})
+
+			When("a tag in the data file", func() {
+				It("returns nil for the new added tags", func() {
+					dp := queryAllMeasurements(svcs, size, []string{"new_tag"}, nil)
+					for i := range dp {
+						Expect(dp[i].TagFamilies[0].Tags[2].Key).Should(Equal("new_tag"))
+						Expect(dp[i].TagFamilies[0].Tags[2].Value.GetValue()).Should(BeAssignableToTypeOf(&modelv1.TagValue_Null{}))
+					}
+				})
+				It("get new values for the new added tags", func() {
+					writeData(svcs, size, []string{"test1", "test2", "test3"}, nil)
+					dp := queryAllMeasurements(svcs, size*2, []string{"new_tag"}, nil)
+					for i := 0; i < size; i++ {
+						Expect(dp[i].TagFamilies[0].Tags[2].Key).Should(Equal("new_tag"))
+						Expect(dp[i].TagFamilies[0].Tags[2].Value.GetValue()).Should(BeAssignableToTypeOf(&modelv1.TagValue_Null{}))
+					}
+					for i := size; i < size*2; i++ {
+						Expect(dp[i].TagFamilies[0].Tags[2].Key).Should(Equal("new_tag"))
+						Expect(dp[i].TagFamilies[0].Tags[2].Value.GetStr().Value).Should(Equal("test" + strconv.Itoa(i%3+1)))
+					}
+				})
+			})
+			When("a field in the data file", func() {
+				It("returns nil for the new added fields", func() {
+					dp := queryAllMeasurements(svcs, size, nil, []string{"new_field"})
+					for i := range dp {
+						Expect(dp[i].Fields[2].Name).Should(Equal("new_field"))
+						Expect(dp[i].Fields[2].Value.GetValue()).Should(BeAssignableToTypeOf(&modelv1.FieldValue_Null{}))
+					}
+				})
+				It("get new values for the new added fields", func() {
+					writeData(svcs, size, nil, []int{1, 2, 3})
+					dp := queryAllMeasurements(svcs, size*2, nil, []string{"new_field"})
+					for i := 0; i < size; i++ {
+						Expect(dp[i].Fields[2].Name).Should(Equal("new_field"))
+						Expect(dp[i].Fields[2].Value.GetValue()).Should(BeAssignableToTypeOf(&modelv1.FieldValue_Null{}))
+					}
+					for i := size; i < size*2; i++ {
+						Expect(dp[i].Fields[2].Name).Should(Equal("new_field"))
+						Expect(dp[i].Fields[2].Value.GetInt().Value).Should(Equal(int64(i%3 + 1)))
+					}
+				})
+			})
+			When("a tag in the index file", func() {
+				BeforeEach(func() {
+					indexRule := &databasev1.IndexRule{
+						Metadata: &commonv1.Metadata{
+							Name:  "new_tag",
+							Group: "sw_metric",
+						},
+						Tags: []string{"new_tag"},
+						Type: databasev1.IndexRule_TYPE_INVERTED,
+					}
+					err := svcs.metadataService.IndexRuleRegistry().CreateIndexRule(context.TODO(), indexRule)
+					Expect(err).ShouldNot(HaveOccurred())
+					indexRuleBinding := &databasev1.IndexRuleBinding{
+						Metadata: &commonv1.Metadata{
+							Name:  "service_cpm_minute_new_tag",
+							Group: "sw_metric",
+						},
+						Subject: &databasev1.Subject{
+							Name:    "service_cpm_minute",
+							Catalog: commonv1.Catalog_CATALOG_MEASURE,
+						},
+						Rules:    []string{"new_tag"},
+						BeginAt:  timestamppb.New(timestamp.NowMilli().Add(-time.Hour)),
+						ExpireAt: timestamppb.New(timestamp.NowMilli().Add(time.Hour)),
+					}
+					err = svcs.metadataService.IndexRuleBindingRegistry().CreateIndexRuleBinding(context.TODO(), indexRuleBinding)
+					Expect(err).ShouldNot(HaveOccurred())
+
+					Eventually(func() bool {
+						val, err := svcs.measure.Measure(&commonv1.Metadata{
+							Name:  "service_cpm_minute",
+							Group: "sw_metric",
+						})
+						if err != nil {
+							return false
+						}
+						rr := val.GetIndexRules()
+						for i := range rr {
+							if rr[i].Metadata.Name == "new_tag" {
+								return true
+							}
+						}
+						return false
+					}).WithTimeout(flags.EventuallyTimeout).Should(BeTrue())
+				})
+
+				It("returns nil for the new added tags", func() {
+					dp := queryAllMeasurements(svcs, size, []string{"new_tag"}, nil)
+					for i := range dp {
+						Expect(dp[i].TagFamilies[0].Tags[2].Key).Should(Equal("new_tag"))
+						Expect(dp[i].TagFamilies[0].Tags[2].Value.GetValue()).Should(BeAssignableToTypeOf(&modelv1.TagValue_Null{}))
+					}
+				})
+
+				It("get new values for the new added tags", func() {
+					writeData(svcs, size, []string{"test1", "test2", "test3"}, nil)
+					Eventually(func() bool {
+						dp := queryAllMeasurements(svcs, size*2, []string{"new_tag"}, nil)
+						for i := 0; i < size; i++ {
+							if dp[i].TagFamilies[0].Tags[2].Value.GetStr() == nil {
+								return false
+							}
+							Expect(dp[i].TagFamilies[0].Tags[2].Key).Should(Equal("new_tag"))
+							Expect(dp[i].TagFamilies[0].Tags[2].Value.GetStr().Value).Should(Equal("test" + strconv.Itoa(i+1)))
+						}
+						for i := size; i < size*2; i++ {
+							Expect(dp[i].TagFamilies[0].Tags[2].Key).Should(Equal("new_tag"))
+							if dp[i].TagFamilies[0].Tags[2].Value.GetStr() == nil {
+								return false
+							}
+							Expect(dp[i].TagFamilies[0].Tags[2].Value.GetStr().Value).Should(Equal("test" + strconv.Itoa(i%3+1)))
+						}
+						return true
+					}).WithTimeout(flags.EventuallyTimeout).Should(BeTrue())
+				})
 			})
 		})
 	})
 })
+
+func writeData(svcs *services, expectedSize int, newTag []string, newFields []int) {
+	bp := svcs.pipeline.NewBatchPublisher(5 * time.Second)
+	defer bp.Close()
+	for i := 0; i < expectedSize; i++ {
+		iStr := strconv.Itoa(i)
+		req := &measurev1.WriteRequest{
+			Metadata: &commonv1.Metadata{
+				Name:  "service_cpm_minute",
+				Group: "sw_metric",
+			},
+			DataPoint: &measurev1.DataPointValue{
+				Timestamp: timestamppb.New(timestamp.NowMilli().Add(time.Millisecond)),
+				TagFamilies: []*modelv1.TagFamilyForWrite{{
+					Tags: []*modelv1.TagValue{{
+						Value: &modelv1.TagValue_Str{Str: &modelv1.Str{Value: "id" + iStr}},
+					}, {
+						Value: &modelv1.TagValue_Str{Str: &modelv1.Str{Value: "entity" + iStr}},
+					}},
+				}},
+				Fields: []*modelv1.FieldValue{{
+					Value: &modelv1.FieldValue_Int{Int: &modelv1.Int{Value: int64(i + 100)}},
+				}, {
+					Value: &modelv1.FieldValue_Int{Int: &modelv1.Int{Value: int64(i)}},
+				}},
+			},
+		}
+		if i < len(newTag) {
+			req.DataPoint.TagFamilies[0].Tags = append(req.DataPoint.TagFamilies[0].Tags, &modelv1.TagValue{
+				Value: &modelv1.TagValue_Str{Str: &modelv1.Str{Value: newTag[i]}},
+			})
+		}
+		if i < len(newFields) {
+			req.DataPoint.Fields = append(req.DataPoint.Fields, &modelv1.FieldValue{
+				Value: &modelv1.FieldValue_Int{Int: &modelv1.Int{Value: int64(newFields[i])}},
+			})
+		}
+		bp.Publish(context.TODO(), data.TopicMeasureWrite, bus.NewMessage(bus.MessageID(i), &measurev1.InternalWriteRequest{
+			EntityValues: []*modelv1.TagValue{{Value: &modelv1.TagValue_Str{Str: &modelv1.Str{Value: "entity" + iStr}}}},
+			Request:      req,
+		}))
+	}
+}
+
+func queryAllMeasurements(svcs *services, expectedSize int, newTag []string, newFields []string) []*measurev1.DataPoint {
+	req := &measurev1.QueryRequest{
+		Groups: []string{"sw_metric"},
+		Name:   "service_cpm_minute",
+		TimeRange: &modelv1.TimeRange{
+			Begin: timestamppb.New(timestamp.NowMilli().Add(-time.Hour)),
+			End:   timestamppb.New(timestamp.NowMilli().Add(time.Hour)),
+		},
+		TagProjection: &modelv1.TagProjection{
+			TagFamilies: []*modelv1.TagProjection_TagFamily{
+				{
+					Name: "default",
+					Tags: append([]string{"id", "entity_id"}, newTag...),
+				},
+			},
+		},
+		FieldProjection: &measurev1.QueryRequest_FieldProjection{
+			Names: append([]string{"total", "value"}, newFields...),
+		},
+	}
+	var resp *measurev1.QueryResponse
+	Eventually(func() bool {
+		feat, err := svcs.pipeline.Publish(context.Background(), data.TopicMeasureQuery, bus.NewMessage(bus.MessageID(time.Now().UnixNano()), req))
+		Expect(err).ShouldNot(HaveOccurred())
+		msg, err := feat.Get()
+		Expect(err).ShouldNot(HaveOccurred())
+		data := msg.Data()
+		switch d := data.(type) {
+		case *measurev1.QueryResponse:
+			if len(d.DataPoints) != expectedSize {
+				GinkgoWriter.Printf("actual: %s", d.DataPoints)
+				return false
+			}
+			resp = d
+			return true
+		case common.Error:
+			Fail(d.Msg())
+		default:
+			Fail("unexpected data type")
+		}
+		return false
+	}).WithTimeout(flags.EventuallyTimeout).Should(BeTrue())
+	return resp.DataPoints
+}

--- a/banyand/metadata/schema/error.go
+++ b/banyand/metadata/schema/error.go
@@ -31,6 +31,8 @@ var (
 	ErrClosed = errors.New("metadata registry is closed")
 	// ErrGRPCAlreadyExists indicates the resource already exists.
 	ErrGRPCAlreadyExists = statusGRPCAlreadyExists.Err()
+	// ErrInputInvalid indicates the input is invalid.
+	ErrInputInvalid = statusGRPCInvalidArgument.Err()
 
 	statusGRPCInvalidArgument  = status.New(codes.InvalidArgument, "banyandb: input is invalid")
 	statusGRPCResourceNotFound = status.New(codes.NotFound, "banyandb: resource not found")

--- a/banyand/stream/block_test.go
+++ b/banyand/stream/block_test.go
@@ -283,7 +283,7 @@ func Test_marshalAndUnmarshalTagFamily(t *testing.T) {
 	unmarshaled.timestamps = make([]int64, len(b.timestamps))
 	unmarshaled.resizeTagFamilies(1)
 
-	unmarshaled.unmarshalTagFamily(decoder, tfIndex, name, bm.getTagFamilyMetadata(name), tagProjection[name], metaBuffer, dataBuffer)
+	unmarshaled.unmarshalTagFamily(decoder, tfIndex, name, bm.getTagFamilyMetadata(name), tagProjection[name], metaBuffer, dataBuffer, 1)
 
 	if diff := cmp.Diff(unmarshaled.tagFamilies[0], b.tagFamilies[0],
 		cmp.AllowUnexported(tagFamily{}, tag{}),

--- a/banyand/stream/tag.go
+++ b/banyand/stream/tag.go
@@ -73,6 +73,12 @@ func (t *tag) mustWriteTo(tm *tagMetadata, tagWriter *writer) {
 func (t *tag) mustReadValues(decoder *encoding.BytesBlockDecoder, reader fs.Reader, cm tagMetadata, count uint64) {
 	t.name = cm.name
 	t.valueType = cm.valueType
+	if t.valueType == pbv1.ValueTypeUnknown {
+		for i := uint64(0); i < count; i++ {
+			t.values = append(t.values, nil)
+		}
+		return
+	}
 
 	bb := bigValuePool.Generate()
 	defer bigValuePool.Release(bb)

--- a/bydbctl/internal/cmd/measure_test.go
+++ b/bydbctl/internal/cmd/measure_test.go
@@ -117,8 +117,10 @@ tag_families:
     tags:
       - name: id
         type: TAG_TYPE_STRING
+      - name: tag1
+        type: TAG_TYPE_STRING
 entity:
-  tagNames: ["tag1"]`))
+  tagNames: ["id"]`))
 		out := capturer.CaptureStdout(func() {
 			err := rootCmd.Execute()
 			Expect(err).NotTo(HaveOccurred())
@@ -133,7 +135,7 @@ entity:
 		helpers.UnmarshalYAML([]byte(out), resp)
 		Expect(resp.Measure.Metadata.Group).To(Equal("group1"))
 		Expect(resp.Measure.Metadata.Name).To(Equal("name1"))
-		Expect(resp.Measure.Entity.TagNames[0]).To(Equal("tag1"))
+		Expect(resp.Measure.TagFamilies[0].Tags[1].GetName()).To(Equal("tag1"))
 	})
 
 	It("delete measure schema", func() {

--- a/bydbctl/internal/cmd/stream_test.go
+++ b/bydbctl/internal/cmd/stream_test.go
@@ -118,6 +118,8 @@ tagFamilies:
     tags: 
       - name: trace_id
         type: TAG_TYPE_STRING
+      - name: tag1
+        type: TAG_TYPE_STRING
 entity:
   tagNames: ["tag1"]`))
 		out := capturer.CaptureStdout(func() {
@@ -134,7 +136,7 @@ entity:
 		helpers.UnmarshalYAML([]byte(out), resp)
 		Expect(resp.Stream.Metadata.Group).To(Equal("group1"))
 		Expect(resp.Stream.Metadata.Name).To(Equal("name1"))
-		Expect(resp.Stream.Entity.TagNames[0]).To(Equal("tag1"))
+		Expect(resp.Stream.TagFamilies[0].Tags[1].GetName()).To(Equal("tag1"))
 	})
 
 	It("delete stream schema", func() {

--- a/dist/LICENSE
+++ b/dist/LICENSE
@@ -178,7 +178,7 @@
 Apache-2.0 licenses
 ========================================================================
 
-    github.com/SkyAPM/bluge v0.0.0-20241111124917-c317df1af201 Apache-2.0
+    github.com/SkyAPM/bluge v0.0.0-20241202124911-7db485ccafc7 Apache-2.0
     github.com/SkyAPM/ice v0.0.0-20241108011032-c3d8eea75118 Apache-2.0
     github.com/apache/skywalking-cli v0.0.0-20240227151024-ee371a210afe Apache-2.0
     github.com/blevesearch/segment v0.9.1 Apache-2.0

--- a/docs/interacting/bydbctl/schema/measure.md
+++ b/docs/interacting/bydbctl/schema/measure.md
@@ -98,6 +98,8 @@ entity:
 EOF
 ```
 
+A measure's `entity` is immutable. If you want to change the entity field, you should delete the measure and create a new one.
+
 ## Delete operation
 
 Delete operation removes a measure's schema.

--- a/docs/interacting/bydbctl/schema/stream.md
+++ b/docs/interacting/bydbctl/schema/stream.md
@@ -87,6 +87,8 @@ EOF
 
 ```
 
+A stream's `entity` field is immutable. If you want to change the entity field, you should delete the stream and create a new one.
+
 ## Delete operation
 
 Delete operation delete a stream's schema.

--- a/go.mod
+++ b/go.mod
@@ -157,7 +157,7 @@ require (
 
 replace (
 	github.com/benbjohnson/clock v1.3.0 => github.com/SkyAPM/clock v1.3.1-0.20220809233656-dc7607c94a97
-	github.com/blugelabs/bluge => github.com/SkyAPM/bluge v0.0.0-20241111124917-c317df1af201
+	github.com/blugelabs/bluge => github.com/SkyAPM/bluge v0.0.0-20241202124911-7db485ccafc7
 	github.com/blugelabs/bluge_segment_api => github.com/zinclabs/bluge_segment_api v1.0.0
 	github.com/blugelabs/ice => github.com/SkyAPM/ice v0.0.0-20241108011032-c3d8eea75118
 )

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAE
 github.com/RoaringBitmap/roaring v0.9.4/go.mod h1:icnadbWcNyfEHlYdr+tDlOTih1Bf/h+rzPpv4sbomAA=
 github.com/RoaringBitmap/roaring v1.9.4 h1:yhEIoH4YezLYT04s1nHehNO64EKFTop/wBhxv2QzDdQ=
 github.com/RoaringBitmap/roaring v1.9.4/go.mod h1:6AXUsoIEzDTFFQCe1RbGA6uFONMhvejWj5rqITANK90=
-github.com/SkyAPM/bluge v0.0.0-20241111124917-c317df1af201 h1:QX/WvtL8j5Zrbs68EVEiOE2nFQSvoT5oTkOFh2uNSpg=
-github.com/SkyAPM/bluge v0.0.0-20241111124917-c317df1af201/go.mod h1:6o9wC3xO3qb5Q7VmD1x0r54qQBDpO9+ghGAQvuOHsCU=
+github.com/SkyAPM/bluge v0.0.0-20241202124911-7db485ccafc7 h1:2I3tM57k+g1j3YbJT+WH3u741iHFcW6rXFUVjbLtrrw=
+github.com/SkyAPM/bluge v0.0.0-20241202124911-7db485ccafc7/go.mod h1:6o9wC3xO3qb5Q7VmD1x0r54qQBDpO9+ghGAQvuOHsCU=
 github.com/SkyAPM/clock v1.3.1-0.20220809233656-dc7607c94a97 h1:FKuhJ+6n/DHspGeLleeNbziWnKr9gHKYN4q7NcoCp4s=
 github.com/SkyAPM/clock v1.3.1-0.20220809233656-dc7607c94a97/go.mod h1:2xGRl9H1pllhxTbEGO1W3gDkip8P9GQaHPni/wpdR44=
 github.com/SkyAPM/ice v0.0.0-20241108011032-c3d8eea75118 h1:Ja62sgOCp2qPTd8Xmldv1U83v11IRIsh6KlB7UaFLj4=


### PR DESCRIPTION
The block reader doesn't expect a tag or field projection. It should try to retrieve the column that doesn't exist in a block. This fix will add null value to those unknown columns.

- [x] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.
- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Fixes apache/skywalking#12805.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-banyandb/blob/main/CHANGES.md).
