### PR TITLE
Fix FileSystemError not matching io/fs.ErrNotExist sentinel

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,7 @@ Release Notes.
 - Fix lifecycle migration failure when the target stage has `close: true`.
 - Fix stale sync request blocking watch session channel, causing repeated "channel full, skipping session" errors when a watch stream is in backoff.
 - Fix nil pointer panic in disk monitor when group schema is not yet initialized during early startup, and ensure monitor loop survives recovered panics.
+- Fix `FileSystemError` not satisfying `errors.Is(err, io/fs.ErrNotExist)`, which prevented the segment controller from cleaning up half-born segment directories and left groups in a permanent zombie state after a crash or partial sync.
 
 ### Chores
 

--- a/banyand/internal/storage/tsdb_test.go
+++ b/banyand/internal/storage/tsdb_test.go
@@ -399,6 +399,65 @@ func TestEpochSegmentCleanupOnOpen(t *testing.T) {
 	require.NoDirExists(t, epochSegDir, "epoch segment should be removed on open")
 }
 
+// TestHalfBornSegmentCleanupOnOpen reproduces the production failure where a
+// segment directory exists on disk without a metadata file (e.g. crash between
+// MkdirPanicIfExist and metadata write, or partial sync receive). Prior to the
+// errors.Is fix in pkg/fs, localFileSystem.Read returned a *FileSystemError
+// that did not satisfy errors.Is(err, io/fs.ErrNotExist), so the segment
+// controller's cleanup branch was never taken and OpenTSDB failed, leaving the
+// group with db=nil forever.
+func TestHalfBornSegmentCleanupOnOpen(t *testing.T) {
+	logger.Init(logger.Logging{
+		Env:   "dev",
+		Level: flags.LogLevel,
+	})
+	dir, defFn := test.Space(require.New(t))
+	defer defFn()
+
+	opts := TSDBOpts[*MockTSTable, any]{
+		Location:        dir,
+		SegmentInterval: IntervalRule{Unit: DAY, Num: 1},
+		TTL:             IntervalRule{Unit: DAY, Num: 7},
+		ShardNum:        1,
+		TSTableCreator:  MockTSTableCreator,
+	}
+
+	ctx := context.Background()
+	mc := timestamp.NewMockClock()
+	ts, err := time.ParseInLocation("2006-01-02 15:04:05", "2024-05-01 00:00:00", time.Local)
+	require.NoError(t, err)
+	mc.Set(ts)
+	ctx = timestamp.SetClock(ctx, mc)
+
+	sc := NewServiceCache()
+	tsdb1, err := OpenTSDB(ctx, opts, sc, group)
+	require.NoError(t, err)
+	seg, segErr := tsdb1.CreateSegmentIfNotExist(ts)
+	require.NoError(t, segErr)
+	seg.DecRef()
+	require.NoError(t, tsdb1.Close())
+
+	halfBornDir := filepath.Join(dir, "seg-20240502")
+	lfs := fs.NewLocalFileSystem()
+	lfs.MkdirIfNotExist(halfBornDir, DirPerm)
+	require.NoFileExists(t, filepath.Join(halfBornDir, metadataFilename),
+		"half-born segment must have no metadata file to reproduce the bug")
+
+	tsdb2, err := OpenTSDB(ctx, opts, sc, group)
+	require.NoError(t, err, "OpenTSDB must not fail on a half-born segment")
+	require.NotNil(t, tsdb2)
+	defer tsdb2.Close()
+
+	require.NoDirExists(t, halfBornDir, "half-born segment should be removed on open")
+
+	db := tsdb2.(*database[*MockTSTable, any])
+	segs, _ := db.segmentController.segments(false)
+	require.Equal(t, 1, len(segs), "only the valid segment should remain after cleanup")
+	for i := range segs {
+		segs[i].DecRef()
+	}
+}
+
 func TestTSDBCollect(t *testing.T) {
 	logger.Init(logger.Logging{
 		Env:   "dev",

--- a/pkg/fs/error.go
+++ b/pkg/fs/error.go
@@ -19,7 +19,6 @@
 package fs
 
 import (
-	"errors"
 	"fmt"
 	iofs "io/fs"
 )
@@ -52,14 +51,16 @@ func (err *FileSystemError) Error() string {
 // Is reports whether the error matches one of the standard io/fs sentinel
 // errors, so callers can use errors.Is with iofs.ErrNotExist, iofs.ErrExist
 // and iofs.ErrPermission regardless of the underlying OS error wrapping.
+// The target is compared directly (no recursive errors.Is) to mirror the
+// convention used by syscall.Errno.Is in the standard library.
 func (err *FileSystemError) Is(target error) bool {
-	switch err.Code {
-	case IsNotExistError:
-		return errors.Is(target, iofs.ErrNotExist)
-	case isExistError:
-		return errors.Is(target, iofs.ErrExist)
-	case permissionError:
-		return errors.Is(target, iofs.ErrPermission)
+	switch target {
+	case iofs.ErrNotExist:
+		return err.Code == IsNotExistError
+	case iofs.ErrExist:
+		return err.Code == isExistError
+	case iofs.ErrPermission:
+		return err.Code == permissionError
 	}
 	return false
 }

--- a/pkg/fs/error.go
+++ b/pkg/fs/error.go
@@ -18,7 +18,11 @@
 // Package fs (file system) is an independent component to operate file and directory.
 package fs
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+	iofs "io/fs"
+)
 
 // FileSystemError code.
 const (
@@ -43,4 +47,19 @@ type FileSystemError struct {
 
 func (err *FileSystemError) Error() string {
 	return fmt.Sprintf("File system return error: %s, error code: %d", err.Message, err.Code)
+}
+
+// Is reports whether the error matches one of the standard io/fs sentinel
+// errors, so callers can use errors.Is with iofs.ErrNotExist, iofs.ErrExist
+// and iofs.ErrPermission regardless of the underlying OS error wrapping.
+func (err *FileSystemError) Is(target error) bool {
+	switch err.Code {
+	case IsNotExistError:
+		return errors.Is(target, iofs.ErrNotExist)
+	case isExistError:
+		return errors.Is(target, iofs.ErrExist)
+	case permissionError:
+		return errors.Is(target, iofs.ErrPermission)
+	}
+	return false
 }

--- a/pkg/fs/error_test.go
+++ b/pkg/fs/error_test.go
@@ -1,0 +1,61 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package fs
+
+import (
+	"errors"
+	iofs "io/fs"
+	"path/filepath"
+	"testing"
+)
+
+func TestFileSystemErrorIsNotExist(t *testing.T) {
+	lfs := NewLocalFileSystem()
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	_, readErr := lfs.Read(missing)
+	if readErr == nil {
+		t.Fatalf("expected error reading missing file, got nil")
+	}
+	if !errors.Is(readErr, iofs.ErrNotExist) {
+		t.Fatalf("expected errors.Is(err, iofs.ErrNotExist) to be true for %T: %v", readErr, readErr)
+	}
+}
+
+func TestFileSystemErrorIsMatrix(t *testing.T) {
+	tests := []struct {
+		target error
+		name   string
+		code   int
+		want   bool
+	}{
+		{name: "not-exist-matches", code: IsNotExistError, target: iofs.ErrNotExist, want: true},
+		{name: "exist-matches", code: isExistError, target: iofs.ErrExist, want: true},
+		{name: "permission-matches", code: permissionError, target: iofs.ErrPermission, want: true},
+		{name: "not-exist-vs-exist", code: IsNotExistError, target: iofs.ErrExist, want: false},
+		{name: "read-vs-not-exist", code: readError, target: iofs.ErrNotExist, want: false},
+		{name: "other-vs-permission", code: otherError, target: iofs.ErrPermission, want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := &FileSystemError{Code: tc.code, Message: "test"}
+			if got := errors.Is(err, tc.target); got != tc.want {
+				t.Fatalf("errors.Is(code=%d, %v) = %v, want %v", tc.code, tc.target, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/fs/error_test.go
+++ b/pkg/fs/error_test.go
@@ -19,6 +19,7 @@ package fs
 
 import (
 	"errors"
+	"fmt"
 	iofs "io/fs"
 	"path/filepath"
 	"testing"
@@ -49,6 +50,7 @@ func TestFileSystemErrorIsMatrix(t *testing.T) {
 		{name: "not-exist-vs-exist", code: IsNotExistError, target: iofs.ErrExist, want: false},
 		{name: "read-vs-not-exist", code: readError, target: iofs.ErrNotExist, want: false},
 		{name: "other-vs-permission", code: otherError, target: iofs.ErrPermission, want: false},
+		{name: "wrapped-not-exist-does-not-match", code: IsNotExistError, target: fmt.Errorf("wrapped: %w", iofs.ErrNotExist), want: false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
### Fix `*FileSystemError` does not satisfy `errors.Is(err, io/fs.ErrNotExist)`, trapping groups in a permanent zombie state after a half-born segment.

- [x] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.

**Why the bug exists.** `localFileSystem.Read` wraps all OS errors in `*FileSystemError` (with numeric `Code`). The type had no `Unwrap` or `Is` method, so `errors.Is(err, io/fs.ErrNotExist)` always returned false. The segment controller relies on exactly that check at `banyand/internal/storage/segment.go:498` to recognize half-born segment directories — a dir that exists on disk but has no `metadata` file (left behind by a crash between `MkdirPanicIfExist` and the metadata write, or by a partial sync receive). Because the check never matched, the `*FileSystemError` propagated up, `OpenTSDB` aborted, the group's `db` was never populated, and every subsequent write/migration call failed with `"group <name> not found"` — the group stayed zombie until an operator removed the corrupt directory manually. We observed this in production on a cold-tier data node where `sw_metricsMinute` migration had been failing for days with `"group not found on target"`.

**How the fix works.** Implement `Is(target error) bool` on `*FileSystemError` that maps the existing codes to `io/fs` sentinels:

| Code | Sentinel |
| --- | --- |
| `IsNotExistError` | `io/fs.ErrNotExist` |
| `isExistError` | `io/fs.ErrExist` |
| `permissionError` | `io/fs.ErrPermission` |

No call sites change. With the fix, `segmentController.open()` correctly detects missing-metadata segments, appends them to `invalidSegments`, and `MustRMAll` cleans them up on startup — so the warm→cold migration recovers on the next pod restart without operator intervention.

**Test coverage.**
- `pkg/fs/error_test.go` — unit test asserting `errors.Is` works for the three sentinels (positive and negative cases) and that a real `localFileSystem.Read` of a missing path is recognized as `io/fs.ErrNotExist`.
- `banyand/internal/storage/TestHalfBornSegmentCleanupOnOpen` — end-to-end regression: plants a `seg-YYYYMMDD` directory without a `metadata` file on disk, confirms `OpenTSDB` succeeds, the invalid dir is removed, and only the valid segment remains. Verified this test fails on the pre-fix code with the exact production error chain.

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Fixes apache/skywalking#\<issue number>.
- [x] Update the [\`CHANGES\` log](https://github.com/apache/skywalking-banyandb/blob/main/CHANGES.md).