### PR TITLE
Fix nil pointer panic in disk monitor during early initialization

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -38,6 +38,7 @@ Release Notes.
 - Fix wrong backup path of schema property.
 - Fix lifecycle migration failure when the target stage has `close: true`.
 - Fix stale sync request blocking watch session channel, causing repeated "channel full, skipping session" errors when a watch stream is in backoff.
+- Fix nil pointer panic in disk monitor when group schema is not yet initialized during early startup, and ensure monitor loop survives recovered panics.
 
 ### Chores
 

--- a/banyand/internal/storage/disk_monitor.go
+++ b/banyand/internal/storage/disk_monitor.go
@@ -177,20 +177,23 @@ func (dm *DiskMonitor) Stop() {
 }
 
 func (dm *DiskMonitor) monitorLoop(serviceName string) {
-	defer func() {
-		if r := recover(); r != nil {
-			dm.logger.Error().Interface("panic", r).Msg("disk monitor panic recovered")
-		}
-	}()
-
 	for {
 		select {
 		case <-dm.stopCh:
 			return
 		case <-dm.ticker.C:
-			dm.checkAndCleanup(serviceName)
+			dm.safeCheckAndCleanup(serviceName)
 		}
 	}
+}
+
+func (dm *DiskMonitor) safeCheckAndCleanup(serviceName string) {
+	defer func() {
+		if r := recover(); r != nil {
+			dm.logger.Error().Interface("panic", r).Msg("disk monitor panic recovered")
+		}
+	}()
+	dm.checkAndCleanup(serviceName)
 }
 
 func (dm *DiskMonitor) checkAndCleanup(serviceName string) {
@@ -344,7 +347,11 @@ func (dm *DiskMonitor) findGroupWithOldestSegment(groups []resourceSchema.Group)
 
 	// Query each group's oldest segment end time
 	for _, group := range groups {
-		groupName := group.GetSchema().Metadata.Name
+		schema := group.GetSchema()
+		if schema == nil || schema.Metadata == nil {
+			continue
+		}
+		groupName := schema.Metadata.Name
 		endTime, hasSegments := dm.service.PeekOldestSegmentEndTimeInGroup(groupName)
 
 		// Only consider groups that have segments

--- a/banyand/internal/storage/disk_monitor.go
+++ b/banyand/internal/storage/disk_monitor.go
@@ -19,6 +19,7 @@ package storage
 
 import (
 	"os"
+	"runtime/debug"
 	"sort"
 	"sync/atomic"
 	"time"
@@ -190,7 +191,10 @@ func (dm *DiskMonitor) monitorLoop(serviceName string) {
 func (dm *DiskMonitor) safeCheckAndCleanup(serviceName string) {
 	defer func() {
 		if r := recover(); r != nil {
-			dm.logger.Error().Interface("panic", r).Msg("disk monitor panic recovered")
+			dm.logger.Error().Interface("panic", r).Str("stack", string(debug.Stack())).Msg("disk monitor panic recovered")
+			// Reset active state so Stop() doesn't hang and the next tick can retry
+			dm.isActive.Store(false)
+			dm.metrics.forcedRetentionActive.Set(0, serviceName)
 		}
 	}()
 	dm.checkAndCleanup(serviceName)

--- a/banyand/internal/storage/disk_monitor_test.go
+++ b/banyand/internal/storage/disk_monitor_test.go
@@ -170,15 +170,11 @@ func (m *mockHistogram) Delete(_ ...string) bool {
 
 // Mock group implementation.
 type mockGroup struct {
-	name string
+	schema *commonv1.Group
 }
 
 func (m *mockGroup) GetSchema() *commonv1.Group {
-	return &commonv1.Group{
-		Metadata: &commonv1.Metadata{
-			Name: m.name,
-		},
-	}
+	return m.schema
 }
 
 func (m *mockGroup) SupplyTSDB() io.Closer {
@@ -186,7 +182,17 @@ func (m *mockGroup) SupplyTSDB() io.Closer {
 }
 
 func createMockGroup(name string) resourceSchema.Group {
-	return &mockGroup{name: name}
+	return &mockGroup{
+		schema: &commonv1.Group{
+			Metadata: &commonv1.Metadata{
+				Name: name,
+			},
+		},
+	}
+}
+
+func createMockGroupWithNilSchema() resourceSchema.Group {
+	return &mockGroup{schema: nil}
 }
 
 func TestNewDiskMonitor(t *testing.T) {
@@ -314,6 +320,27 @@ func TestDiskMonitor_findGroupWithOldestSegment(t *testing.T) {
 
 		result := dm.findGroupWithOldestSegment(groups)
 		assert.Equal(t, "group2", result)
+	})
+
+	t.Run("groups with nil schema are skipped", func(t *testing.T) {
+		nilGroup := createMockGroupWithNilSchema()
+		group1 := createMockGroup("group1")
+		groups := []resourceSchema.Group{nilGroup, group1}
+
+		now := time.Now()
+		service.SetSegmentTime("group1", now.Add(-time.Hour), true)
+
+		result := dm.findGroupWithOldestSegment(groups)
+		assert.Equal(t, "group1", result)
+	})
+
+	t.Run("all groups with nil schema returns empty", func(t *testing.T) {
+		nilGroup1 := createMockGroupWithNilSchema()
+		nilGroup2 := createMockGroupWithNilSchema()
+		groups := []resourceSchema.Group{nilGroup1, nilGroup2}
+
+		result := dm.findGroupWithOldestSegment(groups)
+		assert.Empty(t, result)
 	})
 
 	t.Run("mixed groups - some with segments, some without", func(t *testing.T) {


### PR DESCRIPTION
### Fix nil pointer panic in disk monitor when group schema is not yet initialized

- [x] Add a nil-check to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.

**Bug:** The disk monitor's `findGroupWithOldestSegment` calls `group.GetSchema().Metadata.Name` without nil-checking `GetSchema()`. During early startup, groups can be registered in the schema repo (`groupMap`) before their schema is populated asynchronously via `groupSchema.Store()`. When the monitor's first tick fires (within 1-2 seconds of startup), `GetSchema()` returns nil, causing a nil pointer dereference panic.

A secondary issue: the panic recovery (`defer recover()`) wrapped the entire `monitorLoop` for-loop, so a single recovered panic killed the monitor goroutine permanently — it never ran again for the lifetime of the process.

**Fix (two changes in `disk_monitor.go`):**
1. Nil-check `group.GetSchema()` in `findGroupWithOldestSegment` before accessing `Metadata.Name` — skip groups whose schema hasn't been loaded yet.
2. Move panic recovery from the outer loop scope into a per-tick `safeCheckAndCleanup` wrapper, so a recovered panic doesn't terminate the monitor — it retries on the next tick.

**CI failure reference:** https://github.com/apache/skywalking-banyandb/actions/runs/24668250406/job/72132833713#step:6:1

- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-banyandb/blob/main/CHANGES.md).