### PR TITLE
Updated migration visitor constructors to accept target stage interval

### DIFF
--- a/banyand/backup/lifecycle/migration_integration.go
+++ b/banyand/backup/lifecycle/migration_integration.go
@@ -51,6 +51,9 @@ func migrateStreamWithFileBasedAndProgress(
 	// Convert TTL to IntervalRule using storage.MustToIntervalRule
 	intervalRule := storage.MustToIntervalRule(ttl)
 
+	// Get target stage configuration
+	targetStageInterval := getTargetStageInterval(group)
+
 	// Count total parts before starting migration
 	totalParts, err := countStreamParts(tsdbRootPath, timeRange, intervalRule)
 	if err != nil {
@@ -59,8 +62,8 @@ func migrateStreamWithFileBasedAndProgress(
 		logger.Info().Int("total_parts", totalParts).Msg("counted stream parts for progress tracking")
 	}
 
-	// Create file-based migration visitor with progress tracking
-	visitor := newStreamMigrationVisitor(group, shardNum, replicas, selector, client, logger, progress, chunkSize)
+	// Create file-based migration visitor with progress tracking and target stage interval
+	visitor := newStreamMigrationVisitor(group, shardNum, replicas, selector, client, logger, progress, chunkSize, targetStageInterval)
 	defer visitor.Close()
 
 	// Set the total part count for progress tracking
@@ -129,6 +132,9 @@ func migrateMeasureWithFileBasedAndProgress(
 	// Convert TTL to IntervalRule using storage.MustToIntervalRule
 	intervalRule := storage.MustToIntervalRule(ttl)
 
+	// Get target stage configuration
+	targetStageInterval := getTargetStageInterval(group)
+
 	// Count total parts before starting migration
 	totalParts, err := countMeasureParts(tsdbRootPath, timeRange, intervalRule)
 	if err != nil {
@@ -137,8 +143,8 @@ func migrateMeasureWithFileBasedAndProgress(
 		logger.Info().Int("total_parts", totalParts).Msg("counted measure parts for progress tracking")
 	}
 
-	// Create file-based migration visitor with progress tracking
-	visitor := newMeasureMigrationVisitor(group, shardNum, replicas, selector, client, logger, progress, chunkSize)
+	// Create file-based migration visitor with progress tracking and target stage interval
+	visitor := newMeasureMigrationVisitor(group, shardNum, replicas, selector, client, logger, progress, chunkSize, targetStageInterval)
 	defer visitor.Close()
 
 	// Set the total part count for progress tracking

--- a/banyand/backup/lifecycle/segment_boundary_utils.go
+++ b/banyand/backup/lifecycle/segment_boundary_utils.go
@@ -1,0 +1,78 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package lifecycle
+
+import (
+	"time"
+
+	commonv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/common/v1"
+	"github.com/apache/skywalking-banyandb/banyand/internal/storage"
+	"github.com/apache/skywalking-banyandb/pkg/timestamp"
+)
+
+func calculateTargetSegments(partMinTS, partMaxTS int64, targetInterval storage.IntervalRule) []time.Time {
+	minTime := time.Unix(0, partMinTS).UTC()
+	maxTime := time.Unix(0, partMaxTS).UTC()
+
+	var targetSegments []time.Time
+
+	var segmentStart time.Time
+	switch targetInterval.Unit {
+	case storage.DAY:
+		daysSinceEpoch := minTime.Sub(time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)).Hours() / 24
+		segmentIndex := int(daysSinceEpoch) / targetInterval.Num
+		segmentStart = time.Date(1970, 1, 1+segmentIndex*targetInterval.Num, 0, 0, 0, 0, time.UTC)
+	case storage.HOUR:
+		hoursSinceEpoch := minTime.Sub(time.Date(1970, 1, 1, 0, 0, 0, 0, time.UTC)).Hours()
+		segmentIndex := int(hoursSinceEpoch) / targetInterval.Num
+		segmentStart = time.Date(1970, 1, 1, segmentIndex*targetInterval.Num, 0, 0, 0, time.UTC)
+	default:
+		segmentStart = targetInterval.Unit.Standard(minTime)
+	}
+
+	current := segmentStart
+	for !current.After(maxTime) {
+		segmentEnd := targetInterval.NextTime(current)
+		if !(segmentEnd.Before(minTime) || current.After(maxTime)) {
+			targetSegments = append(targetSegments, current)
+		}
+		current = segmentEnd
+	}
+
+	return targetSegments
+}
+
+func getSegmentTimeRange(segmentStart time.Time, interval storage.IntervalRule) timestamp.TimeRange {
+	segmentEnd := interval.NextTime(segmentStart)
+	return timestamp.NewSectionTimeRange(segmentStart, segmentEnd)
+}
+
+func getTargetStageInterval(group *commonv1.Group) storage.IntervalRule {
+	if group.ResourceOpts != nil && len(group.ResourceOpts.Stages) > 0 {
+		stage := group.ResourceOpts.Stages[0]
+		if stage.SegmentInterval != nil {
+			return storage.MustToIntervalRule(stage.SegmentInterval)
+		}
+	}
+
+	if group.ResourceOpts != nil && group.ResourceOpts.SegmentInterval != nil {
+		return storage.MustToIntervalRule(group.ResourceOpts.SegmentInterval)
+	}
+
+	return storage.IntervalRule{Unit: storage.DAY, Num: 1}
+}

--- a/banyand/backup/lifecycle/segment_boundary_utils_test.go
+++ b/banyand/backup/lifecycle/segment_boundary_utils_test.go
@@ -1,0 +1,138 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package lifecycle
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/apache/skywalking-banyandb/banyand/internal/storage"
+)
+
+func TestCalculateTargetSegments(t *testing.T) {
+	//nolint:govet // fieldalignment: test struct optimization not critical
+	tests := []struct {
+		expected       []time.Time
+		name           string
+		targetInterval storage.IntervalRule
+		partMinTS      int64
+		partMaxTS      int64
+	}{
+		{
+			name:      "2-day to 3-day segments - part spans multiple segments",
+			partMinTS: time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC).UnixNano(), // Day 2
+			partMaxTS: time.Date(2024, 1, 4, 0, 0, 0, 0, time.UTC).UnixNano(), // Day 4
+			targetInterval: storage.IntervalRule{
+				Unit: storage.DAY,
+				Num:  3,
+			},
+			expected: []time.Time{
+				time.Date(2024, 1, 0, 0, 0, 0, 0, time.UTC), // Day 0-3
+				time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC), // Day 3-6
+			},
+		},
+		{
+			name:      "2-day to 3-day segments - part fits in single segment",
+			partMinTS: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC).UnixNano(), // Day 1
+			partMaxTS: time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC).UnixNano(), // Day 2
+			targetInterval: storage.IntervalRule{
+				Unit: storage.DAY,
+				Num:  3,
+			},
+			expected: []time.Time{
+				time.Date(2024, 1, 0, 0, 0, 0, 0, time.UTC), // Day 0-3
+			},
+		},
+		{
+			name:      "hour to day segments - part spans multiple segments",
+			partMinTS: time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC).UnixNano(), // Hour 12
+			partMaxTS: time.Date(2024, 1, 1, 18, 0, 0, 0, time.UTC).UnixNano(), // Hour 18
+			targetInterval: storage.IntervalRule{
+				Unit: storage.DAY,
+				Num:  1,
+			},
+			expected: []time.Time{
+				time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), // Day 1
+			},
+		},
+		{
+			name:      "day to hour segments - part spans multiple segments",
+			partMinTS: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC).UnixNano(),    // Day 1
+			partMaxTS: time.Date(2024, 1, 1, 23, 59, 59, 0, time.UTC).UnixNano(), // End of Day 1
+			targetInterval: storage.IntervalRule{
+				Unit: storage.HOUR,
+				Num:  6,
+			},
+			expected: []time.Time{
+				time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),  // Hour 0-6
+				time.Date(2024, 1, 1, 6, 0, 0, 0, time.UTC),  // Hour 6-12
+				time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC), // Hour 12-18
+				time.Date(2024, 1, 1, 18, 0, 0, 0, time.UTC), // Hour 18-24
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := calculateTargetSegments(tt.partMinTS, tt.partMaxTS, tt.targetInterval)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetSegmentTimeRange(t *testing.T) {
+	//nolint:govet // fieldalignment: test struct optimization not critical
+	tests := []struct {
+		segmentStart  time.Time
+		expectedStart time.Time
+		expectedEnd   time.Time
+		name          string
+		interval      storage.IntervalRule
+	}{
+		{
+			name:         "3-day segment",
+			segmentStart: time.Date(2024, 1, 0, 0, 0, 0, 0, time.UTC),
+			interval: storage.IntervalRule{
+				Unit: storage.DAY,
+				Num:  3,
+			},
+			expectedStart: time.Date(2024, 1, 0, 0, 0, 0, 0, time.UTC),
+			expectedEnd:   time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:         "6-hour segment",
+			segmentStart: time.Date(2024, 1, 1, 6, 0, 0, 0, time.UTC),
+			interval: storage.IntervalRule{
+				Unit: storage.HOUR,
+				Num:  6,
+			},
+			expectedStart: time.Date(2024, 1, 1, 6, 0, 0, 0, time.UTC),
+			expectedEnd:   time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getSegmentTimeRange(tt.segmentStart, tt.interval)
+			assert.Equal(t, tt.expectedStart, result.Start)
+			assert.Equal(t, tt.expectedEnd, result.End)
+		})
+	}
+}

