### PR TITLE
Introduct gossip propagation protocol

### DIFF
--- a/api/data/data.go
+++ b/api/data/data.go
@@ -21,6 +21,7 @@ package data
 import (
 	"google.golang.org/protobuf/proto"
 
+	gossipv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/gossip/v1"
 	measurev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/measure/v1"
 	propertyv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/property/v1"
 	streamv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/stream/v1"
@@ -30,15 +31,17 @@ import (
 var (
 	// TopicMap is the map of topic name to topic.
 	TopicMap = map[string]bus.Topic{
-		TopicStreamWrite.String():    TopicStreamWrite,
-		TopicStreamQuery.String():    TopicStreamQuery,
-		TopicMeasureWrite.String():   TopicMeasureWrite,
-		TopicMeasureQuery.String():   TopicMeasureQuery,
-		TopicTopNQuery.String():      TopicTopNQuery,
-		TopicPropertyDelete.String(): TopicPropertyDelete,
-		TopicPropertyQuery.String():  TopicPropertyQuery,
-		TopicPropertyUpdate.String(): TopicPropertyUpdate,
-		TopicPropertyRepair.String(): TopicPropertyRepair,
+		TopicStreamWrite.String():          TopicStreamWrite,
+		TopicStreamQuery.String():          TopicStreamQuery,
+		TopicMeasureWrite.String():         TopicMeasureWrite,
+		TopicMeasureQuery.String():         TopicMeasureQuery,
+		TopicTopNQuery.String():            TopicTopNQuery,
+		TopicPropertyDelete.String():       TopicPropertyDelete,
+		TopicPropertyQuery.String():        TopicPropertyQuery,
+		TopicPropertyUpdate.String():       TopicPropertyUpdate,
+		TopicPropertyRepair.String():       TopicPropertyRepair,
+		TopicGossipPropagation.String():    TopicGossipPropagation,
+		TopicGossipFutureCallback.String(): TopicGossipFutureCallback,
 	}
 
 	// TopicRequestMap is the map of topic name to request message.
@@ -71,6 +74,12 @@ var (
 		TopicPropertyRepair: func() proto.Message {
 			return &propertyv1.InternalRepairRequest{}
 		},
+		TopicGossipPropagation: func() proto.Message {
+			return &gossipv1.PropagationMessageRequest{}
+		},
+		TopicGossipFutureCallback: func() proto.Message {
+			return &gossipv1.FutureCallbackMessageRequest{}
+		},
 	}
 
 	// TopicResponseMap is the map of topic name to response message.
@@ -96,6 +105,12 @@ var (
 		},
 		TopicPropertyRepair: func() proto.Message {
 			return &propertyv1.InternalRepairResponse{}
+		},
+		TopicGossipPropagation: func() proto.Message {
+			return &gossipv1.PropagationMessageResponse{}
+		},
+		TopicGossipFutureCallback: func() proto.Message {
+			return &gossipv1.FutureCallbackMessageResponse{}
 		},
 	}
 

--- a/api/data/gossip.go
+++ b/api/data/gossip.go
@@ -1,0 +1,41 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package data
+
+import (
+	"github.com/apache/skywalking-banyandb/api/common"
+	"github.com/apache/skywalking-banyandb/pkg/bus"
+)
+
+// TopicGossipPropagationKindVersion defines the kind and version for gossip propagation messages.
+var TopicGossipPropagationKindVersion = common.KindVersion{
+	Version: "v1",
+	Kind:    "gossip-propagation",
+}
+
+// TopicGossipPropagation is a topic for gossip propagation messages.
+var TopicGossipPropagation = bus.BiTopic(TopicGossipPropagationKindVersion.String())
+
+// TopicGossipFutureCallbackKindVersion defines the kind and version for gossip future callback messages.
+var TopicGossipFutureCallbackKindVersion = common.KindVersion{
+	Version: "v1",
+	Kind:    "gossip-future-callback",
+}
+
+// TopicGossipFutureCallback is a topic for gossip future callback messages.
+var TopicGossipFutureCallback = bus.BiTopic(TopicGossipFutureCallbackKindVersion.String())

--- a/api/proto/banyandb/gossip/v1/message.proto
+++ b/api/proto/banyandb/gossip/v1/message.proto
@@ -1,0 +1,51 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+syntax = "proto3";
+
+package banyandb.gossip.v1;
+
+option go_package = "github.com/apache/skywalking-banyandb/api/proto/banyandb/gossip/v1";
+option java_package = "org.apache.skywalking.banyandb.gossip.v1";
+
+message PropagationContext {
+  repeated string nodes = 1;
+  int32 max_propagation_count = 2;
+  string origin_node = 3;
+  uint64 origin_message_id = 4;
+}
+
+message PropagationMessageRequest {
+  string topic = 1;
+  uint64 message_id = 2;
+  PropagationContext context = 3;
+  bytes body = 4;
+}
+
+message PropagationMessageResponse {
+  bool success = 1;
+  string error = 2;
+}
+
+message FutureCallbackMessageRequest {
+  string topic = 1;
+  uint64 message_id = 2;
+  PropagationMessageResponse response = 3;
+}
+
+message FutureCallbackMessageResponse {
+}

--- a/banyand/gossip/client.go
+++ b/banyand/gossip/client.go
@@ -1,0 +1,98 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package gossip
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/apache/skywalking-banyandb/api/data"
+	gossipv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/gossip/v1"
+	"github.com/apache/skywalking-banyandb/banyand/queue"
+	"github.com/apache/skywalking-banyandb/pkg/bus"
+)
+
+func (s *service) Propagation(nodes []string, topic string, message bus.Message) (Future, error) {
+	if len(nodes) < 2 {
+		return nil, fmt.Errorf("must provide at least 2 node")
+	}
+
+	// building propagation context
+	ctx := &gossipv1.PropagationContext{
+		Nodes:           nodes,
+		OriginNode:      s.nodeID,
+		OriginMessageId: uint64(message.ID()),
+	}
+	if len(nodes) == 2 {
+		ctx.MaxPropagationCount = 1
+	} else {
+		// two rounds of all nodes except the lasted node
+		// such when there have three nodes A, B, C,
+		// the propagation will be A -> B, B -> C, C -> A, A -> B
+		ctx.MaxPropagationCount = int32(len(nodes)*2 - 2)
+	}
+
+	// building propagation message request
+	d, ok := message.Data().(proto.Message)
+	if !ok {
+		return nil, fmt.Errorf("invalid message type %T", message.Data())
+	}
+	payload, err := proto.Marshal(d)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal message %T: %w", d, err)
+	}
+	request := &gossipv1.PropagationMessageRequest{
+		Topic:     topic,
+		MessageId: uint64(message.ID()),
+		Context:   ctx,
+		Body:      payload,
+	}
+
+	totalTimeout := time.Second * 15 * time.Duration(ctx.MaxPropagationCount)
+
+	var sendMsg bus.Message
+	var sendTo queue.Client
+	if nodes[0] == s.nodeID {
+		sendMsg = bus.NewMessage(message.ID(), request)
+		sendTo = s.local
+	} else {
+		sendMsg = bus.NewMessageWithNode(message.ID(), nodes[0], request)
+		sendTo = s.remoteClient
+	}
+
+	return s.handleSending(sendTo, sendMsg, ctx.MaxPropagationCount > 1, totalTimeout)
+}
+
+func (s *service) handleSending(sendTo queue.Client, msg bus.Message, hasRemote bool, timeout time.Duration) (Future, error) {
+	ctx, cancelFunc := context.WithTimeout(context.Background(), timeout)
+	defer cancelFunc()
+	publish, err := sendTo.Publish(ctx, data.TopicGossipPropagation, msg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to publish gossip message: %w", err)
+	}
+
+	f := newFuture(s, msg, publish, hasRemote, timeout)
+	// only add to wait list if there is a remote node to propagate
+	if hasRemote {
+		s.addToWait(f)
+	}
+	return f, nil
+}

