### PR TITLE
Fix the bug of node selector in newLiaisonCmd

### DIFF
--- a/banyand/internal/sidx/part_wrapper.go
+++ b/banyand/internal/sidx/part_wrapper.go
@@ -56,7 +56,6 @@ func (s partWrapperState) String() string {
 type partWrapper struct {
 	p         *part
 	mp        *memPart
-	snapshot  []uint64
 	ref       int32
 	state     int32
 	removable atomic.Bool

--- a/banyand/internal/sidx/snapshot.go
+++ b/banyand/internal/sidx/snapshot.go
@@ -277,7 +277,6 @@ func (s *snapshot) copyAllTo(epoch uint64) *snapshot {
 	for _, pw := range result.parts {
 		if pw != nil {
 			pw.acquire()
-			pw.snapshot = append(pw.snapshot, epoch)
 		}
 	}
 
@@ -292,12 +291,10 @@ func (s *snapshot) merge(nextEpoch uint64, nextParts map[uint64]*partWrapper) *s
 	for i := 0; i < len(s.parts); i++ {
 		if n, ok := nextParts[s.parts[i].ID()]; ok {
 			result.parts = append(result.parts, n)
-			n.snapshot = append(n.snapshot, nextEpoch)
 			continue
 		}
 		if s.parts[i].acquire() {
 			result.parts = append(result.parts, s.parts[i])
-			s.parts[i].snapshot = append(s.parts[i].snapshot, nextEpoch)
 		}
 	}
 	return &result

--- a/pkg/cmdsetup/liaison.go
+++ b/pkg/cmdsetup/liaison.go
@@ -135,7 +135,7 @@ func newLiaisonCmd(runners ...run.Unit) *cobra.Command {
 				if err != nil {
 					return err
 				}
-				for _, sel := range []node.Selector{measureDataNodeSel, streamDataNodeSel, propertyNodeSel} {
+				for _, sel := range []node.Selector{measureDataNodeSel, streamDataNodeSel, propertyNodeSel, traceDataNodeSel} {
 					sel.SetNodeSelector(ls)
 				}
 			}

--- a/test/stress/stream-vs-trace/data_generator.go
+++ b/test/stress/stream-vs-trace/data_generator.go
@@ -726,7 +726,7 @@ func (s *SpanData) ToTraceWriteRequest() *tracev1.WriteRequest {
 
 // WriteStreamData writes span data to the stream service.
 func (c *StreamClient) WriteStreamData(ctx context.Context, spans []*SpanData) error {
-	stream, err := c.Write(ctx, nil)
+	stream, err := c.Write(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to create stream write client: %w", err)
 	}

--- a/test/stress/stream-vs-trace/stream_client.go
+++ b/test/stress/stream-vs-trace/stream_client.go
@@ -70,7 +70,7 @@ func (c *StreamClient) VerifySchema(ctx context.Context, group, name string) (bo
 	return true, nil
 }
 
-func (c *StreamClient) Write(ctx context.Context, _ *streamv1.WriteRequest) (streamv1.StreamService_WriteClient, error) {
+func (c *StreamClient) Write(ctx context.Context) (streamv1.StreamService_WriteClient, error) {
 	return c.serviceClient.Write(ctx)
 }
 


### PR DESCRIPTION
It doesn't include traceDataNodeSel, which causes some tracing data to be inaccessible. 

