### PR TITLE
Fix the issue that the etcd watcher gets the historical node registration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Release Notes.
 ### Bug Fixes
 
 - Fix the deadlock issue when loading a closed segment.
+- Fix the issue that the etcd watcher gets the historical node registration events.
 
 ## 0.8.0
 

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ include scripts/build/ginkgo.mk
 test-ci: $(GINKGO) ## Run the unit tests in CI
 	$(GINKGO) --race \
 	  -ldflags \
-	  "-X github.com/apache/skywalking-banyandb/pkg/test/flags.eventuallyTimeout=30s -X github.com/apache/skywalking-banyandb/pkg/test/flags.LogLevel=error" \
+	  "-X github.com/apache/skywalking-banyandb/pkg/test/flags.eventuallyTimeout=30s -X github.com/apache/skywalking-banyandb/pkg/test/flags.consistentlyTimeout=10s -X github.com/apache/skywalking-banyandb/pkg/test/flags.LogLevel=error" \
 	  $(TEST_CI_OPTS) \
 	  ./... 
 

--- a/banyand/metadata/schema/etcd.go
+++ b/banyand/metadata/schema/etcd.go
@@ -172,7 +172,7 @@ func (e *etcdSchemaRegistry) RegisterHandler(name string, kind Kind, handler Eve
 		return
 	}
 	for i := range kinds {
-		e.registerToWatcher(name, kinds[i], 0, handler)
+		e.registerToWatcher(name, kinds[i], -1, handler)
 	}
 }
 
@@ -186,7 +186,7 @@ func (e *etcdSchemaRegistry) registerToWatcher(name string, kind Kind, revision 
 		return
 	}
 	e.l.Info().Str("name", name).Stringer("kind", kind).Msg("registering to a new watcher")
-	w := e.newWatcherWithRevision(name, kind, revision, CheckInterval(e.checkInterval))
+	w := e.NewWatcher(name, kind, revision, CheckInterval(e.checkInterval))
 	w.AddHandler(handler)
 	e.watchers[kind] = w
 }
@@ -578,11 +578,7 @@ func (e *etcdSchemaRegistry) revokeLease(lease *clientv3.LeaseGrantResponse) {
 	}
 }
 
-func (e *etcdSchemaRegistry) NewWatcher(name string, kind Kind, opts ...WatcherOption) *watcher {
-	return e.newWatcherWithRevision(name, kind, 0, opts...)
-}
-
-func (e *etcdSchemaRegistry) newWatcherWithRevision(name string, kind Kind, revision int64, opts ...WatcherOption) *watcher {
+func (e *etcdSchemaRegistry) NewWatcher(name string, kind Kind, revision int64, opts ...WatcherOption) *watcher {
 	wc := watcherConfig{
 		key:           e.prependNamespace(kind.key()),
 		kind:          kind,

--- a/banyand/metadata/schema/schema.go
+++ b/banyand/metadata/schema/schema.go
@@ -66,7 +66,7 @@ type Registry interface {
 	Node
 	Property
 	RegisterHandler(string, Kind, EventHandler)
-	NewWatcher(string, Kind, ...WatcherOption) *watcher
+	NewWatcher(string, Kind, int64, ...WatcherOption) *watcher
 	Register(context.Context, Metadata, bool) error
 	Compact(context.Context, int64) error
 	StartWatcher()

--- a/banyand/queue/pub/pub.go
+++ b/banyand/queue/pub/pub.go
@@ -95,7 +95,9 @@ func (p *pub) Broadcast(timeout time.Duration, topic bus.Topic, messages bus.Mes
 	var nodes []*databasev1.Node
 	p.mu.RLock()
 	for k := range p.active {
-		nodes = append(nodes, p.registered[k])
+		if n := p.registered[k]; n != nil {
+			nodes = append(nodes, n)
+		}
 	}
 	p.mu.RUnlock()
 	if len(nodes) == 0 {
@@ -104,7 +106,7 @@ func (p *pub) Broadcast(timeout time.Duration, topic bus.Topic, messages bus.Mes
 	names := make(map[string]struct{})
 	if len(messages.NodeSelectors()) == 0 {
 		for _, n := range nodes {
-			names[n.Metadata.Name] = struct{}{}
+			names[n.Metadata.GetName()] = struct{}{}
 		}
 	} else {
 		for g, sel := range messages.NodeSelectors() {

--- a/pkg/test/flags/flags.go
+++ b/pkg/test/flags/flags.go
@@ -27,8 +27,13 @@ var (
 
 	neverTimeout string
 
+	consistentlyTimeout string
+
 	// EventuallyTimeout is the timeout of async time cases execution.
 	EventuallyTimeout time.Duration
+
+	// ConsistentlyTimeout is the timeout of async time cases execution.
+	ConsistentlyTimeout time.Duration
 
 	// NeverTimeout is the timeout of async time cases execution.
 	NeverTimeout time.Duration
@@ -44,6 +49,9 @@ func init() {
 	if neverTimeout == "" {
 		neverTimeout = "2s"
 	}
+	if consistentlyTimeout == "" {
+		consistentlyTimeout = "5s"
+	}
 	d, err := time.ParseDuration(eventuallyTimeout)
 	if err != nil {
 		panic(err)
@@ -54,4 +62,9 @@ func init() {
 		panic(err)
 	}
 	NeverTimeout = d
+	d, err = time.ParseDuration(consistentlyTimeout)
+	if err != nil {
+		panic(err)
+	}
+	ConsistentlyTimeout = d
 }


### PR DESCRIPTION

- [x] Tests(including UT, IT, E2E) are added to verify the new feature.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-banyandb/blob/main/CHANGES.md).