--- a/banyand/gossip/future.go
+++ b/banyand/gossip/future.go
@@ -1,0 +1,94 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package gossip
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	gossipv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/gossip/v1"
+	"github.com/apache/skywalking-banyandb/pkg/bus"
+)
+
+type future struct {
+	localFuture bus.Future
+	server      *service
+	remoteMsg   atomic.Pointer[bus.Message]
+	timeout     <-chan time.Time
+	wg          sync.WaitGroup
+	messageID   bus.MessageID
+	hasRemote   bool
+}
+
+func newFuture(server *service, msg bus.Message, localFuture bus.Future, hasRemote bool, timeout time.Duration) *future {
+	f := &future{
+		server:      server,
+		messageID:   msg.ID(),
+		localFuture: localFuture,
+		hasRemote:   hasRemote,
+		remoteMsg:   atomic.Pointer[bus.Message]{},
+		wg:          sync.WaitGroup{},
+		timeout:     time.After(timeout),
+	}
+	f.wg.Add(1)
+	return f
+}
+
+func (f *future) Get() (bus.Message, error) {
+	defer func() {
+		// remove the future from the wait list
+		f.server.removeFromWait(f)
+	}()
+	localResp, err := f.localFuture.Get()
+	if err != nil {
+		return bus.Message{}, err
+	}
+
+	if !f.hasRemote {
+		return localResp, nil
+	}
+
+	localData := localResp.Data().(*gossipv1.PropagationMessageResponse)
+	if !localData.Success {
+		return localResp, nil
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		f.wg.Wait()
+	}()
+
+	select {
+	case <-done:
+		loaded := f.remoteMsg.Load()
+		if loaded == nil {
+			return bus.Message{}, fmt.Errorf("failed to load remote message")
+		}
+		return *loaded, nil
+	case <-f.timeout:
+		return bus.Message{}, fmt.Errorf("timeout waiting for remote response")
+	}
+}
+
+func (f *future) saveRemoteResponse(message bus.Message) {
+	f.remoteMsg.Store(&message)
+	f.wg.Done()
+}

--- a/banyand/gossip/gossip.go
+++ b/banyand/gossip/gossip.go
@@ -1,0 +1,19 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package gossip implements the gossip protocol for BanyanDB, it's dependent on the queue package.
+package gossip

--- a/banyand/gossip/local.go
+++ b/banyand/gossip/local.go
@@ -1,0 +1,73 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package gossip
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/apache/skywalking-banyandb/pkg/bus"
+	"github.com/apache/skywalking-banyandb/pkg/run"
+)
+
+type local struct {
+	local  *bus.Bus
+	stopCh chan struct{}
+
+	listeners     map[string][]MessageListener
+	listenersLock sync.RWMutex
+}
+
+// NewLocalMessenger creates a new local messenger that uses the bus package for message passing.
+func NewLocalMessenger() Messenger {
+	return &local{
+		local:     bus.NewBus(),
+		stopCh:    make(chan struct{}),
+		listeners: make(map[string][]MessageListener),
+	}
+}
+
+func (l *local) GracefulStop() {
+	l.local.Close()
+	if l.stopCh != nil {
+		close(l.stopCh)
+	}
+}
+
+func (l *local) Serve() run.StopNotify {
+	return l.stopCh
+}
+
+func (l *local) Name() string {
+	return "local-gossip-messenger"
+}
+
+func (l *local) Subscribe(topic string, listener MessageListener) error {
+	l.listenersLock.Lock()
+	defer l.listenersLock.Unlock()
+	if _, ok := l.listeners[topic]; !ok {
+		l.listeners[topic] = make([]MessageListener, 0)
+	}
+	l.listeners[topic] = append(l.listeners[topic], listener)
+	return nil
+}
+
+func (l *local) Propagation(_ []string, _ string, _ bus.Message) (Future, error) {
+	// no needs to propagate in local messenger
+	return nil, fmt.Errorf("propagation not supported on local messenger")
+}

--- a/banyand/gossip/message.go
+++ b/banyand/gossip/message.go
@@ -1,0 +1,59 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package gossip
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+
+	"github.com/apache/skywalking-banyandb/pkg/bus"
+	"github.com/apache/skywalking-banyandb/pkg/run"
+)
+
+// MessageListener is an interface that defines a method to handle the incoming propagation message.
+type MessageListener interface {
+	Rev(ctx context.Context, nextNode *grpc.ClientConn, message bus.Message) error
+}
+
+// Messenger is an interface that defines methods for message propagation and subscription in a gossip protocol.
+type Messenger interface {
+	MessageClient
+	MessageServer
+	run.Service
+}
+
+// Future is an interface that defines a method to get the result of a message propagation operation.
+type Future interface {
+	// Get waits for the message to be propagated finished and returns the message or an error if the operation fails.
+	Get() (bus.Message, error)
+}
+
+// MessageClient is an interface that defines methods for propagating messages to other nodes in a gossip protocol.
+type MessageClient interface {
+	run.Unit
+	// Propagation using anti-entropy gossip protocol to propagate messages to the specified nodes.
+	Propagation(nodes []string, topic string, message bus.Message) (Future, error)
+}
+
+// MessageServer is an interface that defines methods for subscribing to topics and receiving messages in a gossip protocol.
+type MessageServer interface {
+	run.Unit
+	// Subscribe allows subscribing to a topic to receive messages.
+	Subscribe(topic string, listener MessageListener) error
+}

