### PR TITLE
Fix the unexpected result when querying by traceID and tag belongs to a index rule

### DIFF
--- a/pkg/query/logical/stream/stream_plan_tag_filter.go
+++ b/pkg/query/logical/stream/stream_plan_tag_filter.go
@@ -83,7 +83,7 @@ func (uis *unresolvedTagFilter) Analyze(s logical.Schema) (logical.Plan, error) 
 	ctx.projectionTags = projTags
 	plan := uis.selectIndexScanner(ctx, uis.ec)
 	if uis.criteria != nil {
-		tagFilter, errFilter := logical.BuildTagFilter(uis.criteria, entityDict, s, len(ctx.globalConditions) > 1, "")
+		tagFilter, errFilter := logical.BuildTagFilter(uis.criteria, entityDict, s, false, "")
 		if errFilter != nil {
 			return nil, errFilter
 		}
@@ -124,19 +124,17 @@ func tagFilter(startTime, endTime time.Time, metadata *commonv1.Metadata, criter
 }
 
 type analyzeContext struct {
-	s                logical.Schema
-	invertedFilter   index.Filter
-	skippingFilter   index.Filter
-	entities         [][]*modelv1.TagValue
-	projectionTags   []model.TagProjection
-	globalConditions []interface{}
-	projTagsRefs     [][]*logical.TagRef
+	s              logical.Schema
+	invertedFilter index.Filter
+	skippingFilter index.Filter
+	entities       [][]*modelv1.TagValue
+	projectionTags []model.TagProjection
+	projTagsRefs   [][]*logical.TagRef
 }
 
 func newAnalyzerContext(s logical.Schema) *analyzeContext {
 	return &analyzeContext{
-		globalConditions: make([]interface{}, 0),
-		s:                s,
+		s: s,
 	}
 }
 

--- a/pkg/query/logical/tag_filter.go
+++ b/pkg/query/logical/tag_filter.go
@@ -94,7 +94,7 @@ func BuildTagFilter(criteria *modelv1.Criteria, entityDict map[string]int, index
 		if err != nil {
 			return nil, err
 		}
-		if _, ok := entityDict[cond.Name]; ok {
+		if _, ok := entityDict[cond.Name]; ok && !hasGlobalIndex {
 			return DummyFilter, nil
 		}
 		if cond.Name == globalTagName {

--- a/pkg/query/logical/trace/trace_plan_tag_filter.go
+++ b/pkg/query/logical/trace/trace_plan_tag_filter.go
@@ -115,7 +115,7 @@ func (uis *unresolvedTraceTagFilter) Analyze(s logical.Schema) (logical.Plan, er
 	}
 	plan := uis.selectTraceScanner(ctx, uis.ec, traceIDs, minVal, maxVal)
 	if uis.criteria != nil {
-		tagFilter, errFilter := logical.BuildTagFilter(uis.criteria, entityDict, s, len(traceIDs) > 1, uis.traceIDTagName)
+		tagFilter, errFilter := logical.BuildTagFilter(uis.criteria, entityDict, s, len(traceIDs) > 0, uis.traceIDTagName)
 		if errFilter != nil {
 			return nil, errFilter
 		}

--- a/test/cases/trace/data/data.go
+++ b/test/cases/trace/data/data.go
@@ -75,7 +75,19 @@ var VerifyFn = func(innerGm gm.Gomega, sharedContext helpers.SharedContext, args
 	}
 	innerGm.Expect(err).NotTo(gm.HaveOccurred(), query.String())
 	if args.WantEmpty {
-		innerGm.Expect(resp.Traces).To(gm.BeEmpty())
+		innerGm.Expect(resp.Traces).To(gm.BeEmpty(), func() string {
+			var j []byte
+			j, err = marshalToJSONWithStringBytes(resp)
+			if err != nil {
+				return err.Error()
+			}
+			var y []byte
+			y, err = yaml.JSONToYAML(j)
+			if err != nil {
+				return err.Error()
+			}
+			return string(y)
+		})
 		return
 	}
 	if args.Want == "" {
@@ -140,7 +152,6 @@ var VerifyFn = func(innerGm gm.Gomega, sharedContext helpers.SharedContext, args
 				return err.Error()
 			}
 			var y []byte
-			// TODO: it lose tag values.
 			y, err = yaml.JSONToYAML(j)
 			if err != nil {
 				return err.Error()

--- a/test/cases/trace/data/input/eq_trace_id_and_service_unknown.yml
+++ b/test/cases/trace/data/input/eq_trace_id_and_service_unknown.yml
@@ -1,0 +1,37 @@
+# Licensed to Apache Software Foundation (ASF) under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Apache Software Foundation (ASF) licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: "sw"
+groups: ["test-trace-group"]
+tag_projection: ["trace_id"]
+criteria:
+  le:
+    op: "LOGICAL_OP_AND"
+    left:
+      condition:
+        name: "trace_id"
+        op: "BINARY_OP_EQ"
+        value:
+          str:
+            value: "trace_001"
+    right:
+      condition:
+        name: "service_id"
+        op: "BINARY_OP_EQ"
+        value:
+          str:
+            value: "unknown"

--- a/test/cases/trace/trace.go
+++ b/test/cases/trace/trace.go
@@ -37,7 +37,7 @@ var (
 	}
 )
 
-var _ = g.FDescribeTable("Scanning Traces", func(args helpers.Args) {
+var _ = g.DescribeTable("Scanning Traces", func(args helpers.Args) {
 	gm.Eventually(func(innerGm gm.Gomega) {
 		verify(innerGm, args)
 	}, flags.EventuallyTimeout).Should(gm.Succeed())

--- a/test/cases/trace/trace.go
+++ b/test/cases/trace/trace.go
@@ -37,7 +37,7 @@ var (
 	}
 )
 
-var _ = g.DescribeTable("Scanning Traces", func(args helpers.Args) {
+var _ = g.FDescribeTable("Scanning Traces", func(args helpers.Args) {
 	gm.Eventually(func(innerGm gm.Gomega) {
 		verify(innerGm, args)
 	}, flags.EventuallyTimeout).Should(gm.Succeed())
@@ -50,4 +50,5 @@ var _ = g.DescribeTable("Scanning Traces", func(args helpers.Args) {
 	g.Entry("filter by service instance id", helpers.Args{Input: "eq_service_instance_order_time_asc", Duration: 1 * time.Hour}),
 	g.Entry("filter by endpoint", helpers.Args{Input: "eq_endpoint_order_duration_asc", Duration: 1 * time.Hour}),
 	g.Entry("order by timestamp limit 2", helpers.Args{Input: "order_timestamp_desc_limit", Duration: 1 * time.Hour}),
+	g.Entry("filter by trace id and service unknown", helpers.Args{Input: "eq_trace_id_and_service_unknown", Duration: 1 * time.Hour, WantEmpty: true}),
 )


### PR DESCRIPTION
Enhance tag filtering logic in query components by adjusting conditions in BuildTagFilter calls. Update test cases to include new scenarios for trace ID filtering and improve error reporting in verification functions. Add new YAML input for trace ID and service unknown criteria.

- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Fixes apache/skywalking#13486.
