### PR TITLE
Update timeout configurations for liaison services to 1 minute

### DIFF
--- a/banyand/liaison/grpc/server.go
+++ b/banyand/liaison/grpc/server.go
@@ -284,9 +284,9 @@ func (s *server) FlagSet() *run.FlagSet {
 	fs.BoolVar(&s.enableQueryAccessLog, "enable-query-access-log", false, "enable query access log")
 	fs.StringVar(&s.accessLogRootPath, "access-log-root-path", "", "access log root path")
 	fs.BoolVar(&s.accessLogSampled, "access-log-sampled", false, "if true, requests may be dropped when the channel is full; if false, requests are never dropped")
-	fs.DurationVar(&s.streamSVC.writeTimeout, "stream-write-timeout", 15*time.Second, "timeout for writing stream among liaison nodes")
-	fs.DurationVar(&s.measureSVC.writeTimeout, "measure-write-timeout", 15*time.Second, "timeout for writing measure among liaison nodes")
-	fs.DurationVar(&s.traceSVC.writeTimeout, "trace-write-timeout", 15*time.Second, "timeout for writing trace among liaison nodes")
+	fs.DurationVar(&s.streamSVC.writeTimeout, "stream-write-timeout", time.Minute, "timeout for writing stream among liaison nodes")
+	fs.DurationVar(&s.measureSVC.writeTimeout, "measure-write-timeout", time.Minute, "timeout for writing measure among liaison nodes")
+	fs.DurationVar(&s.traceSVC.writeTimeout, "trace-write-timeout", time.Minute, "timeout for writing trace among liaison nodes")
 	fs.DurationVar(&s.measureSVC.maxWaitDuration, "measure-metadata-cache-wait-duration", 0,
 		"the maximum duration to wait for metadata cache to load (for testing purposes)")
 	fs.DurationVar(&s.streamSVC.maxWaitDuration, "stream-metadata-cache-wait-duration", 0,

--- a/docs/operation/configuration.md
+++ b/docs/operation/configuration.md
@@ -63,8 +63,9 @@ BanyanDB uses etcd for service discovery and configuration. The following flags 
 
 The following flags are used to configure the timeout of data sending from liaison to data servers:
 
-- `--stream-write-timeout duration`: Stream write timeout (default: 15s).
-- `--measure-write-timeout duration`: Measure write timeout (default: 15s).
+- `--stream-write-timeout duration`: Stream write timeout (default: 1m).
+- `--measure-write-timeout duration`: Measure write timeout (default: 1m).
+- `--trace-write-timeout duration`: Trace write timeout (default: 1m).
 
 ### TLS
 


### PR DESCRIPTION
- Changed default timeout values for stream, measure, and trace write operations from 15 seconds to 1 minute in server.go.
- Updated corresponding documentation in configuration.md to reflect the new default timeout settings.


- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Fixes apache/skywalking#35041.
