### PR TITLE
fix(trace): prevent tagType corruption in partMergeIter

### DIFF
--- a/banyand/trace/block_metadata.go
+++ b/banyand/trace/block_metadata.go
@@ -19,6 +19,7 @@ package trace
 
 import (
 	"fmt"
+	"maps"
 	"sort"
 
 	"github.com/apache/skywalking-banyandb/pkg/convert"
@@ -159,7 +160,12 @@ func (bm *blockMetadata) unmarshal(src []byte, tagType map[string]pbv1.ValueType
 		return nil, fmt.Errorf("cannot unmarshal traceID: %w", err)
 	}
 	bm.traceID = string(traceIDBytes)
-	bm.tagType = tagType
+	if bm.tagType == nil {
+		bm.tagType = make(map[string]pbv1.ValueType)
+	} else {
+		clear(bm.tagType)
+	}
+	maps.Copy(bm.tagType, tagType)
 	src, n := encoding.BytesToVarUint64(src)
 	bm.uncompressedSpanSizeBytes = n
 	src, n = encoding.BytesToVarUint64(src)

--- a/banyand/trace/block_reader.go
+++ b/banyand/trace/block_reader.go
@@ -26,7 +26,6 @@ import (
 	"github.com/apache/skywalking-banyandb/pkg/encoding"
 	"github.com/apache/skywalking-banyandb/pkg/fs"
 	"github.com/apache/skywalking-banyandb/pkg/logger"
-	pbv1 "github.com/apache/skywalking-banyandb/pkg/pb/v1"
 	"github.com/apache/skywalking-banyandb/pkg/pool"
 )
 
@@ -184,11 +183,6 @@ func (br *blockReader) nextBlockMetadata() bool {
 
 func (br *blockReader) nextMetadata() error {
 	head := br.pih[0]
-	tagType := make(map[string]pbv1.ValueType)
-	for key, tv := range br.block.bm.tagType {
-		tagType[key] = tv
-	}
-	head.tagType = tagType
 	if head.nextBlockMetadata() {
 		heap.Fix(&br.pih, 0)
 		br.block = &br.pih[0].block
@@ -207,7 +201,6 @@ func (br *blockReader) nextMetadata() error {
 		return io.EOF
 	}
 
-	br.pih[0].block.bm.tagType = tagType
 	br.block = &br.pih[0].block
 	return nil
 }

--- a/banyand/trace/part_iter.go
+++ b/banyand/trace/part_iter.go
@@ -267,7 +267,7 @@ type partMergeIter struct {
 func (pmi *partMergeIter) reset() {
 	pmi.err = nil
 	pmi.seqReaders.reset()
-	clear(pmi.tagType)
+	pmi.tagType = nil
 	pmi.primaryBlockMetadata = nil
 	pmi.primaryMetadataIdx = 0
 	pmi.primaryBuf = pmi.primaryBuf[:0]


### PR DESCRIPTION
The tagType field in partMergeIter was being shared with blockMetadata, causing it to be reset when blockMetadata.reset() was called. This led to empty tagType maps during block iteration.

Changes:
- Use maps.Copy() instead of direct assignment in blockMetadata.unmarshal() to create independent copies of tagType maps
- Remove tagType copying logic in blockReader.nextMetadata() that was causing the sharing issue
- Change partMergeIter.reset() to set tagType to nil instead of clearing
- Add a comprehensive test case to verify tagType isolation per part



- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Fixes apache/skywalking#13515.
