### PR TITLE
fix(metadata): widen FODC inspection timeout and parallelize InspectAll

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -54,6 +54,7 @@ Release Notes.
 - Fix nil pointer panic in disk monitor when group schema is not yet initialized during early startup, and ensure monitor loop survives recovered panics.
 - Fix `FileSystemError` not satisfying `errors.Is(err, io/fs.ErrNotExist)`, which prevented the segment controller from cleaning up half-born segment directories and left groups in a permanent zombie state after a crash or partial sync.
 - Fix lifecycle migration panic when a stream shard's snapshot has no element index (`idx/`) directory.
+- Avoid FODC lifecycle inspection failing on busy data nodes by raising the per-broadcast `CollectDataInfo` / `CollectLiaisonInfo` deadline from 5s to 30s and parallelizing per-group inspection in the cluster-internal `InspectAll`.
 
 ### Chores
 

--- a/banyand/metadata/schema/collector.go
+++ b/banyand/metadata/schema/collector.go
@@ -33,6 +33,12 @@ import (
 	"github.com/apache/skywalking-banyandb/pkg/logger"
 )
 
+// inspectBroadcastTimeout caps how long the inspection query path waits for
+// data and liaison nodes to answer a CollectDataInfo / CollectLiaisonInfo
+// broadcast. Picked to leave headroom for busy nodes (sw_zipkinTrace under
+// merge/flush load can take several seconds) while still bounding the call.
+const inspectBroadcastTimeout = 30 * time.Second
+
 // GroupGetter provides method to get group metadata.
 type GroupGetter interface {
 	GetGroup(ctx context.Context, group string) (*commonv1.Group, error)
@@ -101,7 +107,7 @@ func (icr *InfoCollectorRegistry) CollectDataInfo(ctx context.Context, group str
 
 func (icr *InfoCollectorRegistry) broadcastCollectDataInfo(topic bus.Topic, group string) []*databasev1.DataInfo {
 	message := bus.NewMessage(bus.MessageID(time.Now().UnixNano()), &databasev1.GroupRegistryServiceInspectRequest{Group: group})
-	futures, broadcastErr := icr.dataBroadcaster.Broadcast(5*time.Second, topic, message)
+	futures, broadcastErr := icr.dataBroadcaster.Broadcast(inspectBroadcastTimeout, topic, message)
 	if broadcastErr != nil {
 		icr.l.Warn().Err(broadcastErr).Str("group", group).Msg("failed to broadcast collect data info request")
 		return []*databasev1.DataInfo{}
@@ -172,7 +178,7 @@ func (icr *InfoCollectorRegistry) CollectLiaisonInfo(ctx context.Context, group 
 
 func (icr *InfoCollectorRegistry) broadcastCollectLiaisonInfo(topic bus.Topic, group string) []*databasev1.LiaisonInfo {
 	message := bus.NewMessage(bus.MessageID(time.Now().UnixNano()), &databasev1.GroupRegistryServiceInspectRequest{Group: group})
-	futures, broadcastErr := icr.liaisonBroadcaster.Broadcast(5*time.Second, topic, message)
+	futures, broadcastErr := icr.liaisonBroadcaster.Broadcast(inspectBroadcastTimeout, topic, message)
 	if broadcastErr != nil {
 		icr.l.Warn().Err(broadcastErr).Str("group", group).Msg("failed to broadcast collect liaison info request")
 		return []*databasev1.LiaisonInfo{}

--- a/banyand/queue/sub/group_lifecycle.go
+++ b/banyand/queue/sub/group_lifecycle.go
@@ -20,12 +20,21 @@ package sub
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	commonv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/common/v1"
 	fodcv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/fodc/v1"
 )
 
+// maxInspectGroupConcurrency caps how many groups InspectAll will inspect
+// in parallel. Picked high enough to fan out all groups in a single wave
+// for typical clusters (BanyanDB rarely has more than a few dozen groups)
+// while still bounding load on the data nodes.
+const maxInspectGroupConcurrency = 32
+
 // InspectAll lists all groups and returns their full lifecycle info.
+// Per-group inspections run in parallel (bounded), so a single slow group
+// cannot consume budget that other groups need.
 func (s *server) InspectAll(ctx context.Context, _ *fodcv1.InspectAllRequest) (*fodcv1.InspectAllResponse, error) {
 	if s.metadataRepo == nil {
 		return nil, fmt.Errorf("metadata repository not available")
@@ -34,15 +43,31 @@ func (s *server) InspectAll(ctx context.Context, _ *fodcv1.InspectAllRequest) (*
 	if err != nil {
 		return nil, fmt.Errorf("failed to list groups: %w", err)
 	}
-	result := make([]*fodcv1.GroupLifecycleInfo, 0, len(groups))
-	for _, group := range groups {
+	results := make([]*fodcv1.GroupLifecycleInfo, len(groups))
+	limit := max(min(len(groups), maxInspectGroupConcurrency), 1)
+	sem := make(chan struct{}, limit)
+	var wg sync.WaitGroup
+	for i, group := range groups {
 		if group == nil || group.Metadata == nil {
 			continue
 		}
-		info := s.inspectGroup(ctx, group)
-		result = append(result, info)
+		sem <- struct{}{}
+		wg.Add(1)
+		go func(idx int, g *commonv1.Group) {
+			defer wg.Done()
+			defer func() { <-sem }()
+			results[idx] = s.inspectGroup(ctx, g)
+		}(i, group)
 	}
-	return &fodcv1.InspectAllResponse{Groups: result}, nil
+	wg.Wait()
+
+	out := make([]*fodcv1.GroupLifecycleInfo, 0, len(results))
+	for _, r := range results {
+		if r != nil {
+			out = append(out, r)
+		}
+	}
+	return &fodcv1.InspectAllResponse{Groups: out}, nil
 }
 
 func (s *server) inspectGroup(ctx context.Context, group *commonv1.Group) *fodcv1.GroupLifecycleInfo {

--- a/banyand/queue/sub/group_lifecycle_test.go
+++ b/banyand/queue/sub/group_lifecycle_test.go
@@ -20,7 +20,9 @@ package sub
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -48,6 +50,10 @@ type mockMetadataRepo struct {
 	groupRegistry *mockGroupRegistry
 	dataInfoMap   map[string][]*databasev1.DataInfo
 	dataInfoErr   map[string]error
+	slowGroups    map[string]time.Duration
+	collectStarts atomic.Int32
+	concurrentMax atomic.Int32
+	concurrentNow atomic.Int32
 }
 
 func (m *mockMetadataRepo) GroupRegistry() schema.Group {
@@ -55,6 +61,20 @@ func (m *mockMetadataRepo) GroupRegistry() schema.Group {
 }
 
 func (m *mockMetadataRepo) CollectDataInfo(_ context.Context, group string) ([]*databasev1.DataInfo, error) {
+	m.collectStarts.Add(1)
+	current := m.concurrentNow.Add(1)
+	defer m.concurrentNow.Add(-1)
+	for {
+		hi := m.concurrentMax.Load()
+		if current <= hi || m.concurrentMax.CompareAndSwap(hi, current) {
+			break
+		}
+	}
+	if m.slowGroups != nil {
+		if d, ok := m.slowGroups[group]; ok && d > 0 {
+			time.Sleep(d)
+		}
+	}
 	if m.dataInfoErr != nil {
 		if err, ok := m.dataInfoErr[group]; ok {
 			return nil, err
@@ -207,4 +227,41 @@ func TestInspectAll_MultipleGroups(t *testing.T) {
 	assert.Equal(t, "sw_record", resp.Groups[1].Name)
 	assert.Equal(t, "CATALOG_STREAM", resp.Groups[1].Catalog)
 	assert.Nil(t, resp.Groups[1].DataInfo)
+}
+
+func TestInspectAll_RunsGroupsInParallel(t *testing.T) {
+	const groupCount = 8
+	const sleep = 80 * time.Millisecond
+	groups := make([]*commonv1.Group, 0, groupCount)
+	slow := make(map[string]time.Duration, groupCount)
+	for i := range groupCount {
+		name := fmt.Sprintf("g_%d", i)
+		groups = append(groups, &commonv1.Group{
+			Metadata: &commonv1.Metadata{Name: name},
+			Catalog:  commonv1.Catalog_CATALOG_STREAM,
+		})
+		slow[name] = sleep
+	}
+	repo := &mockMetadataRepo{
+		groupRegistry: &mockGroupRegistry{groups: groups},
+		slowGroups:    slow,
+	}
+	s := &server{
+		log:          logger.GetLogger("test"),
+		metadataRepo: repo,
+	}
+
+	start := time.Now()
+	resp, err := s.InspectAll(context.Background(), &fodcv1.InspectAllRequest{})
+	elapsed := time.Since(start)
+	require.NoError(t, err)
+	require.Len(t, resp.Groups, groupCount)
+
+	// Sequential execution would take groupCount*sleep; parallel must finish
+	// in roughly one sleep interval. Allow 4x headroom for CI jitter.
+	assert.Less(t, elapsed, 4*sleep, "InspectAll must run groups in parallel; total wall time was %s", elapsed)
+	assert.Equal(t, int32(groupCount), repo.collectStarts.Load())
+	assert.GreaterOrEqual(t, repo.concurrentMax.Load(), int32(2),
+		"at least two CollectDataInfo invocations must overlap; observed max concurrency was %d",
+		repo.concurrentMax.Load())
 }


### PR DESCRIPTION
## Summary

The FODC lifecycle proxy collected per-group `DataInfo` from each data node with a hard-coded 5s broadcast deadline buried in `banyand/metadata/schema/collector.go`. On busy data nodes (sw_zipkinTrace in the live demo) that handler contends with ingestion, merges, flushes, and daily lifecycle migration, routinely exceeding 5s and surfacing as `RemoteDisconnected` on the dashboard.

This PR replaces an earlier cache-based attempt with two surgical changes that fit a daily-frequency API:

1. **Lift the broadcast deadline 5s -> 30s** in `banyand/metadata/schema/collector.go`, via a named `inspectBroadcastTimeout`. Affects both `broadcastCollectDataInfo` and `broadcastCollectLiaisonInfo`.
2. **Parallelize liaison's `InspectAll`** in `banyand/queue/sub/group_lifecycle.go`. Per-group inspection now runs concurrently with bounded concurrency (32 - covers all groups in one wave for typical clusters). A single slow group can no longer consume budget that other groups need; total wall time is `max(per-group)`, not `sum`.

## Why not cache?

A cache was prototyped earlier in this PR's history. For a daily-access API it was the wrong shape:

- 30s x ~12 groups ≈ 2880 background refreshes per data node per day, against ~2 hits/day from the inspection. **Refresh-to-hit ratio ≈ 1440:1.**
- Persistent in-memory copies of every group's `DataInfo`.
- Two-path semantics (bus -> cached, direct API -> fresh) and a generation-counter race fix to make `Invalidate` durable.

The actual bug was a hard-coded 5s timeout tighter than the 10s budget the agent already gives. Lifting that and removing the sequential pinch-point on `InspectAll` resolves the symptom without any always-on machinery.

## Test plan

- [x] `go build ./banyand/queue/sub/... ./banyand/metadata/schema/...`
- [x] `go test -race ./banyand/queue/sub/...` - including new `TestInspectAll_RunsGroupsInParallel` that asserts `>= 2` concurrent `CollectDataInfo` calls and total wall time `< 4 x per-group sleep`.
- [x] Full local CI mirror: license-check, build, lint, check, banyand, bydbctl, pkg, fodc, standalone integration, distributed integration - all green.

## Out of scope

- The data-node-side `CollectDataInfo` itself still runs sequentially across segments. Lock contention with merges/flushes is a real but separate concern; if 30s ever proves insufficient, the next step is to instrument `schemaRepo.CollectDataInfo` and reduce its critical-section footprint, not to widen the timeout further.
- Plumbing `ctx` through `bus.Broadcast` so the broadcast respects caller deadlines (rather than a fixed 30s) is a cleaner architectural follow-up.