### PR TITLE
feat: optimize gRPC message size limits for better time-series data handling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,7 @@ Release Notes.
   - Merge memory data and disk data.
 - Enhance access log functionality with sampling option.
 - Implement a resilient publisher with circuit breaker and retry logic with exponential backoff.
+- Optimize gRPC message size limits: increase server max receive message size to 16MB and client max receive message size to 32MB for better handling of large time-series data blocks.
 
 ### Bug Fixes
 

--- a/banyand/liaison/grpc/server.go
+++ b/banyand/liaison/grpc/server.go
@@ -52,7 +52,7 @@ import (
 	pkgtls "github.com/apache/skywalking-banyandb/pkg/tls"
 )
 
-const defaultRecvSize = 10 << 20
+const defaultRecvSize = 16 << 20
 
 var (
 	errServerCert        = errors.New("invalid server cert file")


### PR DESCRIPTION
- Increase server max receive message size to 16MB
- Increase client max receive message size to 32MB
- Update CHANGES.md to document the optimization


- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Fixes apache/skywalking#13455
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-banyandb/blob/main/CHANGES.md).
