### PR TITLE
Fix View Configuration and remove redundant fields on Property page

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ Release Notes.
 - Fix the bug when adding new tags or fields to the measure, the querying crashes or returns wrong results.
 - Fix the bug that adding new tags to the stream, the querying crashes or returns wrong results.
 - UI: Polish Index Rule Binding Page and Index Page.
+- Fix: View configuration on Property page
 
 ### Documentation
 

--- a/ui/src/components/Property/PropertyEditror.vue
+++ b/ui/src/components/Property/PropertyEditror.vue
@@ -51,8 +51,6 @@ const rules = {
     group: [{ required: true, message: 'Please enter the group.', trigger: 'blur' }],
     name: [{ required: true, message: 'Please enter the name.', trigger: 'blur' }],
     containerID: [{ required: true, message: 'Please enter the container id.', trigger: 'blur' }],
-    modRevision: [{ required: true, message: 'Please enter the container Mod Revision.', trigger: 'blur' }],
-    createRevision: [{ required: true, message: 'Please enter the container Create Revision.', trigger: 'blur' }],
     id: [{ required: true, message: 'Please enter the ID.', trigger: 'blur' }],
     tags: [{ required: true, validator: validateTags, trigger: 'blur' }],
 }
@@ -66,8 +64,6 @@ const formConfig = [
     { label: 'Container Group', prop: 'group', type: 'input', disabled: true },
     { label: 'Container Name', prop: 'name', type: 'input' },
     { label: 'Container ID', prop: 'containerID', type: 'input' },
-    { label: 'Container ModRevision', prop: 'modRevision', type: 'number' },
-    { label: 'Container CreateRevision', prop: 'createRevision', type: 'number' },
     { label: 'ID', prop: 'id', type: 'input' },
 ]
 let promiseResolve

--- a/ui/src/components/Property/PropertyValueReader.vue
+++ b/ui/src/components/Property/PropertyValueReader.vue
@@ -58,7 +58,7 @@ defineExpose({
 
 <template>
     <el-dialog v-model="showDialog" :title="title">
-        <pre>{{valueData.formattedData}}</pre>
+        <div class="configuration">{{valueData.formattedData}}</div>
         <template #footer>
             <span class="dialog-footer footer">
                 <el-button @click="closeDialog">Cancel</el-button>
@@ -75,5 +75,11 @@ defineExpose({
     width: 100%;
     display: flex;
     justify-content: center;
+}
+.configuration {
+    width: 100%;
+    overflow: auto;
+    max-height: 700px;
+    white-space: pre;
 }
 </style>

--- a/ui/src/components/TopNAggregation/Editor.vue
+++ b/ui/src/components/TopNAggregation/Editor.vue
@@ -270,12 +270,12 @@ function initData() {
     <el-card>
       <template #header>
         <el-row>
-          <el-col :span="12">
+          <el-col :span="20">
               <FormHeader :fields="data" />
           </el-col>
-          <el-col :span="12">
+          <el-col :span="4">
             <div class="flex align-item-center justify-end" style="height: 30px;">
-              <el-button size="small" type="primary" @click="submit(ruleFormRef)" color="#6E38F7">submit</el-button>
+              <el-button size="small" type="primary" @click="submit(ruleFormRef)" color="#6E38F7">Submit</el-button>
             </div>
           </el-col>
         </el-row>


### PR DESCRIPTION

- [x] Fixes apache/skywalking#12835.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-banyandb/blob/main/CHANGES.md).

Video

https://github.com/user-attachments/assets/73fce8e8-b67d-4988-b982-833b50d1e651



Signed-off-by: Qiuxia Fan <qiuxiafan@apache.org>
