### PR TITLE
fix(storage): disable rotation task on warm and cold lifecycle nodes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@ Release Notes.
 - Fix flaky on-disk integration tests caused by Ginkgo v2 random container shuffling closing gRPC connections prematurely.
 - Fix snapshot error when there is no data in a segment.
 - ui: fix query editor refresh/reset behavior and BydbQL keyword highlighting.
+- Disable the rotation task on warm and cold nodes to prevent incorrect segment boundaries during lifecycle migration.
 
 ## 0.10.0
 

--- a/banyand/internal/storage/rotation.go
+++ b/banyand/internal/storage/rotation.go
@@ -100,7 +100,7 @@ func (d *database[T, O]) startRotationTask() error {
 						gap := latest.End.UnixNano() - ts
 						// gap <=0 means the event is from the future
 						// the segment will be created by a written event directly
-						if gap <= 0 || gap > newSegmentTimeGap {
+						if gap <= 0 || gap > newSegmentTimeGap || d.disableRotation {
 							return
 						}
 						d.incTotalRotationStarted(1)

--- a/banyand/internal/storage/rotation_test.go
+++ b/banyand/internal/storage/rotation_test.go
@@ -245,12 +245,12 @@ func TestRotationDisabled(t *testing.T) {
 		defer defFn()
 
 		TSDBOpts := TSDBOpts[*MockTSTable, any]{
-			Location:         dir,
-			SegmentInterval:  IntervalRule{Unit: DAY, Num: 3},
-			TTL:              IntervalRule{Unit: DAY, Num: 30},
-			ShardNum:         1,
-			TSTableCreator:   MockTSTableCreator,
-			DisableRotation:  true,
+			Location:        dir,
+			SegmentInterval: IntervalRule{Unit: DAY, Num: 3},
+			TTL:             IntervalRule{Unit: DAY, Num: 30},
+			ShardNum:        1,
+			TSTableCreator:  MockTSTableCreator,
+			DisableRotation: true,
 		}
 		ctx := context.Background()
 		mc := timestamp.NewMockClock()

--- a/banyand/internal/storage/rotation_test.go
+++ b/banyand/internal/storage/rotation_test.go
@@ -238,3 +238,72 @@ func (m *MockMetrics) Factory() observability.Factory {
 }
 
 var MockMetricsCreator = func(_ common.Position) Metrics { return &MockMetrics{} }
+
+func TestRotationDisabled(t *testing.T) {
+	t.Run("rotation should not create segments when disabled", func(t *testing.T) {
+		dir, defFn := test.Space(require.New(t))
+		defer defFn()
+
+		TSDBOpts := TSDBOpts[*MockTSTable, any]{
+			Location:         dir,
+			SegmentInterval:  IntervalRule{Unit: DAY, Num: 3},
+			TTL:              IntervalRule{Unit: DAY, Num: 30},
+			ShardNum:         1,
+			TSTableCreator:   MockTSTableCreator,
+			DisableRotation:  true,
+		}
+		ctx := context.Background()
+		mc := timestamp.NewMockClock()
+		ts, err := time.ParseInLocation("2006-01-02 15:04:05", "2024-05-01 00:00:00", time.Local)
+		require.NoError(t, err)
+		mc.Set(ts)
+		ctx = timestamp.SetClock(ctx, mc)
+
+		sc := NewServiceCache()
+		tsdb, err := OpenTSDB(ctx, TSDBOpts, sc, group)
+		require.NoError(t, err)
+		defer tsdb.Close()
+
+		// Create initial segment for day 1
+		seg, err := tsdb.CreateSegmentIfNotExist(ts)
+		require.NoError(t, err)
+		seg.DecRef()
+
+		db := tsdb.(*database[*MockTSTable, any])
+		segCtrl := db.segmentController
+
+		// Simulate data arriving day by day for 6 days (mimicking lifecycle migration)
+		// Day 1 (05-01): already in segment [05-01, 05-04)
+		// Day 2 (05-02): still in [05-01, 05-04)
+		// Day 3 (05-03): still in [05-01, 05-04)
+		// Day 4 (05-04): need new segment [05-04, 05-07)
+		for day := 0; day < 6; day++ {
+			dayTime := ts.AddDate(0, 0, day)
+			mc.Set(dayTime)
+			// Simulate what migration does: CreateSegmentIfNotExist then Tick
+			seg, segErr := tsdb.CreateSegmentIfNotExist(dayTime)
+			require.NoError(t, segErr)
+			seg.DecRef()
+			// Tick with max timestamp near end of day (like migration does with ctx.MaxTimestamp)
+			maxTS := dayTime.Add(23*time.Hour + 59*time.Minute + 59*time.Second)
+			tsdb.Tick(maxTS.UnixNano())
+		}
+
+		// Verify: only 2 segments created, both with correct 3-day boundaries
+		segments, _ := segCtrl.segments(false)
+		defer func() {
+			for i := range segments {
+				segments[i].DecRef()
+			}
+		}()
+		require.Equal(t, 2, len(segments), "expected 2 segments for 6 days with 3-day interval")
+
+		// First segment: [05-01, 05-04)
+		assert.Equal(t, "2024-05-01 00:00:00", segments[0].Start.Format("2006-01-02 15:04:05"))
+		assert.Equal(t, "2024-05-04 00:00:00", segments[0].End.Format("2006-01-02 15:04:05"))
+
+		// Second segment: [05-04, 05-07)
+		assert.Equal(t, "2024-05-04 00:00:00", segments[1].Start.Format("2006-01-02 15:04:05"))
+		assert.Equal(t, "2024-05-07 00:00:00", segments[1].End.Format("2006-01-02 15:04:05"))
+	})
+}

--- a/banyand/internal/storage/tsdb.go
+++ b/banyand/internal/storage/tsdb.go
@@ -245,6 +245,9 @@ func OpenTSDB[T TSTable, O any](ctx context.Context, opts TSDBOpts[T, O], cache 
 		return nil, err
 	}
 	obsservice.MetricsCollector.Register(location, db.collect)
+	if opts.DisableRotation {
+		return db, nil
+	}
 	return db, db.startRotationTask()
 }
 

--- a/banyand/internal/storage/tsdb.go
+++ b/banyand/internal/storage/tsdb.go
@@ -63,6 +63,7 @@ type TSDBOpts[T TSTable, O any] struct {
 	SeriesIndexCacheMaxBytes       int
 	ShardNum                       uint32
 	DisableRetention               bool
+	DisableRotation                bool
 	SegmentIdleTimeout             time.Duration
 	MemoryLimit                    uint64
 }
@@ -244,6 +245,9 @@ func OpenTSDB[T TSTable, O any](ctx context.Context, opts TSDBOpts[T, O], cache 
 		return nil, err
 	}
 	obsservice.MetricsCollector.Register(location, db.collect)
+	if opts.DisableRotation {
+		return db, nil
+	}
 	return db, db.startRotationTask()
 }
 

--- a/banyand/internal/storage/tsdb.go
+++ b/banyand/internal/storage/tsdb.go
@@ -245,9 +245,6 @@ func OpenTSDB[T TSTable, O any](ctx context.Context, opts TSDBOpts[T, O], cache 
 		return nil, err
 	}
 	obsservice.MetricsCollector.Register(location, db.collect)
-	if opts.DisableRotation {
-		return db, nil
-	}
 	return db, db.startRotationTask()
 }
 

