### PR TITLE
Remove useless console print

### DIFF
--- a/pkg/encoding/float.go
+++ b/pkg/encoding/float.go
@@ -79,8 +79,6 @@ func DecimalIntListToFloat64List(dst []float64, values []int64, exponent int16, 
 // However, if the input is really 3.10000000000000009, this may result in loss of accuracy.
 func countDecimalPlaces(f float64, maxPlace int) int16 {
 	for i := 0; i < maxPlace; i++ {
-		modf, frac := math.Modf(f)
-		fmt.Println(modf, frac)
 		if math.Abs(f-math.Round(f)) < 1e-9 {
 			return int16(i)
 		}


### PR DESCRIPTION
I see a lot of console print in the CI, it makes the CI failure not easy to see. Here is a CI link: https://github.com/apache/skywalking-banyandb/actions/runs/16164154978/job/45623961805?pr=692

![image](https://github.com/user-attachments/assets/0058be7f-5173-490e-8b85-75ca1ec99bdf)

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Fixes apache/skywalking#<issue number>.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking-banyandb/blob/main/CHANGES.md).
