### PR TITLE
bug/fix Panic when creating _top_n_result #13183

### DIFF
--- a/banyand/measure/metadata.go
+++ b/banyand/measure/metadata.go
@@ -323,7 +323,7 @@ func (sr *schemaRepo) createTopNResultMeasure(ctx context.Context, measureSchema
 	}
 
 	backoffStrategy := backoff.NewExponentialBackOff()
-	backoffStrategy.MaxElapsedTime = 2 * time.Minute
+	backoffStrategy.MaxElapsedTime = 0 // never stop until topN measure has been created
 
 	err := backoff.Retry(operation, backoffStrategy)
 	if err != nil {

--- a/bydbctl/internal/cmd/root.go
+++ b/bydbctl/internal/cmd/root.go
@@ -69,7 +69,7 @@ func RootCmdFlags(command *cobra.Command) {
 	_ = viper.BindPFlag("addr", command.PersistentFlags().Lookup("addr"))
 	viper.SetDefault("addr", "http://localhost:17913")
 
-	command.AddCommand(newGroupCmd(), newUserCmd(), newStreamCmd(), newMeasureCmd(), newTopnCmd(),
+	command.AddCommand(newGroupCmd(), newUseCmd(), newStreamCmd(), newMeasureCmd(), newTopnCmd(),
 		newIndexRuleCmd(), newIndexRuleBindingCmd(), newPropertyCmd(), newHealthCheckCmd(), newAnalyzeCmd())
 }
 

--- a/bydbctl/internal/cmd/use.go
+++ b/bydbctl/internal/cmd/use.go
@@ -26,7 +26,7 @@ import (
 	"github.com/apache/skywalking-banyandb/pkg/version"
 )
 
-func newUserCmd() *cobra.Command {
+func newUseCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:     "use group",
 		Version: version.Build(),

--- a/docs/installation/cluster.md
+++ b/docs/installation/cluster.md
@@ -18,9 +18,9 @@ There is an example: The etcd cluster is spread across three nodes with the addr
 Data nodes and liaison nodes are running as independent processes by
 
 ```shell
-banyand storage --etcd-endpoints=http://10.0.0.1:2379,http://10.0.0.2:2379,http://10.0.0.3:2379 <flags>
-banyand storage --etcd-endpoints=http://10.0.0.1:2379,http://10.0.0.2:2379,http://10.0.0.3:2379 <flags>
-banyand storage --etcd-endpoints=http://10.0.0.1:2379,http://10.0.0.2:2379,http://10.0.0.3:2379 <flags>
+banyand data --etcd-endpoints=http://10.0.0.1:2379,http://10.0.0.2:2379,http://10.0.0.3:2379 <flags>
+banyand data --etcd-endpoints=http://10.0.0.1:2379,http://10.0.0.2:2379,http://10.0.0.3:2379 <flags>
+banyand data --etcd-endpoints=http://10.0.0.1:2379,http://10.0.0.2:2379,http://10.0.0.3:2379 <flags>
 banyand liaison --etcd-endpoints=http://10.0.0.1:2379,http://10.0.0.2:2379,http://10.0.0.3:2379 <flags>
 ```
 
@@ -50,7 +50,7 @@ The username/password is configured in the following command:
 ***Note: recommended using environment variables to set username/password for higher security.***
 
 ```shell
-banyand storage --etcd-endpoints=your-endpoints --etcd-username=your-username --etcd-password=your-password <flags>
+banyand data --etcd-endpoints=your-endpoints --etcd-username=your-username --etcd-password=your-password <flags>
 banyand liaison --etcd-endpoints=your-endpoints --etcd-username=your-username --etcd-password=your-password <flags>
 ```
 
@@ -61,7 +61,7 @@ The etcd trusted certificate file can be setup by the [etcd transport security m
 - `etcd-tls-ca-file`: The path of the trusted certificate file.
 
 ```shell
-banyand storage --etcd-endpoints=your-https-endpoints --etcd-tls-ca-file=youf-file-path <flags>
+banyand data --etcd-endpoints=your-https-endpoints --etcd-tls-ca-file=youf-file-path <flags>
 banyand liaison --etcd-endpoints=your-https-endpoints --etcd-tls-ca-file=youf-file-path <flags>
 ```
 
@@ -74,7 +74,7 @@ The etcd client certificates can be setup by the [etcd transport security model]
 - `etcd-tls-key-file`: Key for the certificate. Must be unencrypted.
 
 ```shell
-banyand storage --etcd-endpoints=your-https-endpoints --etcd-tls-ca-file=youf-file-path --etcd-tls-cert-file=youf-file-path --etcd-tls-key-file=youf-file-path <flags>
+banyand data --etcd-endpoints=your-https-endpoints --etcd-tls-ca-file=youf-file-path --etcd-tls-cert-file=youf-file-path --etcd-tls-key-file=youf-file-path <flags>
 banyand liaison --etcd-endpoints=your-https-endpoints --etcd-tls-ca-file=youf-file-path --etcd-tls-cert-file=youf-file-path --etcd-tls-key-file=youf-file-path <flags>
 ```
 


### PR DESCRIPTION
### Fix Panic when creating _top_n_result
- [ ] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.

- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Fixes apache/skywalking#13183.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking-banyandb/blob/main/CHANGES.md).

Continuously retry to avoids panic until metadata is repaired.
1. After approximately 14 retries, the TopN creation retry interval backs off to 60 seconds, ensuring minimal resource contention
2. If during the topn write phase, it is determined that the `_top_n_result` measure exists, canceling the retry may increase code complexity.

fix some problems:
1. docs/installation/cluster.md : the `storage` command may be deprecated
2. bydbctl/internal/cmd/use.go: the `newUserCmd` may be `newUseCmd`