--- a/banyand/internal/storage/tsdb.go
+++ b/banyand/internal/storage/tsdb.go
@@ -158,6 +158,7 @@ type database[T TSTable, O any] struct {
 	rotationProcessOn atomic.Bool
 	closed            atomic.Bool
 	disableRetention  bool
+	disableRotation   bool
 }
 
 func (d *database[T, O]) Close() error {
@@ -245,9 +246,7 @@ func OpenTSDB[T TSTable, O any](ctx context.Context, opts TSDBOpts[T, O], cache 
 		return nil, err
 	}
 	obsservice.MetricsCollector.Register(location, db.collect)
-	if opts.DisableRotation {
-		return db, nil
-	}
+	db.disableRotation = opts.DisableRotation
 	return db, db.startRotationTask()
 }
 

--- a/banyand/measure/metadata.go
+++ b/banyand/measure/metadata.go
@@ -682,6 +682,7 @@ func (s *supplier) OpenDB(groupSchema *commonv1.Group) (resourceSchema.DB, error
 	segInterval := ro.SegmentInterval
 	segmentIdleTimeout := time.Duration(0)
 	disableRetention := false
+	disableRotation := false
 	if len(ro.Stages) > 0 && len(s.nodeLabels) > 0 {
 		var ttlNum uint32
 		foundMatched := false
@@ -705,10 +706,12 @@ func (s *supplier) OpenDB(groupSchema *commonv1.Group) (resourceSchema.DB, error
 				segmentIdleTimeout = 5 * time.Minute
 			}
 			disableRetention = i+1 < len(ro.Stages)
+			disableRotation = true
 			break
 		}
 		if !foundMatched {
 			disableRetention = true
+			disableRotation = true
 		}
 	}
 	group := groupSchema.Metadata.Name