--- a/banyand/measure/introducer.go
+++ b/banyand/measure/introducer.go
@@ -75,6 +75,7 @@ func generateFlusherIntroduction() *flusherIntroduction {
 }
 
 func releaseFlusherIntroduction(i *flusherIntroduction) {
+	i.reset()
 	flusherIntroductionPool.Put(i)
 }
 

--- a/banyand/measure/metadata.go
+++ b/banyand/measure/metadata.go
@@ -559,13 +559,17 @@ func (s *queueSupplier) OpenDB(groupSchema *commonv1.Group) (resourceSchema.DB, 
 		SubQueueCreator: newWriteQueue,
 		GetNodes: func(shardID common.ShardID) []string {
 			copies := ro.Replicas + 1
-			nodes := make([]string, 0, copies)
+			nodeSet := make(map[string]struct{}, copies)
 			for i := uint32(0); i < copies; i++ {
 				nodeID, err := s.measureDataNodeRegistry.Locate(group, "", uint32(shardID), i)
 				if err != nil {
 					s.l.Error().Err(err).Str("group", group).Uint32("shard", uint32(shardID)).Uint32("copy", i).Msg("failed to locate node")
 					return nil
 				}
+				nodeSet[nodeID] = struct{}{}
+			}
+			nodes := make([]string, 0, len(nodeSet))
+			for nodeID := range nodeSet {
 				nodes = append(nodes, nodeID)
 			}
 			return nodes

--- a/banyand/stream/tstable.go
+++ b/banyand/stream/tstable.go
@@ -226,6 +226,9 @@ func initTSTable(fileSystem fs.FileSystem, rootPath string, p common.Position,
 			if ee[i].Name() == elementIndexFilename {
 				continue
 			}
+			if ee[i].Name() == inverted.ExternalSegmentTempDirName {
+				continue
+			}
 			p, err := parseEpoch(ee[i].Name())
 			if err != nil {
 				l.Info().Err(err).Msg("cannot parse part file name. skip and delete it")

--- a/banyand/stream/write_standalone.go
+++ b/banyand/stream/write_standalone.go
@@ -166,7 +166,7 @@ func processElements(schemaRepo *schemaRepo, elements *elements, writeEvent *str
 	req := writeEvent.Request
 
 	elements.timestamps = append(elements.timestamps, ts)
-	eID := convert.HashStr(req.Metadata.Name + "|" + req.Element.ElementId)
+	eID := convert.HashStr(req.Metadata.Group + "|" + req.Metadata.Name + "|" + req.Element.ElementId)
 	elements.elementIDs = append(elements.elementIDs, eID)
 
 	stm, ok := schemaRepo.loadStream(writeEvent.GetRequest().GetMetadata())

--- a/pkg/fs/local_file_system.go
+++ b/pkg/fs/local_file_system.go
@@ -462,6 +462,10 @@ func (file *LocalFile) SequentialRead() SeqReader {
 	// Use the cached parameter from upper layer instead of local file's cached field
 	// This allows override when needed (e.g. metadata always cached)
 
+	// Reset file position to beginning to ensure each SeqReader starts from the beginning
+	// If seek fails, we'll still try to create the reader and the error will be handled when reading
+	_, _ = file.file.Seek(0, 0)
+
 	reader := generateReader(file.file, file.ioSize)
 	return &seqReader{reader: reader, file: file.file, fileName: file.file.Name(), length: 0, skipFadvise: file.cached}
 }

--- a/pkg/query/logical/stream/stream_plan_distributed.go
+++ b/pkg/query/logical/stream/stream_plan_distributed.go
@@ -175,11 +175,17 @@ func (t *distributedPlan) Execute(ctx context.Context) (ee []*streamv1.Element, 
 				newSortableElements(resp.Elements, t.sortByTime, t.sortTagSpec))
 		}
 	}
-	iter := sort.NewItemIter[*comparableElement](see, t.desc)
+	iter := sort.NewItemIter(see, t.desc)
 	var result []*streamv1.Element
+	seen := make(map[string]bool)
 	for iter.Next() {
-		result = append(result, iter.Val().Element)
+		element := iter.Val().Element
+		if !seen[element.ElementId] {
+			seen[element.ElementId] = true
+			result = append(result, element)
+		}
 	}
+
 	return result, allErr
 }
 

--- a/pkg/query/logical/stream/stream_plan_merge.go
+++ b/pkg/query/logical/stream/stream_plan_merge.go
@@ -135,11 +135,7 @@ func (m *mergePlan) Execute(ctx context.Context) ([]*streamv1.Element, error) {
 			continue
 		}
 
-		iter := &sortableElements{
-			elements:     elements,
-			isSortByTime: m.sortByTime,
-			sortTagSpec:  m.sortTagSpec,
-		}
+		iter := newSortableElements(elements, m.sortByTime, m.sortTagSpec)
 		see = append(see, iter)
 	}
 

--- a/pkg/test/measure/testdata/groups/sw_metric.json
+++ b/pkg/test/measure/testdata/groups/sw_metric.json
@@ -12,7 +12,8 @@
     "ttl": {
       "unit": "UNIT_DAY",
       "num": 7
-    }
+    },
+    "replicas": 1
   },
   "updated_at": "2021-04-15T01:30:15.01Z"
 }

