### PR TITLE
Fix memory leak in measure package

### DIFF
--- a/banyand/measure/block_metadata.go
+++ b/banyand/measure/block_metadata.go
@@ -192,28 +192,6 @@ type blockMetadataArray struct {
 	arr []blockMetadata
 }
 
-func (bma *blockMetadataArray) reset() {
-	for i := range bma.arr {
-		bma.arr[i].reset()
-	}
-	bma.arr = bma.arr[:0]
-}
-
-var blockMetadataArrayPool = pool.Register[*blockMetadataArray]("measure-blockMetadataArray")
-
-func generateBlockMetadataArray() *blockMetadataArray {
-	v := blockMetadataArrayPool.Get()
-	if v == nil {
-		return &blockMetadataArray{}
-	}
-	return v
-}
-
-func releaseBlockMetadataArray(bma *blockMetadataArray) {
-	bma.reset()
-	blockMetadataArrayPool.Put(bma)
-}
-
 type timestampsMetadata struct {
 	dataBlock
 	min               int64

--- a/banyand/measure/part_iter_test.go
+++ b/banyand/measure/part_iter_test.go
@@ -110,14 +110,12 @@ func Test_partIter_nextBlock(t *testing.T) {
 		},
 	}
 
-	bma := generateBlockMetadataArray()
-	defer releaseBlockMetadataArray(bma)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			verifyPart := func(p *part) {
 				defer p.close()
 				pi := partIter{}
-				pi.init(bma, p, tt.sids, tt.opt.minTimestamp, tt.opt.maxTimestamp)
+				pi.init(p, tt.sids, tt.opt.minTimestamp, tt.opt.maxTimestamp)
 
 				var got []blockMetadata
 				for pi.nextBlock() {

--- a/banyand/measure/query.go
+++ b/banyand/measure/query.go
@@ -361,8 +361,6 @@ func (m *measure) buildIndexQueryResult(ctx context.Context, mqo model.MeasureQu
 }
 
 func (m *measure) searchBlocks(ctx context.Context, result *queryResult, sids []common.SeriesID, parts []*part, qo queryOptions) error {
-	bma := generateBlockMetadataArray()
-	defer releaseBlockMetadataArray(bma)
 	defFn := startBlockScanSpan(ctx, len(sids), parts, result)
 	defer defFn()
 	tstIter := generateTstIter()
@@ -370,7 +368,7 @@ func (m *measure) searchBlocks(ctx context.Context, result *queryResult, sids []
 	originalSids := make([]common.SeriesID, len(sids))
 	copy(originalSids, sids)
 	sort.Slice(sids, func(i, j int) bool { return sids[i] < sids[j] })
-	tstIter.init(bma, parts, sids, qo.minTimestamp, qo.maxTimestamp)
+	tstIter.init(parts, sids, qo.minTimestamp, qo.maxTimestamp)
 	if tstIter.Error() != nil {
 		return fmt.Errorf("cannot init tstIter: %w", tstIter.Error())
 	}

--- a/banyand/measure/query_test.go
+++ b/banyand/measure/query_test.go
@@ -1232,8 +1232,6 @@ func TestQueryResult(t *testing.T) {
 		},
 	}
 
-	bma := generateBlockMetadataArray()
-	defer releaseBlockMetadataArray(bma)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			verify := func(t *testing.T, tst *tsTable) {
@@ -1253,7 +1251,7 @@ func TestQueryResult(t *testing.T) {
 					return sids[i] < tt.sids[j]
 				})
 				ti := &tstIter{}
-				ti.init(bma, pp, sids, tt.minTimestamp, tt.maxTimestamp)
+				ti.init(pp, sids, tt.minTimestamp, tt.maxTimestamp)
 
 				var result queryResult
 				result.ctx = context.TODO()

--- a/banyand/measure/tstable.go
+++ b/banyand/measure/tstable.go
@@ -340,7 +340,7 @@ func (ti *tstIter) reset() {
 	ti.nextBlockNoop = false
 }
 
-func (ti *tstIter) init(bma *blockMetadataArray, parts []*part, sids []common.SeriesID, minTimestamp, maxTimestamp int64) {
+func (ti *tstIter) init(parts []*part, sids []common.SeriesID, minTimestamp, maxTimestamp int64) {
 	ti.reset()
 	ti.parts = parts
 
@@ -349,7 +349,7 @@ func (ti *tstIter) init(bma *blockMetadataArray, parts []*part, sids []common.Se
 	}
 	ti.piPool = ti.piPool[:len(ti.parts)]
 	for i, p := range ti.parts {
-		ti.piPool[i].init(bma, p, sids, minTimestamp, maxTimestamp)
+		ti.piPool[i].init(p, sids, minTimestamp, maxTimestamp)
 	}
 
 	ti.piHeap = ti.piHeap[:0]

--- a/banyand/measure/tstable_test.go
+++ b/banyand/measure/tstable_test.go
@@ -138,8 +138,6 @@ func Test_tstIter(t *testing.T) {
 		minTimestamp int64
 		maxTimestamp int64
 	}
-	bma := generateBlockMetadataArray()
-	defer releaseBlockMetadataArray(bma)
 
 	verify := func(t *testing.T, tt testCtx, tst *tsTable) uint64 {
 		defer tst.Close()
@@ -152,7 +150,7 @@ func Test_tstIter(t *testing.T) {
 		pp, n := s.getParts(nil, shardCache, tt.minTimestamp, tt.maxTimestamp)
 		require.Equal(t, len(s.parts), n)
 		ti := &tstIter{}
-		ti.init(bma, pp, tt.sids, tt.minTimestamp, tt.maxTimestamp)
+		ti.init(pp, tt.sids, tt.minTimestamp, tt.maxTimestamp)
 		var got []blockMetadata
 		for ti.nextBlock() {
 			if ti.piHeap[0].curBlock.seriesID == 0 {


### PR DESCRIPTION
resolve cache-related memory issues in block metadata, part iteration, query processing, and table operations
