### PR TITLE
Fix the property repair test failure

### DIFF
--- a/test/property_repair/base-compose.yml
+++ b/test/property_repair/base-compose.yml
@@ -24,6 +24,13 @@ x-data-base: &data_base
   depends_on:
     etcd:
       condition: service_healthy
+    liaison:
+      condition: service_healthy
+  healthcheck:
+    test: ["CMD", "nc", "-z", "localhost", "17913"]
+    interval: 5s
+    timeout: 3s
+    retries: 20
   cpus: 2
   mem_limit: 4g
   command: &base_data_cmd |
@@ -56,6 +63,11 @@ services:
     cpus: 2
     mem_limit: 3g
     container_name: liaison
+    healthcheck:
+      test: ["CMD", "nc", "-z", "localhost", "17913"]
+      interval: 5s
+      timeout: 120s
+      retries: 120
     ports:
       - "17912:17912"
       - "17913:17913"

--- a/test/property_repair/full_data/integrated_test.go
+++ b/test/property_repair/full_data/integrated_test.go
@@ -87,7 +87,7 @@ var _ = ginkgo.Describe("Property Repair Full Data Test", ginkgo.Ordered, func()
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 			// Simple wait for services to be ready
-			time.Sleep(10 * time.Second)
+			time.Sleep(20 * time.Second)
 		})
 
 		ginkgo.It("Should connect to liaison and setup clients", func() {


### PR DESCRIPTION
Following https://github.com/apache/skywalking-banyandb/actions/runs/17884261590/job/50855907436, the property repair UT may fail, causing the Docker container not to be ready. So I have added the container health check. 

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Fixes apache/skywalking#<issue number>.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking-banyandb/blob/main/CHANGES.md).