--- a/pkg/test/stream/testdata/group.json
+++ b/pkg/test/stream/testdata/group.json
@@ -1,35 +1,39 @@
-[{
-  "metadata": {
-    "name": "default"
-  },
-  "catalog": "CATALOG_STREAM",
-  "resource_opts": {
-    "shard_num": 2,
-    "segment_interval": {
-      "unit": "UNIT_DAY",
-      "num": 1
+[
+  {
+    "metadata": {
+      "name": "default"
     },
-    "ttl": {
-      "unit": "UNIT_DAY",
-      "num": 3
-    }
-  },
-  "updated_at": "2021-04-15T01:30:15.01Z"
-},{
-  "metadata": {
-    "name": "updated"
-  },
-  "catalog": "CATALOG_STREAM",
-  "resource_opts": {
-    "shard_num": 2,
-    "segment_interval": {
-      "unit": "UNIT_DAY",
-      "num": 1
+    "catalog": "CATALOG_STREAM",
+    "resource_opts": {
+      "shard_num": 2,
+      "replicas": 1,
+      "segment_interval": {
+        "unit": "UNIT_DAY",
+        "num": 1
+      },
+      "ttl": {
+        "unit": "UNIT_DAY",
+        "num": 3
+      }
     },
-    "ttl": {
-      "unit": "UNIT_DAY",
-      "num": 3
-    }
+    "updated_at": "2021-04-15T01:30:15.01Z"
   },
-  "updated_at": "2021-04-15T01:30:15.01Z"
-}]
+  {
+    "metadata": {
+      "name": "updated"
+    },
+    "catalog": "CATALOG_STREAM",
+    "resource_opts": {
+      "shard_num": 2,
+      "segment_interval": {
+        "unit": "UNIT_DAY",
+        "num": 1
+      },
+      "ttl": {
+        "unit": "UNIT_DAY",
+        "num": 3
+      }
+    },
+    "updated_at": "2021-04-15T01:30:15.01Z"
+  }
+]

--- a/test/cases/init.go
+++ b/test/cases/init.go
@@ -59,4 +59,5 @@ func Initialize(addr string, now time.Time) {
 	casesmeasuredata.Write(conn, "endpoint_traffic", "sw_metric", "endpoint_traffic.json", now, interval)
 	casesmeasuredata.Write(conn, "duplicated", "exception", "duplicated.json", now, 0)
 	casesmeasuredata.Write(conn, "service_cpm_minute", "sw_updated", "service_cpm_minute_updated_data.json", now.Add(10*time.Minute), interval)
+	time.Sleep(5 * time.Second)
 }

--- a/test/cases/stream/data/data.go
+++ b/test/cases/stream/data/data.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"embed"
 	"encoding/base64"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -44,7 +43,6 @@ import (
 	databasev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
 	modelv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/model/v1"
 	streamv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/stream/v1"
-	"github.com/apache/skywalking-banyandb/pkg/convert"
 	"github.com/apache/skywalking-banyandb/pkg/test/flags"
 	"github.com/apache/skywalking-banyandb/pkg/test/helpers"
 )
@@ -87,11 +85,6 @@ var VerifyFn = func(innerGm gm.Gomega, sharedContext helpers.SharedContext, args
 	innerGm.Expect(err).NotTo(gm.HaveOccurred())
 	want := &streamv1.QueryResponse{}
 	helpers.UnmarshalYAML(ww, want)
-	if !args.IgnoreElementID {
-		for i := range want.Elements {
-			want.Elements[i].ElementId = hex.EncodeToString(convert.Uint64ToBytes(convert.HashStr(query.Name + "|" + want.Elements[i].ElementId)))
-		}
-	}
 	if args.DisOrder {
 		slices.SortFunc(want.Elements, func(a, b *streamv1.Element) int {
 			return strings.Compare(a.ElementId, b.ElementId)

--- a/test/cases/stream/data/want/all.yaml
+++ b/test/cases/stream/data/want/all.yaml
@@ -16,7 +16,7 @@
 # under the License.
 
 elements:
-  - elementId: "0"
+  - elementId: "0978df79cf4ed409"
     tagFamilies:
     - name: searchable
       tags:
@@ -29,7 +29,7 @@ elements:
       - key: data_binary
         value:
           binaryData: YWJjMTIzIT8kKiYoKSctPUB+
-  - elementId: "1"
+  - elementId: "4dd999e3502d728d"
     tagFamilies:
     - name: searchable
       tags:
@@ -42,7 +42,7 @@ elements:
       - key: data_binary
         value:
           binaryData: YWJjMTIzIT8kKiYoKSctPUB+
-  - elementId: "2"
+  - elementId: "fafaa63b403a1604"
     tagFamilies:
     - name: searchable
       tags:
@@ -55,7 +55,7 @@ elements:
       - key: data_binary
         value:
           binaryData: YWJjMTIzIT8kKiYoKSctPUB+
-  - elementId: "3"
+  - elementId: "5fdc8aab6ea5c9d4"
     tagFamilies:
     - name: searchable
       tags:
@@ -68,7 +68,7 @@ elements:
       - key: data_binary
         value:
           binaryData: YWJjMTIzIT8kKiYoKSctPUB+
-  - elementId: "4"
+  - elementId: "aaede9362761569a"
     tagFamilies:
     - name: searchable
       tags:

--- a/test/cases/stream/data/want/duplicated_all.yaml
+++ b/test/cases/stream/data/want/duplicated_all.yaml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 elements:
-- elementId: "3"
+- elementId: "93423d5c731c53ed"
   tagFamilies:
   - name: searchable
     tags:
@@ -41,7 +41,7 @@ elements:
       value:
         binaryData: YWJjMTIzIT8kKiYoKSctPUB+
   timestamp: "2024-07-04T10:35:00Z"
-- elementId: "4"
+- elementId: "dbc685c3e6aac8b7"
   tagFamilies:
   - name: searchable
     tags:
@@ -67,7 +67,7 @@ elements:
       value:
         binaryData: YWJjMTIzIT8kKiYoKSctPUB+
   timestamp: "2024-07-04T10:35:00Z"
-- elementId: "0"
+- elementId: "5df4d9d2f751488d"
   tagFamilies:
   - name: searchable
     tags:
@@ -93,7 +93,7 @@ elements:
       value:
         binaryData: YWJjMTIzIT8kKiYoKSctPUB+
   timestamp: "2024-07-04T10:35:00Z"
-- elementId: "1"
+- elementId: "0a6f72178f0fdbeb"
   tagFamilies:
   - name: searchable
     tags:
@@ -119,7 +119,7 @@ elements:
       value:
         binaryData: YWJjMTIzIT8kKiYoKSctPUB+
   timestamp: "2024-07-04T10:35:00Z"
-- elementId: "2"
+- elementId: "b55ed52d70bbfbe7"
   tagFamilies:
   - name: searchable
     tags:

--- a/test/cases/stream/data/want/duplicated_entity_filter.yaml
+++ b/test/cases/stream/data/want/duplicated_entity_filter.yaml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 elements:
-- elementId: "3"
+- elementId: "93423d5c731c53ed"
   tagFamilies:
   - name: searchable
     tags:
@@ -40,7 +40,7 @@ elements:
     - key: data_binary
       value:
         binaryData: YWJjMTIzIT8kKiYoKSctPUB+
-- elementId: "4"
+- elementId: "dbc685c3e6aac8b7"
   tagFamilies:
   - name: searchable
     tags:

--- a/test/cases/stream/data/want/duplicated_index_filter.yaml
+++ b/test/cases/stream/data/want/duplicated_index_filter.yaml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 elements:
-- elementId: "3"
+- elementId: "93423d5c731c53ed"
   tagFamilies:
   - name: searchable
     tags:
@@ -40,7 +40,7 @@ elements:
     - key: data_binary
       value:
         binaryData: YWJjMTIzIT8kKiYoKSctPUB+
-- elementId: "0"
+- elementId: "5df4d9d2f751488d"
   tagFamilies:
   - name: searchable
     tags:

--- a/test/cases/stream/data/want/duplicated_order_by_filter.yaml
+++ b/test/cases/stream/data/want/duplicated_order_by_filter.yaml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 elements:
-- elementId: "0"
+- elementId: "5df4d9d2f751488d"
   tagFamilies:
   - name: searchable
     tags:
@@ -40,7 +40,7 @@ elements:
     - key: data_binary
       value:
         binaryData: YWJjMTIzIT8kKiYoKSctPUB+
-- elementId: "3"
+- elementId: "93423d5c731c53ed"
   tagFamilies:
   - name: searchable
     tags:

--- a/test/cases/stream/data/want/duplicated_order_by_index.yaml
+++ b/test/cases/stream/data/want/duplicated_order_by_index.yaml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 elements:
-- elementId: "1"
+- elementId: "0a6f72178f0fdbeb"
   tagFamilies:
   - name: searchable
     tags:
@@ -41,7 +41,7 @@ elements:
       value:
         binaryData: YWJjMTIzIT8kKiYoKSctPUB+
   timestamp: "2024-07-13T04:13:00Z"
-- elementId: "0"
+- elementId: "5df4d9d2f751488d"
   tagFamilies:
   - name: searchable
     tags:
@@ -67,7 +67,7 @@ elements:
       value:
         binaryData: YWJjMTIzIT8kKiYoKSctPUB+
   timestamp: "2024-07-13T04:13:00Z"
-- elementId: "2"
+- elementId: "b55ed52d70bbfbe7"
   tagFamilies:
   - name: searchable
     tags:
@@ -93,7 +93,7 @@ elements:
       value:
         binaryData: YWJjMTIzIT8kKiYoKSctPUB+
   timestamp: "2024-07-13T04:13:00Z"
-- elementId: "4"
+- elementId: "dbc685c3e6aac8b7"
   tagFamilies:
   - name: searchable
     tags:
@@ -119,7 +119,7 @@ elements:
       value:
         binaryData: YWJjMTIzIT8kKiYoKSctPUB+
   timestamp: "2024-07-13T04:13:00Z"
-- elementId: "3"
+- elementId: "93423d5c731c53ed"
   tagFamilies:
   - name: searchable
     tags:

--- a/test/cases/stream/data/want/filter_no_indexed.yaml
+++ b/test/cases/stream/data/want/filter_no_indexed.yaml
@@ -16,7 +16,7 @@
 # under the License.
 
 elements:
-- elementId: "0"
+- elementId: "0978df79cf4ed409"
   tagFamilies:
   - name: searchable
     tags:
@@ -32,7 +32,7 @@ elements:
       value:
         int:
           value: "1622933202000000000"
-- elementId: "1"
+- elementId: "4dd999e3502d728d"
   tagFamilies:
   - name: searchable
     tags:

--- a/test/cases/stream/data/want/filter_no_indexed_or.yaml
+++ b/test/cases/stream/data/want/filter_no_indexed_or.yaml
@@ -16,7 +16,7 @@
 # under the License.
 
 elements:
-  - elementId: "0"
+  - elementId: "0978df79cf4ed409"
     tagFamilies:
     - name: searchable
       tags:
@@ -36,7 +36,7 @@ elements:
         value:
           int:
             value: "1622933202000000000"
-  - elementId: "1"
+  - elementId: "4dd999e3502d728d"
     tagFamilies:
     - name: searchable
       tags:
@@ -56,7 +56,7 @@ elements:
         value:
           int:
             value: "1622933202000000000"
-  - elementId: "2"
+  - elementId: "fafaa63b403a1604"
     tagFamilies:
     - name: searchable
       tags:
@@ -75,7 +75,7 @@ elements:
         value:
           int:
             value: "1622933202000000000"
-  - elementId: "3"
+  - elementId: "5fdc8aab6ea5c9d4"
     tagFamilies:
     - name: searchable
       tags:
@@ -94,7 +94,7 @@ elements:
         value:
           int:
             value: "1622933202000000000"
-  - elementId: "4"
+  - elementId: "aaede9362761569a"
     tagFamilies:
     - name: searchable
       tags:

--- a/test/cases/stream/data/want/filter_order_desc.yaml
+++ b/test/cases/stream/data/want/filter_order_desc.yaml
@@ -16,7 +16,7 @@
 # under the License.
 
 elements:
-  - elementId: "4"
+  - elementId: "aaede9362761569a"
     tagFamilies:
     - name: searchable
       tags:
@@ -33,7 +33,7 @@ elements:
       - key: data_binary
         value:
           binaryData: YWJjMTIzIT8kKiYoKSctPUB+
-  - elementId: "3"
+  - elementId: "5fdc8aab6ea5c9d4"
     tagFamilies:
     - name: searchable
       tags:

--- a/test/cases/stream/data/want/filter_tag.yaml
+++ b/test/cases/stream/data/want/filter_tag.yaml
@@ -16,7 +16,7 @@
 # under the License.
 
 elements:
-  - elementId: "0"
+  - elementId: "0978df79cf4ed409"
     tagFamilies:
     - name: searchable
       tags:

--- a/test/cases/stream/data/want/global_index.yaml
+++ b/test/cases/stream/data/want/global_index.yaml
@@ -16,7 +16,7 @@
 # under the License.
 
 elements:
-  - elementId: "0"
+  - elementId: "0978df79cf4ed409"
     tagFamilies:
     - name: searchable
       tags:

--- a/test/cases/stream/data/want/global_indices.yaml
+++ b/test/cases/stream/data/want/global_indices.yaml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 elements:
-  - elementId: "0"
+  - elementId: "0978df79cf4ed409"
     tagFamilies:
     - name: searchable
       tags:
@@ -28,7 +28,7 @@ elements:
       - key: data_binary
         value:
           binaryData: YWJjMTIzIT8kKiYoKSctPUB+
-  - elementId: "2"
+  - elementId: "fafaa63b403a1604"
     tagFamilies:
     - name: searchable
       tags:
@@ -41,7 +41,7 @@ elements:
       - key: data_binary
         value:
           binaryData: YWJjMTIzIT8kKiYoKSctPUB+
-  - elementId: "4"
+  - elementId: "aaede9362761569a"
     tagFamilies:
     - name: searchable
       tags:

--- a/test/cases/stream/data/want/having.yaml
+++ b/test/cases/stream/data/want/having.yaml
@@ -16,7 +16,7 @@
 # under the License.
 
 elements:
-  - elementId: "3"
+  - elementId: "5fdc8aab6ea5c9d4"
     tagFamilies:
     - name: searchable
       tags:
@@ -35,7 +35,7 @@ elements:
       - key: data_binary
         value:
           binaryData: YWJjMTIzIT8kKiYoKSctPUB+
-  - elementId: "4"
+  - elementId: "aaede9362761569a"
     tagFamilies:
     - name: searchable
       tags:

--- a/test/cases/stream/data/want/having_non_indexed.yaml
+++ b/test/cases/stream/data/want/having_non_indexed.yaml
@@ -16,7 +16,7 @@
 # under the License.
 
 elements:
-  - elementId: "2"
+  - elementId: "fafaa63b403a1604"
     tagFamilies:
     - name: searchable
       tags:
@@ -34,7 +34,7 @@ elements:
       - key: data_binary
         value:
           binaryData: YWJjMTIzIT8kKiYoKSctPUB+
-  - elementId: "3"
+  - elementId: "5fdc8aab6ea5c9d4"
     tagFamilies:
     - name: searchable
       tags:
@@ -53,7 +53,7 @@ elements:
       - key: data_binary
         value:
           binaryData: YWJjMTIzIT8kKiYoKSctPUB+
-  - elementId: "4"
+  - elementId: "aaede9362761569a"
     tagFamilies:
     - name: searchable
       tags:

--- a/test/cases/stream/data/want/having_non_indexed_arr.yaml
+++ b/test/cases/stream/data/want/having_non_indexed_arr.yaml
@@ -16,7 +16,7 @@
 # under the License.
 
 elements:
-  - elementId: "3"
+  - elementId: "5fdc8aab6ea5c9d4"
     tagFamilies:
     - name: searchable
       tags:
@@ -35,7 +35,7 @@ elements:
       - key: data_binary
         value:
           binaryData: YWJjMTIzIT8kKiYoKSctPUB+
-  - elementId: "4"
+  - elementId: "aaede9362761569a"
     tagFamilies:
     - name: searchable
       tags:

--- a/test/cases/stream/data/want/less.yaml
+++ b/test/cases/stream/data/want/less.yaml
@@ -16,7 +16,7 @@
 # under the License.
 
 elements:
-  - elementId: "2"
+  - elementId: "fafaa63b403a1604"
     tagFamilies:
     - name: searchable
       tags:
@@ -33,7 +33,7 @@ elements:
       - key: data_binary
         value:
           binaryData: YWJjMTIzIT8kKiYoKSctPUB+
-  - elementId: "3"
+  - elementId: "5fdc8aab6ea5c9d4"
     tagFamilies:
     - name: searchable
       tags:
@@ -50,7 +50,7 @@ elements:
       - key: data_binary
         value:
           binaryData: YWJjMTIzIT8kKiYoKSctPUB+
-  - elementId: "4"
+  - elementId: "aaede9362761569a"
     tagFamilies:
     - name: searchable
       tags:

--- a/test/cases/stream/data/want/less_eq.yaml
+++ b/test/cases/stream/data/want/less_eq.yaml
@@ -16,7 +16,7 @@
 # under the License.
 
 elements:
-  - elementId: "1"
+  - elementId: "4dd999e3502d728d"
     tagFamilies:
     - name: searchable
       tags:
@@ -33,7 +33,7 @@ elements:
       - key: data_binary
         value:
           binaryData: YWJjMTIzIT8kKiYoKSctPUB+
-  - elementId: "2"
+  - elementId: "fafaa63b403a1604"
     tagFamilies:
     - name: searchable
       tags:
@@ -50,7 +50,7 @@ elements:
       - key: data_binary
         value:
           binaryData: YWJjMTIzIT8kKiYoKSctPUB+
-  - elementId: "3"
+  - elementId: "5fdc8aab6ea5c9d4"
     tagFamilies:
     - name: searchable
       tags:
@@ -67,7 +67,7 @@ elements:
       - key: data_binary
         value:
           binaryData: YWJjMTIzIT8kKiYoKSctPUB+
-  - elementId: "4"
+  - elementId: "aaede9362761569a"
     tagFamilies:
     - name: searchable
       tags:

--- a/test/cases/stream/data/want/limit.yaml
+++ b/test/cases/stream/data/want/limit.yaml
@@ -16,7 +16,7 @@
 # under the License.
 
 elements:
-  - elementId: "0"
+  - elementId: "0978df79cf4ed409"
     tagFamilies:
     - name: searchable
       tags:
@@ -29,7 +29,7 @@ elements:
       - key: data_binary
         value:
           binaryData: YWJjMTIzIT8kKiYoKSctPUB+
-  - elementId: "1"
+  - elementId: "4dd999e3502d728d"
     tagFamilies:
     - name: searchable
       tags:
@@ -42,7 +42,7 @@ elements:
       - key: data_binary
         value:
           binaryData: YWJjMTIzIT8kKiYoKSctPUB+
-  - elementId: "2"
+  - elementId: "fafaa63b403a1604"
     tagFamilies:
     - name: searchable
       tags:

--- a/test/cases/stream/data/want/logical.yaml
+++ b/test/cases/stream/data/want/logical.yaml
@@ -16,7 +16,7 @@
 # under the License.
 
 elements:
-  - elementId: "2"
+  - elementId: "fafaa63b403a1604"
     tagFamilies:
     - name: searchable
       tags:
@@ -41,7 +41,7 @@ elements:
       - key: data_binary
         value:
           binaryData: YWJjMTIzIT8kKiYoKSctPUB+
-  - elementId: "3"
+  - elementId: "5fdc8aab6ea5c9d4"
     tagFamilies:
     - name: searchable
       tags:

--- a/test/cases/stream/data/want/offset.yaml
+++ b/test/cases/stream/data/want/offset.yaml
@@ -16,7 +16,7 @@
 # under the License.
 
 elements:
-- elementId: "3"
+- elementId: "5fdc8aab6ea5c9d4"
   tagFamilies:
   - name: searchable
     tags:

--- a/test/cases/stream/data/want/order_asc.yaml
+++ b/test/cases/stream/data/want/order_asc.yaml
@@ -16,7 +16,7 @@
 # under the License.
 
 elements:
-  - elementId: "0"
+  - elementId: "0978df79cf4ed409"
     tagFamilies:
     - name: searchable
       tags:
@@ -33,7 +33,7 @@ elements:
       - key: data_binary
         value:
           binaryData: YWJjMTIzIT8kKiYoKSctPUB+
-  - elementId: "1"
+  - elementId: "4dd999e3502d728d"
     tagFamilies:
     - name: searchable
       tags:
@@ -50,7 +50,7 @@ elements:
       - key: data_binary
         value:
           binaryData: YWJjMTIzIT8kKiYoKSctPUB+
-  - elementId: "2"
+  - elementId: "fafaa63b403a1604"
     tagFamilies:
     - name: searchable
       tags:
@@ -67,7 +67,7 @@ elements:
       - key: data_binary
         value:
           binaryData: YWJjMTIzIT8kKiYoKSctPUB+
-  - elementId: "3"
+  - elementId: "5fdc8aab6ea5c9d4"
     tagFamilies:
     - name: searchable
       tags:
@@ -84,7 +84,7 @@ elements:
       - key: data_binary
         value:
           binaryData: YWJjMTIzIT8kKiYoKSctPUB+
-  - elementId: "4"
+  - elementId: "aaede9362761569a"
     tagFamilies:
     - name: searchable
       tags:

--- a/test/cases/stream/data/want/order_desc.yaml
+++ b/test/cases/stream/data/want/order_desc.yaml
@@ -16,7 +16,7 @@
 # under the License.
 
 elements:
-  - elementId: "4"
+  - elementId: "aaede9362761569a"
     tagFamilies:
     - name: searchable
       tags:
@@ -33,7 +33,7 @@ elements:
       - key: data_binary
         value:
           binaryData: YWJjMTIzIT8kKiYoKSctPUB+
-  - elementId: "3"
+  - elementId: "5fdc8aab6ea5c9d4"
     tagFamilies:
     - name: searchable
       tags:
@@ -50,7 +50,7 @@ elements:
       - key: data_binary
         value:
           binaryData: YWJjMTIzIT8kKiYoKSctPUB+
-  - elementId: "2"
+  - elementId: "fafaa63b403a1604"
     tagFamilies:
     - name: searchable
       tags:
@@ -67,7 +67,7 @@ elements:
       - key: data_binary
         value:
           binaryData: YWJjMTIzIT8kKiYoKSctPUB+
-  - elementId: "1"
+  - elementId: "4dd999e3502d728d"
     tagFamilies:
     - name: searchable
       tags:
@@ -84,7 +84,7 @@ elements:
       - key: data_binary
         value:
           binaryData: YWJjMTIzIT8kKiYoKSctPUB+
-  - elementId: "0"
+  - elementId: "0978df79cf4ed409"
     tagFamilies:
     - name: searchable
       tags:

--- a/test/cases/stream/data/want/search.yaml
+++ b/test/cases/stream/data/want/search.yaml
@@ -16,7 +16,7 @@
 # under the License.
 
 elements:
-  - elementId: "1"
+  - elementId: "4dd999e3502d728d"
     tagFamilies:
     - name: searchable
       tags:
@@ -33,7 +33,7 @@ elements:
       - key: data_binary
         value:
           binaryData: YWJjMTIzIT8kKiYoKSctPUB+
-  - elementId: "2"
+  - elementId: "fafaa63b403a1604"
     tagFamilies:
     - name: searchable
       tags:

--- a/test/cases/stream/data/want/sort_desc.yaml
+++ b/test/cases/stream/data/want/sort_desc.yaml
@@ -16,7 +16,7 @@
 # under the License.
 
 elements:
-  - elementId: "0"
+  - elementId: "0978df79cf4ed409"
     tagFamilies:
     - name: searchable
       tags:
@@ -33,7 +33,7 @@ elements:
       - key: data_binary
         value:
           binaryData: YWJjMTIzIT8kKiYoKSctPUB+
-  - elementId: "1"
+  - elementId: "4dd999e3502d728d"
     tagFamilies:
     - name: searchable
       tags:
@@ -50,7 +50,7 @@ elements:
       - key: data_binary
         value:
           binaryData: YWJjMTIzIT8kKiYoKSctPUB+
-  - elementId: "4"
+  - elementId: "aaede9362761569a"
     tagFamilies:
     - name: searchable
       tags:
@@ -67,7 +67,7 @@ elements:
       - key: data_binary
         value:
           binaryData: YWJjMTIzIT8kKiYoKSctPUB+
-  - elementId: "3"
+  - elementId: "5fdc8aab6ea5c9d4"
     tagFamilies:
     - name: searchable
       tags:
@@ -84,7 +84,7 @@ elements:
       - key: data_binary
         value:
           binaryData: YWJjMTIzIT8kKiYoKSctPUB+
-  - elementId: "2"
+  - elementId: "fafaa63b403a1604"
     tagFamilies:
     - name: searchable
       tags:

--- a/test/cases/stream/data/want/sort_duration_no_index_limit.yaml
+++ b/test/cases/stream/data/want/sort_duration_no_index_limit.yaml
@@ -16,7 +16,7 @@
 # under the License.
 
 elements:
-- elementId: "3"
+- elementId: "5fdc8aab6ea5c9d4"
   tagFamilies:
   - name: searchable
     tags:
@@ -38,7 +38,7 @@ elements:
       value:
         binaryData: YWJjMTIzIT8kKiYoKSctPUB+
   timestamp: "2024-07-13T04:01:01.500Z"
-- elementId: "2"
+- elementId: "fafaa63b403a1604"
   tagFamilies:
   - name: searchable
     tags:

--- a/test/cases/stream/data/want/sort_filter.yaml
+++ b/test/cases/stream/data/want/sort_filter.yaml
@@ -16,7 +16,7 @@
 # under the License.
 
 elements:
-  - elementId: "4"
+  - elementId: "aaede9362761569a"
     tagFamilies:
     - name: searchable
       tags:
@@ -33,7 +33,7 @@ elements:
       - key: data_binary
         value:
           binaryData: YWJjMTIzIT8kKiYoKSctPUB+
-  - elementId: "3"
+  - elementId: "5fdc8aab6ea5c9d4"
     tagFamilies:
     - name: searchable
       tags:
@@ -50,7 +50,7 @@ elements:
       - key: data_binary
         value:
           binaryData: YWJjMTIzIT8kKiYoKSctPUB+
-  - elementId: "2"
+  - elementId: "fafaa63b403a1604"
     tagFamilies:
     - name: searchable
       tags:

--- a/test/cases/stream/stream.go
+++ b/test/cases/stream/stream.go
@@ -34,10 +34,8 @@ import (
 var (
 	// SharedContext is the parallel execution context.
 	SharedContext helpers.SharedContext
-	verify        = func(_ gm.Gomega, args helpers.Args) {
-		gm.Eventually(func(innerGm gm.Gomega) {
-			stream_test_data.VerifyFn(innerGm, SharedContext, args)
-		}, flags.EventuallyTimeout).Should(gm.Succeed())
+	verify        = func(innerGm gm.Gomega, args helpers.Args) {
+		stream_test_data.VerifyFn(innerGm, SharedContext, args)
 	}
 )
 


### PR DESCRIPTION
Added utility functions for segment calculations. Introduced tests for segment boundary utilities to ensure correct segment calculations.

This change follows up on #716. We are implementing a duplicated writing strategy: if a file spans multiple segments, it will be written to each of them. Additionally, we are introducing a deduplication algorithm during the query process to maintain correctness in querying.
 
