### PR TITLE
docs: add property ordering and v0.11 version table

### DIFF
--- a/docs/installation/versions.md
+++ b/docs/installation/versions.md
@@ -5,6 +5,8 @@ OAP releases, you need to pick the proper API versions.
 
 | API Version | BanyanDB Release Version |
 |-------------|--------------------------|
+| 0.11        | 0.11                     |
+| 0.10        | 0.10                     |
 | 0.9         | 0.9                      |
 | 0.8         | 0.8                      |
 

--- a/docs/interacting/bydbctl/property.md
+++ b/docs/interacting/bydbctl/property.md
@@ -148,6 +148,38 @@ name: temp_data
 EOF
 ```
 
+## Sorted Query
+
+Property queries support sorting results by tag values using the `order_by` field. This allows you to retrieve properties in a specific order based on a tag's value.
+
+### Examples of sorted queries
+
+Sort properties by a string tag in ascending order:
+
+```shell
+bydbctl property query -f - <<EOF
+groups: ["sw"]
+name: temp_data
+order_by:
+  tag_name: "name"
+  sort: SORT_ASC
+EOF
+```
+
+Sort properties by a string tag in descending order:
+
+```shell
+bydbctl property query -f - <<EOF
+groups: ["sw"]
+name: temp_data
+order_by:
+  tag_name: "name"
+  sort: SORT_DESC
+EOF
+```
+
+The `sort` field accepts `SORT_ASC` for ascending order and `SORT_DESC` for descending order.
+
 ## API Reference
 
 [PropertyService v1](../../api-reference.md#propertyservice)

--- a/docs/interacting/bydbql.md
+++ b/docs/interacting/bydbql.md
@@ -737,6 +737,8 @@ ORDER BY value DESC;
 
 BydbQL for properties is designed for simple key-value lookups and metadata filtering. It maps to the `banyandb.property.v1.QueryRequest` message.
 
+> **Note**: As of BanyanDB v0.10.0, Property queries support `ORDER BY` for sorted results.
+
 ### 7.1. Grammar
 
 ```
@@ -781,6 +783,13 @@ FROM PROPERTY server_metadata IN datacenter-1
 WHERE datacenter = 'dc-101' AND in_service = 'true'
 LIMIT 50
 ORDER BY ip;
+
+-- Find properties and sort by an integer tag
+SELECT ip, owner, priority
+FROM PROPERTY server_metadata IN datacenter-1
+WHERE in_service = 'true'
+ORDER BY priority ASC
+LIMIT 20;
 
 -- Retrieve a specific property by its unique ID
 SELECT *


### PR DESCRIPTION
## Summary
- Add v0.11 API/BanyanDB version mapping to the versions page
- Document property sorted queries with `order_by` ASC/DESC examples in bydbctl
- Add BydbQL `ORDER BY` syntax example for property queries

## Test plan
- [ ] Verify version table renders correctly
- [ ] Verify property query examples are valid bydbctl syntax
- [ ] Verify BydbQL ORDER BY example parses correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)