--- a/banyand/gossip/register.go
+++ b/banyand/gossip/register.go
@@ -1,0 +1,23 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package gossip
+
+import "google.golang.org/protobuf/proto"
+
+// TopicMessageRequestMap is a map that associates topic names with functions that return a new instance of the corresponding message type.
+var TopicMessageRequestMap = map[string]func() proto.Message{}

--- a/banyand/gossip/server.go
+++ b/banyand/gossip/server.go
@@ -1,0 +1,312 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package gossip
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/apache/skywalking-banyandb/api/data"
+	gossipv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/gossip/v1"
+	"github.com/apache/skywalking-banyandb/banyand/observability"
+	"github.com/apache/skywalking-banyandb/banyand/queue"
+	"github.com/apache/skywalking-banyandb/pkg/bus"
+	"github.com/apache/skywalking-banyandb/pkg/meter"
+)
+
+func (s *service) Subscribe(topic string, listener MessageListener) error {
+	s.listenersLock.Lock()
+	defer s.listenersLock.Unlock()
+	if _, ok := s.listeners[topic]; !ok {
+		s.listeners[topic] = make([]MessageListener, 0)
+	}
+	s.listeners[topic] = append(s.listeners[topic], listener)
+	return nil
+}
+
+func (s *service) getListener(topic string) MessageListener {
+	s.listenersLock.RLock()
+	defer s.listenersLock.RUnlock()
+	listeners, ok := s.listeners[topic]
+	if !ok || len(listeners) == 0 {
+		return nil
+	}
+	return listeners[0]
+}
+
+type propagationServer struct {
+	*bus.UnImplementedHealthyListener
+	s *service
+}
+
+func (q *propagationServer) Rev(ctx context.Context, message bus.Message) bus.Message {
+	n := time.Now()
+	now := n.UnixNano()
+	request := message.Data().(*gossipv1.PropagationMessageRequest)
+	nodes := request.Context.Nodes
+	q.s.serverMetrics.totalStarted.Inc(1, request.Topic)
+	q.s.log.Debug().Stringer("request", request).Msg("received gossip message for propagation")
+	defer func() {
+		q.s.serverMetrics.totalFinished.Inc(1, request.Topic)
+		q.s.serverMetrics.totalLatency.Inc(n.Sub(time.Unix(0, now)).Seconds(), request.Topic)
+	}()
+	if len(nodes) == 0 {
+		return q.replyError(ctx, now, request, nil, "no nodes available for gossip message propagation")
+	}
+	nextNodeID, nextNodeConn, err := q.nextNodeConnection(nodes)
+	if err != nil {
+		return q.replyError(ctx, now, request, err, "failed to get next node connection for gossip message propagation")
+	}
+	if nextNodeConn == nil {
+		return q.replyError(ctx, now, request, nil, "no valid connection found for gossip message propagation")
+	}
+	listener := q.s.getListener(request.Topic)
+	if listener == nil {
+		return q.replyError(ctx, now, request, nil, "no listener found for gossip message propagation")
+	}
+	var msg bus.Message
+	if reqSupplier, ok := TopicMessageRequestMap[request.Topic]; ok {
+		// If the topic is registered, we can use the request supplier to create a new request.
+		req := reqSupplier()
+		if errUnmarshal := proto.Unmarshal(request.Body, req); errUnmarshal != nil {
+			return q.replyError(ctx, now, request, errUnmarshal, "failed to unmarshal gossip message propagation")
+		}
+		msg = bus.NewMessage(bus.MessageID(now), req)
+	} else {
+		return q.replyError(ctx, now, request, nil, "no request supplier for gossip message propagation")
+	}
+	q.s.serverMetrics.totalStarted.Inc(1, request.Topic)
+	// process the message using the listener
+	if err = listener.Rev(ctx, nextNodeConn, msg); err != nil {
+		q.s.serverMetrics.totalErr.Inc(1, request.Topic)
+		return q.replyError(ctx, now, request, err, "failed to process gossip message propagation")
+	}
+
+	request.Context.MaxPropagationCount--
+	if request.Context.MaxPropagationCount <= 0 {
+		return q.replySuccess(ctx, now, request, false)
+	}
+
+	// propagate the message to the next node
+	q.s.serverMetrics.totalPropagationStarted.Inc(1, request.Topic)
+	propagationStart := time.Now()
+	q.s.log.Debug().Stringer("request", request).Str("nextNodeID", nextNodeID).
+		Msg("propagating gossip message to next node")
+	publish, err := q.s.remoteClient.Publish(ctx, data.TopicGossipPropagation, bus.NewMessageWithNode(bus.MessageID(now), nextNodeID,
+		request))
+	if err != nil {
+		q.s.serverMetrics.totalPropagationFinished.Inc(1, request.Topic)
+		q.s.serverMetrics.totalPropagationErr.Inc(1, request.Topic)
+		q.s.serverMetrics.totalPropagationLatency.Inc(time.Since(propagationStart).Seconds(), request.Topic)
+		return q.replyError(ctx, now, request, err, "failed to propagate gossip message")
+	}
+	go func(nodeID string, future bus.Future) {
+		resp, err := future.Get()
+		q.s.serverMetrics.totalPropagationFinished.Inc(1, request.Topic)
+		q.s.serverMetrics.totalPropagationLatency.Inc(time.Since(propagationStart).Seconds(), request.Topic)
+		if err != nil {
+			q.s.serverMetrics.totalPropagationErr.Inc(1, request.Topic)
+			q.s.log.Error().Err(err).
+				Stringer("request", request).
+				Str("nodeID", nodeID).
+				Msg("failed to send gossip propagation message")
+			return
+		}
+		respData := resp.Data().(*gossipv1.PropagationMessageResponse)
+		if !respData.Success {
+			q.s.serverMetrics.totalPropagationErr.Inc(1, request.Topic)
+			q.s.log.Error().
+				Stringer("request", request).
+				Str("nodeID", nodeID).
+				Msgf("gossip propagation message failed: %s", respData.Error)
+			return
+		}
+	}(nextNodeID, publish)
+
+	return q.replySuccess(ctx, now, request, true)
+}
+
+func (q *propagationServer) nextNodeConnection(nodes []string) (string, *grpc.ClientConn, error) {
+	if len(nodes) == 0 {
+		return "", nil, errors.New("no nodes available for gossip message propagation")
+	}
+	var nodeID string
+	var node queue.Node
+	var exist bool
+	for i := 0; i < len(nodes); i++ {
+		if nodes[i] == q.s.nodeID {
+			nodeID, node, exist = q.nextExistNode(nodes, i)
+		}
+	}
+	if !exist {
+		return "", nil, errors.New("no valid node found for gossip message propagation")
+	}
+	original := node.Original()
+	if original == nil {
+		return "", nil, fmt.Errorf("no original node found for gossip message propagation")
+	}
+	conn, ok := original.(*grpc.ClientConn)
+	if !ok {
+		return "", nil, fmt.Errorf("expected grpc.ClientConn, got %T", original)
+	}
+	return nodeID, conn, nil
+}
+
+func (q *propagationServer) nextExistNode(nodes []string, curIndex int) (string, queue.Node, bool) {
+	curIndex = (curIndex + 1) % len(nodes)
+	node, exist := q.s.remoteClient.ClusterNode(nodes[curIndex])
+	if exist {
+		return nodes[curIndex], node, true
+	}
+	return "", nil, false
+}
+
+type futureCallbackServer struct {
+	*bus.UnImplementedHealthyListener
+	s *service
+}
+
+func (c *futureCallbackServer) Rev(_ context.Context, message bus.Message) bus.Message {
+	t := time.Now()
+	now := t.UnixNano()
+	req := message.Data().(*gossipv1.FutureCallbackMessageRequest)
+	c.s.serverMetrics.totalFutureCallbackRevStarted.Inc(1, req.Topic)
+	c.s.log.Debug().Stringer("request", req).Msg("received gossip message future callback")
+	defer func() {
+		c.s.serverMetrics.totalFutureCallbackRevLatency.Inc(t.Sub(time.Unix(0, now)).Seconds(), req.Topic)
+		c.s.serverMetrics.totalFutureCallbackRevFinished.Inc(1, req.Topic)
+	}()
+	wait := c.s.getFromWait(bus.MessageID(req.MessageId))
+	if wait == nil {
+		c.s.log.Error().Stringer("request", req).Msg("no future found for gossip message callback")
+		c.s.serverMetrics.totalFutureCallbackRevErr.Inc(1, req.Topic)
+		return bus.NewMessage(bus.MessageID(now), &gossipv1.FutureCallbackMessageResponse{})
+	}
+	wait.saveRemoteResponse(bus.NewMessage(bus.MessageID(now), req.Response))
+	c.s.removeFromWait(wait)
+	return bus.NewMessage(bus.MessageID(now), &gossipv1.FutureCallbackMessageResponse{})
+}
+
+func (q *propagationServer) replyError(ctx context.Context, now int64, req *gossipv1.PropagationMessageRequest, err error, msg string) bus.Message {
+	q.s.log.Error().Err(err).Stringer("request", req).Msg(msg)
+	q.s.serverMetrics.totalErr.Inc(1, req.Topic)
+	if msg == "" {
+		msg = err.Error()
+	}
+	// send the future callback to the original node
+	resp := &gossipv1.PropagationMessageResponse{
+		Success: false,
+		Error:   msg,
+	}
+	go q.sendFutureCallback(ctx, req, resp)
+	return bus.NewMessage(bus.MessageID(now), resp)
+}
+
+func (q *propagationServer) replySuccess(ctx context.Context, now int64, req *gossipv1.PropagationMessageRequest, stillSend bool) bus.Message {
+	q.s.log.Debug().Stringer("request", req).Msg("gossip message propagation succeeded")
+	resp := &gossipv1.PropagationMessageResponse{
+		Success: true,
+	}
+	// if the propagation context has no more propagation count, we should not send the future callback
+	if !stillSend {
+		go q.sendFutureCallback(ctx, req, resp)
+	}
+	return bus.NewMessage(bus.MessageID(now), resp)
+}
+
+func (q *propagationServer) sendFutureCallback(ctx context.Context, req *gossipv1.PropagationMessageRequest, resp *gossipv1.PropagationMessageResponse) {
+	now := time.Now()
+	q.s.serverMetrics.totalFutureCallbackSendStarted.Inc(1, req.Topic)
+	var err error
+	defer func() {
+		q.s.serverMetrics.totalFutureCallbackSendLatency.Inc(time.Since(now).Seconds(), req.Topic)
+		q.s.serverMetrics.totalFutureCallbackSendFinished.Inc(1, req.Topic)
+		if err != nil {
+			q.s.serverMetrics.totalFutureCallbackSendErr.Inc(1, req.Topic)
+		}
+	}()
+	node := req.Context.OriginNode
+	var publishFuture bus.Future
+	callbackReq := &gossipv1.FutureCallbackMessageRequest{
+		Topic:     req.Topic,
+		MessageId: req.Context.OriginMessageId,
+		Response:  resp,
+	}
+	publishFuture, err = q.s.remoteClient.Publish(ctx, data.TopicGossipFutureCallback, bus.NewMessageWithNode(
+		bus.MessageID(now.UnixNano()), node, callbackReq))
+	if err != nil {
+		q.s.log.Error().Err(err).Stringer("request", callbackReq).Msg("failed to send future callback for gossip message propagation")
+		return
+	}
+	_, err = publishFuture.Get()
+	if err != nil {
+		q.s.log.Error().Err(err).Stringer("request", callbackReq).Msg("failed to get future callback response for gossip message propagation")
+		return
+	}
+}
+
+type serverMetrics struct {
+	totalStarted  meter.Counter
+	totalFinished meter.Counter
+	totalErr      meter.Counter
+	totalLatency  meter.Counter
+
+	totalPropagationStarted  meter.Counter
+	totalPropagationFinished meter.Counter
+	totalPropagationErr      meter.Counter
+	totalPropagationLatency  meter.Counter
+
+	totalFutureCallbackRevStarted  meter.Counter
+	totalFutureCallbackRevFinished meter.Counter
+	totalFutureCallbackRevErr      meter.Counter
+	totalFutureCallbackRevLatency  meter.Counter
+
+	totalFutureCallbackSendStarted  meter.Counter
+	totalFutureCallbackSendFinished meter.Counter
+	totalFutureCallbackSendErr      meter.Counter
+	totalFutureCallbackSendLatency  meter.Counter
+}
+
+func newServerMetrics(factory *observability.Factory) *serverMetrics {
+	return &serverMetrics{
+		totalStarted:  factory.NewCounter("total_started", "topic"),
+		totalFinished: factory.NewCounter("total_finished", "topic"),
+		totalErr:      factory.NewCounter("total_err", "topic"),
+		totalLatency:  factory.NewCounter("total_latency", "topic"),
+
+		totalPropagationStarted:  factory.NewCounter("total_msg_received", "topic"),
+		totalPropagationFinished: factory.NewCounter("total_msg_received_err", "topic"),
+		totalPropagationErr:      factory.NewCounter("total_msg_sent", "topic"),
+		totalPropagationLatency:  factory.NewCounter("total_msg_sent_err", "topic"),
+
+		totalFutureCallbackRevStarted:  factory.NewCounter("total_future_callback_rev_started", "topic"),
+		totalFutureCallbackRevFinished: factory.NewCounter("total_future_callback_rev_finished", "topic"),
+		totalFutureCallbackRevErr:      factory.NewCounter("total_future_callback_rev_err", "topic"),
+		totalFutureCallbackRevLatency:  factory.NewCounter("total_future_callback_rev_latency", "topic"),
+
+		totalFutureCallbackSendStarted:  factory.NewCounter("total_future_callback_send_started", "topic"),
+		totalFutureCallbackSendFinished: factory.NewCounter("total_future_callback_send_finished", "topic"),
+		totalFutureCallbackSendErr:      factory.NewCounter("total_future_callback_send_err", "topic"),
+		totalFutureCallbackSendLatency:  factory.NewCounter("total_future_callback_send_latency", "topic"),
+	}
+}

