### PR TITLE
docs: add write specifications, server-generated element ID, and query deduplication

### DIFF
--- a/docs/interacting/bydbctl/schema/stream.md
+++ b/docs/interacting/bydbctl/schema/stream.md
@@ -114,6 +114,16 @@ List operation list all streams' schema in a group.
 bydbctl stream list -g default
 ```
 
+## Server-Generated Element ID
+
+When writing stream data, the `element_id` field in the write request is optional. If omitted, the server generates a unique element ID automatically. This simplifies client code when stable element IDs are not required.
+
+## Query Deduplication
+
+Stream queries deduplicate results by element ID across the scan, merge, and result building stages. This ensures that each element appears only once in query results, even if the underlying storage or replication causes the same element to be read from multiple sources.
+
+This deduplication is automatic and requires no configuration. Users benefit from cleaner query results without needing to handle duplicates in client code.
+
 ## API Reference
 
 [Stream Registration Operations](../../../api-reference.md#streamregistryservice)

--- a/docs/interacting/bydbctl/schema/stream.md
+++ b/docs/interacting/bydbctl/schema/stream.md
@@ -118,11 +118,11 @@ bydbctl stream list -g default
 
 When writing stream data, the `element_id` field in the write request is optional. If omitted, the server generates a unique element ID automatically. This simplifies client code when stable element IDs are not required.
 
+Note that this generated `element_id` is server-side only. The StreamService `WriteResponse` does not return the generated ID, so clients cannot rely on retrieving it later for correlation, retries, or idempotent writes. If a client needs a stable or externally known element ID, it must set `element_id` explicitly in the write request.
+
 ## Query Deduplication
 
-Stream queries deduplicate results by element ID across the scan, merge, and result building stages. This ensures that each element appears only once in query results, even if the underlying storage or replication causes the same element to be read from multiple sources.
-
-This deduplication is automatic and requires no configuration. Users benefit from cleaner query results without needing to handle duplicates in client code.
+For details about stream query deduplication and element identity, see [Element Identity and Deduplication](../query/stream.md#element-identity-and-deduplication).
 
 ## API Reference
 

--- a/docs/interacting/client.md
+++ b/docs/interacting/client.md
@@ -18,3 +18,8 @@ For stream writes, `element_id` is optional.
 - If the client omits `element_id`, BanyanDB generates a server-side element ID for that write. This is convenient for append-only ingestion, but repeated writes without a stable `element_id` are treated as different elements.
 
 See [Query Streams](./bydbctl/query/stream.md#element-identity-and-deduplication) for how element identity affects query results.
+See [Server-Generated Element ID](./bydbctl/schema/stream.md#server-generated-element-id) for writing stream data without an explicit element ID.
+
+## Write Specifications
+
+As of 0.10.0, BanyanDB supports writing data with specifications for [Stream](./concept/data-model.md#streams) and [Trace](./concept/data-model.md#traces) models. Write specifications allow clients to include metadata alongside data in a write request, enabling the server to better route and validate the write operation.

--- a/docs/interacting/client.md
+++ b/docs/interacting/client.md
@@ -22,4 +22,4 @@ See [Server-Generated Element ID](./bydbctl/schema/stream.md#server-generated-el
 
 ## Write Specifications
 
-As of 0.10.0, BanyanDB supports writing data with specifications for [Stream](../concept/data-model.md#streams) and [Trace](../concept/data-model.md#traces) models. Write specifications allow clients to include metadata alongside data in a write request, enabling the server to better route and validate the write operation.
+As of 0.10.0, BanyanDB supports write specifications for [Stream](../concept/data-model.md#streams), [Measure](../concept/data-model.md#measures), and [Trace](../concept/data-model.md#traces) models. These specifications describe how the write payload maps to the schema, such as tag and field ordering, enabling the server to correctly interpret and validate the write operation.

--- a/docs/interacting/client.md
+++ b/docs/interacting/client.md
@@ -22,4 +22,4 @@ See [Server-Generated Element ID](./bydbctl/schema/stream.md#server-generated-el
 
 ## Write Specifications
 
-As of 0.10.0, BanyanDB supports writing data with specifications for [Stream](./concept/data-model.md#streams) and [Trace](./concept/data-model.md#traces) models. Write specifications allow clients to include metadata alongside data in a write request, enabling the server to better route and validate the write operation.
+As of 0.10.0, BanyanDB supports writing data with specifications for [Stream](../concept/data-model.md#streams) and [Trace](../concept/data-model.md#traces) models. Write specifications allow clients to include metadata alongside data in a write request, enabling the server to better route and validate the write operation.


### PR DESCRIPTION
## Summary
- Add write specifications overview for Stream and Trace models in client docs
- Document server-generated element ID behavior for stream writes
- Document automatic query deduplication by element ID in stream queries

## Test plan
- [x] Verified server-generated element ID behavior matches proto definitions
- [x] Verified query deduplication exists in stream query implementation
- [x] Removed inaccurate `bydbctl stream write`/`bydbctl trace write` examples (these commands do not exist in the CLI)
- [x] Cross-references between client.md and stream.md are consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)