### PR TITLE
Fix stale sync request blocking watch session channel

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,7 @@ Release Notes.
 - Add validation for MATCH and IN conditions in inverted index query builder, and handle nil OR branch when all entities are specific.
 - Fix wrong backup path of schema property.
 - Fix lifecycle migration failure when the target stage has `close: true`.
+- Fix stale sync request blocking watch session channel, causing repeated "channel full, skipping session" errors when a watch stream is in backoff.
 
 ### Chores
 

--- a/banyand/metadata/schema/property/client.go
+++ b/banyand/metadata/schema/property/client.go
@@ -1331,6 +1331,12 @@ func (r *SchemaRegistry) sendSyncRequest(ctx context.Context,
 	sentChs := make(map[string]chan []*digestEntry, len(sessions))
 	var skipped int
 	for name, s := range sessions {
+		// Drain any stale message left from a previous timed-out sync.
+		select {
+		case <-s.syncReqCh:
+			r.l.Debug().Str("node", name).Msg("sendSyncRequest: drained stale sync request")
+		default:
+		}
 		msg := &syncMessage{
 			syncRequest: *req,
 			responseCh:  make(chan []*digestEntry, 1),


### PR DESCRIPTION
### Fix apache/skywalking#13830

When a watch stream to the property schema registry disconnects and enters backoff, a timed-out sync request remains stuck in `syncReqCh` (buffer=1). Every subsequent tick finds the channel full and logs `sendSyncRequest: channel full, skipping session`, effectively disabling schema sync for the duration of the backoff — surfaced in CI as cascading `sync partially failed: 1 skipped` warnings and eventual test failure.

**Why the bug exists:** `performFullSync` / `performIncrementalSync` push one `syncMessage` into a buffered channel of size 1. When the watch goroutine is asleep in `time.After(backoff)` after a disconnect, no one drains the channel. The caller times out waiting on `responseCh`, but the orphaned message keeps the slot occupied, blocking all later sync rounds.

**Fix:** Before enqueuing a new sync message, drain any stale message left over from a previous timed-out round. This reclaims the buffer slot so subsequent sync requests can be re-queued and consumed as soon as the watch session restarts.

- [ ] Add a unit test to verify that the fix works. *(Existing `TestWatchPush/watch_server_restart` and `TestSyncLoop` exercise the surrounding sync/reconnect paths and continue to pass; a dedicated regression test targeting the drain path is not yet added.)*
- [x] Explain briefly why the bug exists and how to fix it.

- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Fixes apache/skywalking#13830.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-banyandb/blob/main/CHANGES.md).