--- a/banyand/gossip/service.go
+++ b/banyand/gossip/service.go
@@ -1,0 +1,130 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package gossip
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"go.uber.org/multierr"
+
+	"github.com/apache/skywalking-banyandb/api/common"
+	"github.com/apache/skywalking-banyandb/api/data"
+	databasev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
+	"github.com/apache/skywalking-banyandb/banyand/observability"
+	"github.com/apache/skywalking-banyandb/banyand/queue"
+	"github.com/apache/skywalking-banyandb/pkg/bus"
+	"github.com/apache/skywalking-banyandb/pkg/logger"
+	"github.com/apache/skywalking-banyandb/pkg/run"
+)
+
+var serverScope = observability.RootScope.SubScope("gossip_messenger_server")
+
+type service struct {
+	omr           observability.MetricsRegistry
+	local         queue.Queue
+	remoteClient  queue.Client
+	remoteServer  queue.Server
+	log           *logger.Logger
+	serverMetrics *serverMetrics
+	listeners     map[string][]MessageListener
+	closer        *run.Closer
+	futures       map[bus.MessageID]*future
+	nodeID        string
+	listenersLock sync.RWMutex
+	futuresLock   sync.Mutex
+}
+
+// NewMessenger creates a new instance of Messenger for gossip propagation communication between nodes.
+func NewMessenger(omr observability.MetricsRegistry, client queue.Client, server queue.Server) Messenger {
+	return &service{
+		omr:           omr,
+		remoteClient:  client,
+		remoteServer:  server,
+		local:         queue.Local(),
+		closer:        run.NewCloser(1),
+		serverMetrics: newServerMetrics(omr.With(serverScope)),
+		listeners:     make(map[string][]MessageListener),
+		futures:       make(map[bus.MessageID]*future),
+	}
+}
+
+func (s *service) PreRun(ctx context.Context) error {
+	val := ctx.Value(common.ContextNodeKey)
+	if val == nil {
+		return errors.New("node id is empty")
+	}
+	node := val.(common.Node)
+	s.nodeID = node.NodeID
+	s.log = logger.GetLogger("gossip-messenger")
+	s.listeners = make(map[string][]MessageListener)
+	s.serverMetrics = newServerMetrics(s.omr.With(serverScope))
+
+	propagation := &propagationServer{s: s}
+	futureCallback := &futureCallbackServer{s: s}
+	return multierr.Combine(
+		s.local.Subscribe(data.TopicGossipPropagation, propagation),
+		s.remoteServer.Subscribe(data.TopicGossipPropagation, propagation),
+		s.remoteServer.Subscribe(data.TopicGossipFutureCallback, futureCallback),
+	)
+}
+
+func (s *service) Name() string {
+	return "gossip-messenger"
+}
+
+func (s *service) Role() databasev1.Role {
+	return databasev1.Role_ROLE_UNSPECIFIED
+}
+
+func (s *service) FlagSet() *run.FlagSet {
+	fs := run.NewFlagSet("gossip-messenger")
+	return fs
+}
+
+func (s *service) Validate() error {
+	return nil
+}
+
+func (s *service) Serve() run.StopNotify {
+	return s.closer.CloseNotify()
+}
+
+func (s *service) GracefulStop() {
+	s.closer.Done()
+	s.closer.CloseThenWait()
+}
+
+func (s *service) removeFromWait(f *future) {
+	s.futuresLock.Lock()
+	defer s.futuresLock.Unlock()
+	delete(s.futures, f.messageID)
+}
+
+func (s *service) addToWait(f *future) {
+	s.futuresLock.Lock()
+	defer s.futuresLock.Unlock()
+	s.futures[f.messageID] = f
+}
+
+func (s *service) getFromWait(msgID bus.MessageID) *future {
+	s.futuresLock.Lock()
+	defer s.futuresLock.Unlock()
+	return s.futures[msgID]
+}

