### PR TITLE
Refactor OpenDB functions to use 'Name' field from groupSchema.Metadata

### DIFF
--- a/banyand/trace/metadata.go
+++ b/banyand/trace/metadata.go
@@ -308,7 +308,7 @@ func (s *supplier) ResourceSchema(md *commonv1.Metadata) (resourceSchema.Resourc
 }
 
 func (s *supplier) OpenDB(groupSchema *commonv1.Group) (resourceSchema.DB, error) {
-	name := groupSchema.Metadata.Group
+	name := groupSchema.Metadata.Name
 	p := common.Position{
 		Module:   "trace",
 		Database: name,
@@ -413,7 +413,7 @@ func (qs *queueSupplier) ResourceSchema(md *commonv1.Metadata) (resourceSchema.R
 }
 
 func (qs *queueSupplier) OpenDB(groupSchema *commonv1.Group) (resourceSchema.DB, error) {
-	name := groupSchema.Metadata.Group
+	name := groupSchema.Metadata.Name
 	p := common.Position{
 		Module:   "trace",
 		Database: name,
@@ -423,7 +423,7 @@ func (qs *queueSupplier) OpenDB(groupSchema *commonv1.Group) (resourceSchema.DB,
 		return nil, fmt.Errorf("no resource opts in group %s", name)
 	}
 	shardNum := ro.ShardNum
-	group := groupSchema.Metadata.Group
+	group := groupSchema.Metadata.Name
 	opts := wqueue.Opts[*tsTable, option]{
 		Group:           group,
 		ShardNum:        shardNum,

--- a/pkg/schema/cache.go
+++ b/pkg/schema/cache.go
@@ -551,6 +551,9 @@ func (g *group) GetSchema() *commonv1.Group {
 }
 
 func (g *group) SupplyTSDB() io.Closer {
+	if g.db.Load() == nil {
+		return nil
+	}
 	return g.db.Load().(io.Closer)
 }
 

--- a/pkg/test/trace/testdata/groups/zipkin-trace-group.json
+++ b/pkg/test/trace/testdata/groups/zipkin-trace-group.json
@@ -1,0 +1,19 @@
+{
+    "metadata": {
+        "name": "zipkinTrace"
+    },
+    "catalog": "CATALOG_TRACE",
+    "resource_opts": {
+        "shard_num": 2,
+        "replicas": 1,
+        "segment_interval": {
+            "unit": "UNIT_DAY",
+            "num": 1
+        },
+        "ttl": {
+            "unit": "UNIT_DAY",
+            "num": 7
+        }
+    },
+    "updated_at": "2021-04-15T01:30:15.01Z"
+}

--- a/pkg/test/trace/testdata/index_rule_bindings/zipkin.json
+++ b/pkg/test/trace/testdata/index_rule_bindings/zipkin.json
@@ -1,0 +1,18 @@
+{
+    "metadata": {
+        "name": "zipkin-index-rule-binding",
+        "group": "zipkinTrace"
+    },
+    "rules": [
+        "zipkin-duration",
+        "zipkin-timestamp",
+        "zipkin-service"
+    ],
+    "subject": {
+        "catalog": "CATALOG_TRACE",
+        "name": "zipkin"
+    },
+    "begin_at": "2021-04-15T01:30:15.01Z",
+    "expire_at": "2121-04-15T01:30:15.01Z",
+    "updated_at": "2021-04-15T01:30:15.01Z"
+}

--- a/pkg/test/trace/testdata/index_rules/zipkin-duration.json
+++ b/pkg/test/trace/testdata/index_rules/zipkin-duration.json
@@ -1,0 +1,14 @@
+{
+    "metadata": {
+        "name": "zipkin-duration",
+        "group": "zipkinTrace"
+    },
+    "tags": [
+        "local_endpoint_service_name",
+        "operation_name",
+        "kind",
+        "duration"
+    ],
+    "type": "TYPE_TREE",
+    "updated_at": "2021-04-15T01:30:15.01Z"
+}

--- a/pkg/test/trace/testdata/index_rules/zipkin-service.json
+++ b/pkg/test/trace/testdata/index_rules/zipkin-service.json
@@ -1,0 +1,14 @@
+{
+    "metadata": {
+        "name": "zipkin-service",
+        "group": "zipkinTrace"
+    },
+    "tags": [
+        "local_endpoint_service_name",
+        "remote_endpoint_service_name",
+        "operation_name",
+        "kind"
+    ],
+    "type": "TYPE_TREE",
+    "updated_at": "2021-04-15T01:30:15.01Z"
+}

--- a/pkg/test/trace/testdata/index_rules/zipkin-timestamp.json
+++ b/pkg/test/trace/testdata/index_rules/zipkin-timestamp.json
@@ -1,0 +1,14 @@
+{
+    "metadata": {
+        "name": "zipkin-timestamp",
+        "group": "zipkinTrace"
+    },
+    "tags": [
+        "local_endpoint_service_name",
+        "operation_name",
+        "kind",
+        "timestamp"
+    ],
+    "type": "TYPE_TREE",
+    "updated_at": "2021-04-15T01:30:15.01Z"
+}

--- a/pkg/test/trace/testdata/traces/zipkin.json
+++ b/pkg/test/trace/testdata/traces/zipkin.json
@@ -1,0 +1,71 @@
+{
+    "metadata": {
+        "name": "zipkin",
+        "group": "zipkinTrace"
+    },
+    "tags": [
+        {
+            "name": "trace_id",
+            "type": "TAG_TYPE_STRING"
+        },
+        {
+            "name": "span_id",
+            "type": "TAG_TYPE_STRING"
+        },
+        {
+            "name": "parent_id",
+            "type": "TAG_TYPE_STRING"
+        },
+        {
+            "name": "operation_name",
+            "type": "TAG_TYPE_STRING"
+        },
+        {
+            "name": "kind",
+            "type": "TAG_TYPE_STRING"
+        },
+        {
+            "name": "timestamp",
+            "type": "TAG_TYPE_TIMESTAMP"
+        },
+        {
+            "name": "duration",
+            "type": "TAG_TYPE_INT"
+        },
+        {
+            "name": "local_endpoint_service_name",
+            "type": "TAG_TYPE_STRING"
+        },
+        {
+            "name": "local_endpoint_ipv4",
+            "type": "TAG_TYPE_STRING"
+        },
+        {
+            "name": "local_endpoint_port",
+            "type": "TAG_TYPE_INT"
+        },
+        {
+            "name": "remote_endpoint_service_name",
+            "type": "TAG_TYPE_STRING"
+        },
+        {
+            "name": "remote_endpoint_ipv4",
+            "type": "TAG_TYPE_STRING"
+        },
+        {
+            "name": "remote_endpoint_port",
+            "type": "TAG_TYPE_INT"
+        },
+        {
+            "name": "shared",
+            "type": "TAG_TYPE_INT"
+        },
+        {
+            "name": "debug",
+            "type": "TAG_TYPE_INT"
+        }
+    ],
+    "trace_id_tag_name": "trace_id",
+    "timestamp_tag_name": "timestamp",
+    "updated_at": "2021-04-15T01:30:15.01Z"
+}

--- a/test/cases/init.go
+++ b/test/cases/init.go
@@ -64,4 +64,5 @@ func Initialize(addr string, now time.Time) {
 	// trace
 	interval = 500 * time.Millisecond
 	casestrace.Write(conn, "sw", now, interval)
+	casestrace.Write(conn, "zipkin", now, interval)
 }

--- a/test/cases/trace/data/testdata/zipkin.json
+++ b/test/cases/trace/data/testdata/zipkin.json
@@ -1,0 +1,377 @@
+[
+    {
+        "tags": [
+            {
+                "str": {
+                    "value": "zipkin_trace_001"
+                }
+            },
+            {
+                "str": {
+                    "value": "span_001"
+                }
+            },
+            {
+                "str": {
+                    "value": ""
+                }
+            },
+            {
+                "str": {
+                    "value": "/api/users"
+                }
+            },
+            {
+                "str": {
+                    "value": "SERVER"
+                }
+            },
+            {
+                "int": {
+                    "value": 1500
+                }
+            },
+            {
+                "str": {
+                    "value": "user-service"
+                }
+            },
+            {
+                "str": {
+                    "value": "192.168.1.10"
+                }
+            },
+            {
+                "int": {
+                    "value": 8080
+                }
+            },
+            {
+                "str": {
+                    "value": ""
+                }
+            },
+            {
+                "str": {
+                    "value": ""
+                }
+            },
+            {
+                "int": {
+                    "value": 0
+                }
+            },
+            {
+                "int": {
+                    "value": 0
+                }
+            },
+            {
+                "int": {
+                    "value": 0
+                }
+            }
+        ],
+        "span": "zipkin_trace_001_span_001"
+    },
+    {
+        "tags": [
+            {
+                "str": {
+                    "value": "zipkin_trace_001"
+                }
+            },
+            {
+                "str": {
+                    "value": "span_002"
+                }
+            },
+            {
+                "str": {
+                    "value": "span_001"
+                }
+            },
+            {
+                "str": {
+                    "value": "/db/query"
+                }
+            },
+            {
+                "str": {
+                    "value": "CLIENT"
+                }
+            },
+            {
+                "int": {
+                    "value": 800
+                }
+            },
+            {
+                "str": {
+                    "value": "user-service"
+                }
+            },
+            {
+                "str": {
+                    "value": "192.168.1.10"
+                }
+            },
+            {
+                "int": {
+                    "value": 8080
+                }
+            },
+            {
+                "str": {
+                    "value": "database-service"
+                }
+            },
+            {
+                "str": {
+                    "value": "192.168.1.20"
+                }
+            },
+            {
+                "int": {
+                    "value": 3306
+                }
+            },
+            {
+                "int": {
+                    "value": 0
+                }
+            },
+            {
+                "int": {
+                    "value": 0
+                }
+            }
+        ],
+        "span": "zipkin_trace_001_span_002"
+    },
+    {
+        "tags": [
+            {
+                "str": {
+                    "value": "zipkin_trace_002"
+                }
+            },
+            {
+                "str": {
+                    "value": "span_003"
+                }
+            },
+            {
+                "str": {
+                    "value": ""
+                }
+            },
+            {
+                "str": {
+                    "value": "/api/orders"
+                }
+            },
+            {
+                "str": {
+                    "value": "SERVER"
+                }
+            },
+            {
+                "int": {
+                    "value": 2200
+                }
+            },
+            {
+                "str": {
+                    "value": "order-service"
+                }
+            },
+            {
+                "str": {
+                    "value": "192.168.1.15"
+                }
+            },
+            {
+                "int": {
+                    "value": 8090
+                }
+            },
+            {
+                "str": {
+                    "value": ""
+                }
+            },
+            {
+                "str": {
+                    "value": ""
+                }
+            },
+            {
+                "int": {
+                    "value": 0
+                }
+            },
+            {
+                "int": {
+                    "value": 0
+                }
+            },
+            {
+                "int": {
+                    "value": 0
+                }
+            }
+        ],
+        "span": "zipkin_trace_002_span_003"
+    },
+    {
+        "tags": [
+            {
+                "str": {
+                    "value": "zipkin_trace_002"
+                }
+            },
+            {
+                "str": {
+                    "value": "span_004"
+                }
+            },
+            {
+                "str": {
+                    "value": "span_003"
+                }
+            },
+            {
+                "str": {
+                    "value": "/cache/get"
+                }
+            },
+            {
+                "str": {
+                    "value": "CLIENT"
+                }
+            },
+            {
+                "int": {
+                    "value": 300
+                }
+            },
+            {
+                "str": {
+                    "value": "order-service"
+                }
+            },
+            {
+                "str": {
+                    "value": "192.168.1.15"
+                }
+            },
+            {
+                "int": {
+                    "value": 8090
+                }
+            },
+            {
+                "str": {
+                    "value": "redis-service"
+                }
+            },
+            {
+                "str": {
+                    "value": "192.168.1.30"
+                }
+            },
+            {
+                "int": {
+                    "value": 6379
+                }
+            },
+            {
+                "int": {
+                    "value": 0
+                }
+            },
+            {
+                "int": {
+                    "value": 0
+                }
+            }
+        ],
+        "span": "zipkin_trace_002_span_004"
+    },
+    {
+        "tags": [
+            {
+                "str": {
+                    "value": "zipkin_trace_003"
+                }
+            },
+            {
+                "str": {
+                    "value": "span_005"
+                }
+            },
+            {
+                "str": {
+                    "value": ""
+                }
+            },
+            {
+                "str": {
+                    "value": "/api/health"
+                }
+            },
+            {
+                "str": {
+                    "value": "SERVER"
+                }
+            },
+            {
+                "int": {
+                    "value": 50
+                }
+            },
+            {
+                "str": {
+                    "value": "health-service"
+                }
+            },
+            {
+                "str": {
+                    "value": "192.168.1.5"
+                }
+            },
+            {
+                "int": {
+                    "value": 8070
+                }
+            },
+            {
+                "str": {
+                    "value": ""
+                }
+            },
+            {
+                "str": {
+                    "value": ""
+                }
+            },
+            {
+                "int": {
+                    "value": 0
+                }
+            },
+            {
+                "int": {
+                    "value": 0
+                }
+            },
+            {
+                "int": {
+                    "value": 1
+                }
+            }
+        ],
+        "span": "zipkin_trace_003_span_005"
+    }
+]


### PR DESCRIPTION
Refactor OpenDB functions to use 'Name' field from groupSchema.Metadata instead of 'Group'. Add new test data for Zipkin trace, index rules, and traces to enhance testing capabilities.