@@ -725,6 +728,7 @@ func (s *supplier) OpenDB(groupSchema *commonv1.Group) (resourceSchema.DB, error
 		StorageMetricsFactory:          factory,
 		SegmentIdleTimeout:             segmentIdleTimeout,
 		DisableRetention:               disableRetention,
+		DisableRotation:                disableRotation,
 		MemoryLimit:                    s.pm.GetLimit(),
 	}
 	return storage.OpenTSDB(

--- a/banyand/stream/metadata.go
+++ b/banyand/stream/metadata.go
@@ -537,6 +537,7 @@ func (s *supplier) OpenDB(groupSchema *commonv1.Group) (resourceSchema.DB, error
 	segInterval := ro.SegmentInterval
 	segmentIdleTimeout := time.Duration(0)
 	disableRetention := false
+	disableRotation := false
 	if len(ro.Stages) > 0 && len(s.nodeLabels) > 0 {
 		var ttlNum uint32
 		foundMatched := false
@@ -560,10 +561,12 @@ func (s *supplier) OpenDB(groupSchema *commonv1.Group) (resourceSchema.DB, error
 				segmentIdleTimeout = 5 * time.Minute
 			}
 			disableRetention = i+1 < len(ro.Stages)
+			disableRotation = true
 			break
 		}
 		if !foundMatched {
 			disableRetention = true
+			disableRotation = true
 		}
 	}
 	group := groupSchema.Metadata.Name
@@ -580,6 +583,7 @@ func (s *supplier) OpenDB(groupSchema *commonv1.Group) (resourceSchema.DB, error
 		StorageMetricsFactory:          s.omr.With(storageScope.ConstLabels(meter.ToLabelPairs(common.DBLabelNames(), p.DBLabelValues()))),
 		SegmentIdleTimeout:             segmentIdleTimeout,
 		DisableRetention:               disableRetention,
+		DisableRotation:                disableRotation,
 		MemoryLimit:                    s.pm.GetLimit(),
 	}
 	return storage.OpenTSDB(

--- a/banyand/trace/metadata.go
+++ b/banyand/trace/metadata.go
@@ -560,6 +560,7 @@ func (s *supplier) OpenDB(groupSchema *commonv1.Group) (resourceSchema.DB, error
 	segInterval := ro.SegmentInterval
 	segmentIdleTimeout := time.Duration(0)
 	disableRetention := false
+	disableRotation := false
 	if len(ro.Stages) > 0 && len(s.nodeLabels) > 0 {
 		var ttlNum uint32
 		foundMatched := false
@@ -583,10 +584,12 @@ func (s *supplier) OpenDB(groupSchema *commonv1.Group) (resourceSchema.DB, error
 				segmentIdleTimeout = 5 * time.Minute
 			}
 			disableRetention = i+1 < len(ro.Stages)
+			disableRotation = true
 			break
 		}
 		if !foundMatched {
 			disableRetention = true
+			disableRotation = true
 		}
 	}
 	group := groupSchema.Metadata.Name
@@ -603,6 +606,7 @@ func (s *supplier) OpenDB(groupSchema *commonv1.Group) (resourceSchema.DB, error
 		StorageMetricsFactory:          s.omr.With(traceScope.ConstLabels(meter.ToLabelPairs(common.DBLabelNames(), p.DBLabelValues()))),
 		SegmentIdleTimeout:             segmentIdleTimeout,
 		DisableRetention:               disableRetention,
+		DisableRotation:                disableRotation,
 		MemoryLimit:                    s.pm.GetLimit(),
 	}
 	return storage.OpenTSDB(

--- a/docs/concept/rotation.md
+++ b/docs/concept/rotation.md
@@ -136,6 +136,15 @@ S = 2
 
 So, **2 segments** are required to retain data for 7 days with an 8-day segment interval. 2 segments are the minimum number whatever the TTL and segment interval are. When the TTL is less than the segment interval, you can have the minimum number of segments.
 
+## Rotation in Lifecycle Deployments
+
+In a hot-warm-cold lifecycle deployment, data rotation behaves differently depending on the node's role:
+
+- **Hot nodes**: Rotation is enabled. The rotation task pre-creates segments based on the hot stage's `segment_interval`.
+- **Warm and cold nodes**: Rotation is disabled. Segments are created on demand by the lifecycle migration process via `CreateSegmentIfNotExist`, using the target stage's `segment_interval`. Since the rotation task uses `NextTime(eventTime)` which produces incorrect boundaries for multi-day intervals, disabling it on warm/cold nodes ensures segments are always created with correct boundaries.
+
+Additionally, data retention (TTL-based segment deletion) is disabled on non-last-stage nodes, since the lifecycle agent manages data migration between stages instead.
+
 ## Conclusion
 
 Data rotation is a critical aspect of managing data in BanyanDB. By understanding the relationship between the number of segments, segment interval, and TTL, you can effectively manage data retention and query performance in the database. The formula provided here offers a simple way to calculate the number of segments required based on the chosen segment interval and TTL.

--- a/docs/operation/lifecycle.md
+++ b/docs/operation/lifecycle.md
@@ -132,6 +132,15 @@ lifecycle \
 | `--etcd-endpoints`    | Endpoints for etcd connections                                                | `""`                           |
 | `--schedule`          | Schedule for periodic backup (e.g., @yearly, @monthly, @weekly, @daily, etc.) | `""`                           |
 
+## Automatic Behavior on Warm and Cold Nodes
+
+When a data node matches a lifecycle stage (i.e., its labels match a stage's `node_selector`), two behaviors are automatically configured:
+
+- **Rotation is disabled**: The rotation task (which pre-creates segments on hot nodes) is not started on warm or cold nodes. Segments are created on demand by the lifecycle migration process, ensuring correct segment boundaries for multi-day intervals.
+- **Retention is disabled on non-last stages**: TTL-based segment deletion is disabled on all stages except the last one. Data removal on intermediate stages is managed by the lifecycle migration process, not by the built-in retention mechanism.
+
+If a node's labels do not match any stage, both rotation and retention are disabled as a safety measure.
+
 ## Best Practices
 
 1. **Node Labeling:**


### PR DESCRIPTION
### Fix apache/skywalking#13793 - Warm stage segments exceed configured segment_interval after lifecycle migration
- [x] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.

**Root cause:** The rotation task in `rotation.go` uses `NextTime(eventTime)` to pre-create segments. For multi-day intervals (e.g., 3-day warm stage), this produces incorrect segment boundaries. For example, with a 3-day interval and an event at day 3 23:59, `NextTime` creates a segment starting at day 6 instead of day 4. This doesn't affect hot nodes with 1-day intervals because `NextTime(near-midnight) ≈ next midnight`.

**Fix:** Disable the rotation task on warm and cold nodes. These nodes receive data via lifecycle migration, which creates segments on demand via `CreateSegmentIfNotExist` with correct boundaries. The rotation task is only needed on hot nodes where it pre-creates the next segment ahead of time.

**Changes:**
- Add `DisableRotation` flag to `TSDBOpts` in the storage layer
- Wire `DisableRotation` in measure, stream, and trace `OpenDB` functions: rotation is disabled when a node matches any lifecycle stage, and also when no stage matches (safety measure)
- Add `TestRotationDisabled` unit test verifying correct 3-day segment boundaries with rotation disabled
- Update `docs/concept/rotation.md` and `docs/operation/lifecycle.md` with documentation on rotation and retention behavior in lifecycle deployments

- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-banyandb/blob/main/CHANGES.md).
- [x] apache/skywalking#13793

🤖 Generated with [Claude Code](https://claude.com/claude-code)