--- a/banyand/gossip/service_test.go
+++ b/banyand/gossip/service_test.go
@@ -1,0 +1,259 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package gossip
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/apache/skywalking-banyandb/api/common"
+	commonv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/common/v1"
+	databasev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
+	gossipv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/gossip/v1"
+	"github.com/apache/skywalking-banyandb/banyand/metadata/schema"
+	"github.com/apache/skywalking-banyandb/banyand/observability"
+	"github.com/apache/skywalking-banyandb/banyand/queue"
+	"github.com/apache/skywalking-banyandb/banyand/queue/pub"
+	"github.com/apache/skywalking-banyandb/banyand/queue/sub"
+	"github.com/apache/skywalking-banyandb/pkg/bus"
+	"github.com/apache/skywalking-banyandb/pkg/logger"
+	"github.com/apache/skywalking-banyandb/pkg/run"
+	"github.com/apache/skywalking-banyandb/pkg/test"
+	"github.com/apache/skywalking-banyandb/pkg/test/flags"
+)
+
+const mockTopic = "mock-topic"
+
+func TestGossip(t *testing.T) {
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, "Gossip Suite")
+}
+
+var _ = ginkgo.Describe("Propagation Messenger", func() {
+	gomega.Expect(logger.Init(logger.Logging{
+		Env:   "dev",
+		Level: flags.LogLevel,
+	})).To(gomega.Succeed())
+
+	var nodes []*nodeContext
+	ginkgo.BeforeEach(func() {
+		TopicMessageRequestMap[mockTopic] = func() proto.Message {
+			return &commonv1.Group{}
+		}
+	})
+	ginkgo.AfterEach(func() {
+		for _, node := range nodes {
+			if node != nil {
+				node.stop()
+			}
+		}
+		nodes = nil
+	})
+
+	ginkgo.It("single node", func() {
+		nodes = startNodes(1)
+		node := nodes[0]
+
+		_, err := node.messenger.Propagation([]string{node.nodeID}, mockTopic, bus.NewMessage(1, &commonv1.Group{}))
+		gomega.Expect(err).To(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("two nodes and send from self", func() {
+		nodes = startNodes(2)
+		node1, node2 := nodes[0], nodes[1]
+
+		f, err := node1.messenger.Propagation([]string{node1.nodeID, node2.nodeID}, mockTopic, bus.NewMessage(1, &commonv1.Group{}))
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		verifyFuture(f, true)
+		gomega.Expect(node1.listener.targets).To(gomega.Equal([]string{node2.nodeID}))
+		gomega.Expect(node1.listener.messages).To(gomega.HaveLen(1))
+	})
+
+	ginkgo.It("two nodes and send from other node", func() {
+		nodes = startNodes(2)
+		node1, node2 := nodes[0], nodes[1]
+
+		f, err := node2.messenger.Propagation([]string{node1.nodeID, node2.nodeID}, mockTopic, bus.NewMessage(1, &commonv1.Group{}))
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		verifyFuture(f, true)
+		gomega.Expect(node1.listener.targets).To(gomega.Equal([]string{node2.nodeID}))
+		gomega.Expect(node1.listener.messages).To(gomega.HaveLen(1))
+
+		gomega.Expect(node2.listener.targets).To(gomega.HaveLen(0))
+	})
+
+	ginkgo.It("multiple nodes with propagation", func() {
+		nodes = startNodes(3)
+		node1, node2, node3 := nodes[0], nodes[1], nodes[2]
+
+		f, err := node1.messenger.Propagation([]string{node1.nodeID, node2.nodeID, node3.nodeID}, mockTopic, bus.NewMessage(1, &commonv1.Group{}))
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		verifyFuture(f, true)
+		gomega.Expect(node1.listener.targets).To(gomega.Equal([]string{node2.nodeID, node2.nodeID}))
+		gomega.Expect(node1.listener.messages).To(gomega.HaveLen(2))
+
+		gomega.Expect(node2.listener.targets).To(gomega.Equal([]string{node3.nodeID}))
+		gomega.Expect(node2.listener.messages).To(gomega.HaveLen(1))
+
+		gomega.Expect(node3.listener.targets).To(gomega.Equal([]string{node1.nodeID}))
+		gomega.Expect(node3.listener.messages).To(gomega.HaveLen(1))
+	})
+
+	ginkgo.It("multiple nodes with propagation with error", func() {
+		nodes = startNodes(3)
+		node1, node2, node3 := nodes[0], nodes[1], nodes[2]
+		node3.listener.mockErr = fmt.Errorf("mock error")
+
+		f, err := node1.messenger.Propagation([]string{node1.nodeID, node2.nodeID, node3.nodeID}, mockTopic, bus.NewMessage(1, &commonv1.Group{}))
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		verifyFuture(f, false)
+		gomega.Expect(node1.listener.targets).To(gomega.Equal([]string{node2.nodeID}))
+		gomega.Expect(node1.listener.messages).To(gomega.HaveLen(1))
+
+		gomega.Expect(node2.listener.targets).To(gomega.Equal([]string{node3.nodeID}))
+		gomega.Expect(node2.listener.messages).To(gomega.HaveLen(1))
+
+		gomega.Expect(node3.listener.targets).To(gomega.HaveLen(0))
+		gomega.Expect(node3.listener.messages).To(gomega.HaveLen(0))
+	})
+})
+
+type nodeContext struct {
+	messenger Messenger
+	listener  *mockListener
+	stop      func()
+	nodeID    string
+}
+
+func startNodes(count int) []*nodeContext {
+	p := pub.NewWithoutMetadata()
+	result := make([]*nodeContext, count)
+	for i := 0; i < count; i++ {
+		listener := &mockListener{}
+
+		// starting grpc server node
+		addr, server := startNode()
+		gomega.Expect(server).NotTo(gomega.BeNil())
+
+		// starting gossip messenger
+		messenger := NewMessenger(observability.NewBypassRegistry(), p, server)
+		gomega.Expect(messenger).NotTo(gomega.BeNil())
+		messenger.(run.PreRunner).PreRun(context.WithValue(context.Background(), common.ContextNodeKey, common.Node{
+			NodeID: addr,
+		}))
+		messenger.Subscribe(mockTopic, listener)
+		_ = messenger.Serve()
+
+		// adding node context
+		result[i] = &nodeContext{
+			nodeID:    addr,
+			listener:  listener,
+			messenger: messenger,
+			stop: func() {
+				messenger.GracefulStop()
+				server.(run.Service).GracefulStop()
+			},
+		}
+
+		// registering the node in the gossip system
+		p.OnAddOrUpdate(schema.Metadata{
+			TypeMeta: schema.TypeMeta{
+				Name: addr,
+				Kind: schema.KindNode,
+			},
+			Spec: &databasev1.Node{
+				Metadata: &commonv1.Metadata{
+					Name: addr,
+				},
+				Roles:       []databasev1.Role{databasev1.Role_ROLE_DATA},
+				GrpcAddress: addr,
+			},
+		})
+	}
+
+	// make sure all nodes are activated
+	gomega.Eventually(func() error {
+		for _, node := range result {
+			_, exist := p.ClusterNode(node.nodeID)
+			if !exist {
+				return fmt.Errorf("node %s is not registered in gossip", node.nodeID)
+			}
+		}
+		return nil
+	}, flags.EventuallyTimeout).Should(gomega.Succeed())
+	return result
+}
+
+func startNode() (string, queue.Server) {
+	ports, err := test.AllocateFreePorts(2)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	server := sub.NewServerWithPorts(observability.NewBypassRegistry(), "",
+		uint32(ports[0]), uint32(ports[1]))
+	server.(run.PreRunner).PreRun(context.Background())
+	err = server.(run.Config).Validate()
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	_ = server.(run.Service).Serve()
+	addr := net.JoinHostPort("localhost", strconv.Itoa(ports[0]))
+	gomega.Eventually(func() error {
+		conn, err := net.DialTimeout("tcp", addr, time.Second*2)
+		if err == nil {
+			_ = conn.Close()
+		}
+		return err
+	}, flags.EventuallyTimeout).Should(gomega.Succeed())
+	return addr, server
+}
+
+func verifyFuture(f Future, success bool) {
+	gomega.Expect(f).NotTo(gomega.BeNil())
+	resp, err := f.Get()
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	gomega.Expect(resp).NotTo(gomega.BeNil())
+	gomega.Expect(resp.Data()).NotTo(gomega.BeNil())
+	data, ok := resp.Data().(*gossipv1.PropagationMessageResponse)
+	gomega.Expect(ok).To(gomega.BeTrue())
+	if success {
+		gomega.Expect(data.Success).To(gomega.BeTrue(), "Propagation should be successful")
+	} else {
+		gomega.Expect(data.Success).To(gomega.BeFalse(), "Propagation should not be successful")
+	}
+}
+
+type mockListener struct {
+	mockErr  error
+	targets  []string
+	messages []bus.Message
+}
+
+func (m *mockListener) Rev(_ context.Context, nextNode *grpc.ClientConn, message bus.Message) error {
+	if m.mockErr != nil {
+		return m.mockErr
+	}
+	m.targets = append(m.targets, nextNode.Target())
+	m.messages = append(m.messages, message)
+	return nil
+}

--- a/banyand/property/service.go
+++ b/banyand/property/service.go
@@ -29,6 +29,7 @@ import (
 	"github.com/apache/skywalking-banyandb/api/common"
 	"github.com/apache/skywalking-banyandb/api/data"
 	databasev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
+	"github.com/apache/skywalking-banyandb/banyand/gossip"
 	"github.com/apache/skywalking-banyandb/banyand/internal/storage"
 	"github.com/apache/skywalking-banyandb/banyand/metadata"
 	"github.com/apache/skywalking-banyandb/banyand/observability"
@@ -51,6 +52,7 @@ var (
 type service struct {
 	metadata            metadata.Repo
 	pipeline            queue.Server
+	gossipMessenger     gossip.Messenger
 	omr                 observability.MetricsRegistry
 	lfs                 fs.FileSystem
 	close               chan struct{}
@@ -137,7 +139,7 @@ func (s *service) GracefulStop() {
 }
 
 // NewService returns a new service.
-func NewService(metadata metadata.Repo, pipeline queue.Server, omr observability.MetricsRegistry, pm protector.Memory) (Service, error) {
+func NewService(metadata metadata.Repo, pipeline queue.Server, omr observability.MetricsRegistry, pm protector.Memory, messenger gossip.Messenger) (Service, error) {
 	return &service{
 		metadata: metadata,
 		pipeline: pipeline,
@@ -145,5 +147,7 @@ func NewService(metadata metadata.Repo, pipeline queue.Server, omr observability
 		db:       &database{},
 		pm:       pm,
 		close:    make(chan struct{}),
+
+		gossipMessenger: messenger,
 	}, nil
 }

--- a/banyand/queue/local.go
+++ b/banyand/queue/local.go
@@ -99,6 +99,10 @@ func (*local) GetPort() *uint32 {
 func (*local) Register(bus.Topic, schema.EventHandler) {
 }
 
+func (*local) ClusterNode(_ string) (Node, bool) {
+	return nil, false
+}
+
 type localBatchPublisher struct {
 	ctx      context.Context
 	local    *bus.Bus

--- a/banyand/queue/pub/client.go
+++ b/banyand/queue/pub/client.go
@@ -66,6 +66,10 @@ type client struct {
 	md     schema.Metadata
 }
 
+func (c *client) Original() any {
+	return c.conn
+}
+
 func (p *pub) OnAddOrUpdate(md schema.Metadata) {
 	if md.Kind != schema.KindNode {
 		return

--- a/banyand/queue/pub/pub.go
+++ b/banyand/queue/pub/pub.go
@@ -303,6 +303,15 @@ func (p *pub) PreRun(context.Context) error {
 	return nil
 }
 
+func (p *pub) ClusterNode(nodeID string) (queue.Node, bool) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	if c, ok := p.active[nodeID]; ok {
+		return c, true
+	}
+	return nil, false
+}
+
 func messageToRequest(topic bus.Topic, m bus.Message) (*clusterv1.SendRequest, error) {
 	r := &clusterv1.SendRequest{
 		Topic:     topic.String(),

--- a/banyand/queue/queue.go
+++ b/banyand/queue/queue.go
@@ -42,10 +42,23 @@ type Client interface {
 	run.Unit
 	bus.Publisher
 	bus.Broadcaster
+	ClusterAware
 	NewBatchPublisher(timeout time.Duration) BatchPublisher
 	Register(bus.Topic, schema.EventHandler)
 	OnAddOrUpdate(md schema.Metadata)
 	GracefulStop()
+}
+
+// ClusterAware is the interface for clients that are aware of the cluster topology.
+type ClusterAware interface {
+	// ClusterNode returns a Node that can be used to activate a client for a specific node.
+	ClusterNode(nodeID string) (Node, bool)
+}
+
+// Node is the interface for a node in the cluster.
+type Node interface {
+	// Original returns the original connection of the node, generally should be *grpc.ClientConn.
+	Original() any
 }
 
 // Server is the interface for receiving data from the queue.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -193,6 +193,13 @@
     - [StreamRegistryService](#banyandb-database-v1-StreamRegistryService)
     - [TopNAggregationRegistryService](#banyandb-database-v1-TopNAggregationRegistryService)
   
+- [banyandb/gossip/v1/message.proto](#banyandb_gossip_v1_message-proto)
+    - [FutureCallbackMessageRequest](#banyandb-gossip-v1-FutureCallbackMessageRequest)
+    - [FutureCallbackMessageResponse](#banyandb-gossip-v1-FutureCallbackMessageResponse)
+    - [PropagationContext](#banyandb-gossip-v1-PropagationContext)
+    - [PropagationMessageRequest](#banyandb-gossip-v1-PropagationMessageRequest)
+    - [PropagationMessageResponse](#banyandb-gossip-v1-PropagationMessageResponse)
+  
 - [banyandb/measure/v1/query.proto](#banyandb_measure_v1_query-proto)
     - [DataPoint](#banyandb-measure-v1-DataPoint)
     - [DataPoint.Field](#banyandb-measure-v1-DataPoint-Field)
@@ -2934,6 +2941,101 @@ Type determine the index structure under the hood
 | Get | [TopNAggregationRegistryServiceGetRequest](#banyandb-database-v1-TopNAggregationRegistryServiceGetRequest) | [TopNAggregationRegistryServiceGetResponse](#banyandb-database-v1-TopNAggregationRegistryServiceGetResponse) |  |
 | List | [TopNAggregationRegistryServiceListRequest](#banyandb-database-v1-TopNAggregationRegistryServiceListRequest) | [TopNAggregationRegistryServiceListResponse](#banyandb-database-v1-TopNAggregationRegistryServiceListResponse) |  |
 | Exist | [TopNAggregationRegistryServiceExistRequest](#banyandb-database-v1-TopNAggregationRegistryServiceExistRequest) | [TopNAggregationRegistryServiceExistResponse](#banyandb-database-v1-TopNAggregationRegistryServiceExistResponse) | Exist doesn&#39;t expose an HTTP endpoint. Please use HEAD method to touch Get instead |
+
+ 
+
+
+
+<a name="banyandb_gossip_v1_message-proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## banyandb/gossip/v1/message.proto
+
+
+
+<a name="banyandb-gossip-v1-FutureCallbackMessageRequest"></a>
+
+### FutureCallbackMessageRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| topic | [string](#string) |  |  |
+| message_id | [uint64](#uint64) |  |  |
+| response | [PropagationMessageResponse](#banyandb-gossip-v1-PropagationMessageResponse) |  |  |
+
+
+
+
+
+
+<a name="banyandb-gossip-v1-FutureCallbackMessageResponse"></a>
+
+### FutureCallbackMessageResponse
+
+
+
+
+
+
+
+<a name="banyandb-gossip-v1-PropagationContext"></a>
+
+### PropagationContext
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| nodes | [string](#string) | repeated |  |
+| max_propagation_count | [int32](#int32) |  |  |
+| origin_node | [string](#string) |  |  |
+| origin_message_id | [uint64](#uint64) |  |  |
+
+
+
+
+
+
+<a name="banyandb-gossip-v1-PropagationMessageRequest"></a>
+
+### PropagationMessageRequest
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| topic | [string](#string) |  |  |
+| message_id | [uint64](#uint64) |  |  |
+| context | [PropagationContext](#banyandb-gossip-v1-PropagationContext) |  |  |
+| body | [bytes](#bytes) |  |  |
+
+
+
+
+
+
+<a name="banyandb-gossip-v1-PropagationMessageResponse"></a>
+
+### PropagationMessageResponse
+
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| success | [bool](#bool) |  |  |
+| error | [string](#string) |  |  |
+
+
+
+
+
+ 
+
+ 
+
+ 
 
  
 

--- a/pkg/cmdsetup/data.go
+++ b/pkg/cmdsetup/data.go
@@ -24,6 +24,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/apache/skywalking-banyandb/api/common"
+	databasev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
+	"github.com/apache/skywalking-banyandb/banyand/gossip"
 	"github.com/apache/skywalking-banyandb/banyand/measure"
 	"github.com/apache/skywalking-banyandb/banyand/metadata"
 	"github.com/apache/skywalking-banyandb/banyand/observability"
@@ -31,6 +33,7 @@ import (
 	"github.com/apache/skywalking-banyandb/banyand/protector"
 	"github.com/apache/skywalking-banyandb/banyand/query"
 	"github.com/apache/skywalking-banyandb/banyand/queue"
+	"github.com/apache/skywalking-banyandb/banyand/queue/pub"
 	"github.com/apache/skywalking-banyandb/banyand/queue/sub"
 	"github.com/apache/skywalking-banyandb/banyand/stream"
 	"github.com/apache/skywalking-banyandb/pkg/logger"
@@ -49,7 +52,9 @@ func newDataCmd(runners ...run.Unit) *cobra.Command {
 	metricSvc := observability.NewMetricService(metaSvc, localPipeline, "data", nil)
 	pm := protector.NewMemory(metricSvc)
 	pipeline := sub.NewServer(metricSvc)
-	propertySvc, err := property.NewService(metaSvc, pipeline, metricSvc, pm)
+	client := pub.New(metaSvc, databasev1.Role_ROLE_DATA)
+	messenger := gossip.NewMessenger(metricSvc, client, pipeline)
+	propertySvc, err := property.NewService(metaSvc, pipeline, metricSvc, pm, messenger)
 	if err != nil {
 		l.Fatal().Err(err).Msg("failed to initiate property service")
 	}
@@ -75,6 +80,7 @@ func newDataCmd(runners ...run.Unit) *cobra.Command {
 		metricSvc,
 		pm,
 		pipeline,
+		messenger,
 		propertySvc,
 		measureSvc,
 		streamSvc,

--- a/pkg/cmdsetup/standalone.go
+++ b/pkg/cmdsetup/standalone.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/apache/skywalking-banyandb/api/common"
+	"github.com/apache/skywalking-banyandb/banyand/gossip"
 	"github.com/apache/skywalking-banyandb/banyand/liaison/grpc"
 	"github.com/apache/skywalking-banyandb/banyand/liaison/http"
 	"github.com/apache/skywalking-banyandb/banyand/measure"
@@ -51,7 +52,7 @@ func newStandaloneCmd(runners ...run.Unit) *cobra.Command {
 	}
 	metricSvc := observability.NewMetricService(metaSvc, liaisonPipeline, "standalone", nil)
 	pm := protector.NewMemory(metricSvc)
-	propertySvc, err := property.NewService(metaSvc, dataPipeline, metricSvc, pm)
+	propertySvc, err := property.NewService(metaSvc, dataPipeline, metricSvc, pm, gossip.NewLocalMessenger())
 	if err != nil {
 		l.Fatal().Err(err).Msg("failed to initiate property service")
 	}


### PR DESCRIPTION
Introduce the gossip propagation protocol for the data nodes to communicate without liaison. It's based on the queue package as a basic protocol. 

When using gossip propagation message, it still needs to register the protocol and topic, same as the queue. And pass the `nodes` list to let these nodes communicate self, then return the Future for the result notification. 

- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Part of Apache/Skywalking #13284.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking-banyandb/blob/main/CHANGES.md).
