### PR TITLE
docs: document group deletion task flow

### DIFF
--- a/docs/interacting/bydbctl/schema/group.md
+++ b/docs/interacting/bydbctl/schema/group.md
@@ -76,7 +76,7 @@ Delete operation removes a group's data and, unless `--data-only` is set, its as
 
 - Default delete only succeeds when the group is empty.
 - `--force` allows deleting a non-empty group.
-- `--dry-run` previews the schema resources that would be deleted in `schema_info` and does not create a deletion task.
+- `--dry-run` previews the schema resources that would be deleted in `schemaInfo` in the HTTP JSON / `bydbctl` YAML output (proto field: `schema_info`) and does not create a deletion task.
 - `--data-only` removes only the data files and keeps the group metadata and schema resources.
 
 ### Examples of deleting
@@ -154,5 +154,5 @@ bydbctl group list
 
 ## API Reference
 
-- [Group Registration Operations](../../../api-reference.md#groupregistryservice)
+- [Group Registration Operations](../../../api-reference.md#banyandb-database-v1-GroupRegistryService)
 - [GroupDeletionTask](../../../api-reference.md#banyandb-database-v1-GroupDeletionTask)

--- a/docs/interacting/bydbctl/schema/group.md
+++ b/docs/interacting/bydbctl/schema/group.md
@@ -76,7 +76,7 @@ Delete operation removes a group's data and, unless `--data-only` is set, its as
 
 - Default delete only succeeds when the group is empty.
 - `--force` allows deleting a non-empty group.
-- `--dry-run` previews the schema resources that would be deleted in `schemaInfo` in the HTTP JSON / `bydbctl` YAML output (proto field: `schema_info`) and does not create a deletion task.
+- `--dry-run` previews the schema resources that would be deleted and does not create a deletion task.
 - `--data-only` removes only the data files and keeps the group metadata and schema resources.
 
 ### Examples of deleting
@@ -135,7 +135,9 @@ Example response:
     },
     "totalDataSizeBytes": "1048576",
     "deletedDataSizeBytes": "524288",
-    "message": "deleting streams"
+    "message": "deleting streams",
+    "createdAt": "2026-04-21T10:30:00Z",
+    "updatedAt": "2026-04-21T10:31:15Z"
   }
 }
 ```

--- a/docs/interacting/bydbctl/schema/group.md
+++ b/docs/interacting/bydbctl/schema/group.md
@@ -70,13 +70,77 @@ You can't change the unit of `segment_interval`. If you want to change the unit,
 
 ## Delete operation
 
-Delete operation deletes a group's schema.
+Delete operation removes a group's data and, unless `--data-only` is set, its associated schema resources. For non-dry-run deletes, BanyanDB creates a background task so the request can return quickly while data files and schema resources are removed in order.
+
+### Delete modes
+
+- Default delete only succeeds when the group is empty.
+- `--force` allows deleting a non-empty group.
+- `--dry-run` previews the schema resources that would be deleted in `schema_info` and does not create a deletion task.
+- `--data-only` removes only the data files and keeps the group metadata and schema resources.
 
 ### Examples of deleting
+
+Delete an empty group:
 
 ```shell
 bydbctl group delete -g sw_metric
 ```
+
+Preview what would be deleted from a non-empty group:
+
+```shell
+bydbctl group delete -g sw_metric --dry-run
+```
+
+Force delete a non-empty group:
+
+```shell
+bydbctl group delete -g sw_metric --force
+```
+
+Delete only the data files while keeping the schema:
+
+```shell
+bydbctl group delete -g sw_metric --force --data-only
+```
+
+### Deletion task status
+
+For non-dry-run deletes, BanyanDB creates a background deletion task. The task typically moves through these phases:
+
+- `PHASE_PENDING`: the task is created and waiting to start.
+- `PHASE_IN_PROGRESS`: data files and schema resources are being removed.
+- `PHASE_COMPLETED`: deletion finished successfully.
+- `PHASE_FAILED`: deletion stopped with an error message.
+
+`bydbctl` currently exposes the delete request itself, but not a dedicated subcommand for polling the task status. Because `bydbctl` uses BanyanDB's HTTP endpoints, you can query the task status with any HTTP client:
+
+```shell
+curl http://127.0.0.1:17913/api/v1/group/task/sw_metric
+```
+
+Example response:
+
+```json
+{
+  "task": {
+    "currentPhase": "PHASE_IN_PROGRESS",
+    "totalCounts": {
+      "stream": 1,
+      "index_rule_binding": 1
+    },
+    "deletedCounts": {
+      "index_rule_binding": 1
+    },
+    "totalDataSizeBytes": "1048576",
+    "deletedDataSizeBytes": "524288",
+    "message": "deleting streams"
+  }
+}
+```
+
+The task endpoint is especially useful after `--force` or `--data-only`, because those operations may continue after the initial delete request returns.
 
 ## List operation
 
@@ -90,4 +154,5 @@ bydbctl group list
 
 ## API Reference
 
-[Group Registration Operations](../../../api-reference.md#groupregistryservice)
+- [Group Registration Operations](../../../api-reference.md#groupregistryservice)
+- [GroupDeletionTask](../../../api-reference.md#banyandb-database-v1-GroupDeletionTask)


### PR DESCRIPTION
## Summary

Document the remaining 0.10 group deletion gap from `#13777`.

This updates `docs/interacting/bydbctl/schema/group.md` to cover:
- `bydbctl group delete` modes
- `--force`, `--dry-run`, and `--data-only`
- the background deletion task lifecycle
- the task status query endpoint
- links to the relevant API reference entries

## Why

Group deletion behavior has changed beyond the original one-line `bydbctl group delete` example.

The current code supports:
- dry-run previews
- forced deletion of non-empty groups
- data-only deletion that preserves metadata
- background deletion tasks with queryable status

But the user-facing docs were still missing those details.

## Validation

Validated against the current implementation:
- `bydbctl/internal/cmd/group.go`
- `api/proto/banyandb/database/v1/rpc.proto`
- `banyand/liaison/grpc/registry.go`
- `banyand/liaison/grpc/deletion.go`

Part of apache/skywalking#13777
