### PR TITLE
Fix query access log Unmarshal error

### DIFF
--- a/pkg/accesslog/file.go
+++ b/pkg/accesslog/file.go
@@ -187,7 +187,7 @@ func flushBatch(file *os.File, batch []interface{}, log *logger.Logger) {
 		switch v := req.(type) {
 		case *QueryLogEntry:
 			// For query log entries, use regular JSON marshaling
-			data, err = json.Marshal(v)
+			data, err = v.Marshal()
 		case proto.Message:
 			// For protobuf messages, use protojson marshaling
 			data, err = protojson.Marshal(v)

--- a/pkg/accesslog/query_log_test.go
+++ b/pkg/accesslog/query_log_test.go
@@ -26,6 +26,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 
 	measurev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/measure/v1"
 	streamv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/stream/v1"
@@ -102,6 +104,16 @@ func TestQueryLogEntry_WriteQuery(t *testing.T) {
 		// Verify service is correct
 		service := entry["service"].(string)
 		require.True(t, service == "stream" || service == "measure")
+
+		// Verify Request can be Unmarshal
+		requestStr := entry["request"].(string)
+		var msg proto.Message
+		if service == "stream" {
+			msg = &streamv1.QueryRequest{}
+		} else {
+			msg = &measurev1.QueryRequest{}
+		}
+		require.NoError(t, protojson.Unmarshal([]byte(requestStr), msg))
 
 		// Verify duration is recorded
 		durationMs := entry["duration_ms"]


### PR DESCRIPTION
Currently, the query access log has two issues:
1. Request data cannot be unmarshaled. It needs to use `protojson.Marshal` first.
2. Duration is not milliseconds. 

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Fixes apache/skywalking#<issue number>.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking-banyandb/blob/main/CHANGES.md).
