### PR TITLE
fix(measure,stream,trace): eliminate flusher/introducer data race on shutdown

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -256,6 +256,7 @@ Release Notes.
 - UI: Update BanyanDB UI to Integrate New Property Query API.
 - UI: Fix the Stream List.
 - Fix the oom issue when loading too many unnecessary parts into memory.
+- Fix data race between flusher/merger/syncer senders and the introducer loop during shutdown, caught by the Go race detector under CI pressure.
 - bydbctl: Fix the bug that the bydbctl can't parse the absolute time flag.
 
 ### Documentation

--- a/banyand/measure/flusher.go
+++ b/banyand/measure/flusher.go
@@ -204,10 +204,7 @@ func (tst *tsTable) flush(snapshot *snapshot, flushCh chan *flusherIntroduction)
 	case <-tst.loopCloser.CloseNotify():
 		return
 	}
-	select {
-	case <-ind.applied:
-	case <-tst.loopCloser.CloseNotify():
-	}
+	<-ind.applied
 	tst.incTotalFlushIntroLatency(time.Since(end).Seconds())
 }
 

--- a/banyand/measure/introducer.go
+++ b/banyand/measure/introducer.go
@@ -117,7 +117,22 @@ func (tst *tsTable) introducerLoop(flushCh chan *flusherIntroduction, mergeCh ch
 	for {
 		select {
 		case <-tst.loopCloser.CloseNotify():
-			return
+			// Drain pending introductions so senders don't block on applied.
+			for {
+				select {
+				case next := <-tst.introductions:
+					tst.introducePart(next, epoch)
+					epoch++
+				case next := <-flushCh:
+					tst.introduceFlushed(next, epoch)
+					epoch++
+				case next := <-mergeCh:
+					tst.introduceMerged(next, epoch)
+					epoch++
+				default:
+					return
+				}
+			}
 		case next := <-tst.introductions:
 			tst.incTotalIntroduceLoopStarted("mem")
 			tst.introducePart(next, epoch)
@@ -151,7 +166,25 @@ func (tst *tsTable) introducerLoopWithSync(flushCh chan *flusherIntroduction, me
 	for {
 		select {
 		case <-tst.loopCloser.CloseNotify():
-			return
+			// Drain pending introductions so senders don't block on applied.
+			for {
+				select {
+				case next := <-tst.introductions:
+					tst.introducePart(next, epoch)
+					epoch++
+				case next := <-flushCh:
+					tst.introduceFlushed(next, epoch)
+					epoch++
+				case next := <-mergeCh:
+					tst.introduceMerged(next, epoch)
+					epoch++
+				case next := <-syncCh:
+					tst.introduceSync(next, epoch)
+					epoch++
+				default:
+					return
+				}
+			}
 		case next := <-tst.introductions:
 			tst.incTotalIntroduceLoopStarted("mem")
 			tst.introducePart(next, epoch)

--- a/banyand/measure/introducer.go
+++ b/banyand/measure/introducer.go
@@ -130,6 +130,7 @@ func (tst *tsTable) introducerLoop(flushCh chan *flusherIntroduction, mergeCh ch
 					tst.introduceMerged(next, epoch)
 					epoch++
 				default:
+					tst.gc.clean()
 					return
 				}
 			}
@@ -182,6 +183,7 @@ func (tst *tsTable) introducerLoopWithSync(flushCh chan *flusherIntroduction, me
 					tst.introduceSync(next, epoch)
 					epoch++
 				default:
+					tst.gc.clean()
 					return
 				}
 			}

--- a/banyand/measure/merger.go
+++ b/banyand/measure/merger.go
@@ -163,11 +163,7 @@ func (tst *tsTable) mergePartsThenSendIntroduction(creator snapshotCreator, part
 	case <-tst.loopCloser.CloseNotify():
 		return newPart, errClosed
 	}
-	select {
-	case <-mi.applied:
-	case <-tst.loopCloser.CloseNotify():
-		return newPart, errClosed
-	}
+	<-mi.applied
 	return newPart, nil
 }
 

--- a/banyand/measure/syncer.go
+++ b/banyand/measure/syncer.go
@@ -466,11 +466,7 @@ func (tst *tsTable) sendSyncIntroduction(partsToSync []*part, syncCh chan *syncI
 	case <-tst.loopCloser.CloseNotify():
 		return errClosed
 	}
-	select {
-	case <-si.applied:
-	case <-tst.loopCloser.CloseNotify():
-		return errClosed
-	}
+	<-si.applied
 
 	return nil
 }

--- a/banyand/measure/tstable.go
+++ b/banyand/measure/tstable.go
@@ -364,10 +364,7 @@ func (tst *tsTable) mustAddFilePart(partID uint64) {
 		ind.part.decRef()
 		return
 	}
-	select {
-	case <-ind.applied:
-	case <-tst.loopCloser.CloseNotify():
-	}
+	<-ind.applied
 }
 
 func (tst *tsTable) mustAddMemPart(mp *memPart) {
@@ -388,10 +385,7 @@ func (tst *tsTable) mustAddMemPart(mp *memPart) {
 		ind.part.decRef()
 		return
 	}
-	select {
-	case <-ind.applied:
-	case <-tst.loopCloser.CloseNotify():
-	}
+	<-ind.applied
 	tst.incTotalWritten(int(totalCount))
 	tst.incTotalBatch(1)
 	tst.incTotalBatchIntroLatency(time.Since(startTime).Seconds())

--- a/banyand/stream/flusher.go
+++ b/banyand/stream/flusher.go
@@ -234,10 +234,7 @@ func (tst *tsTable) flush(snapshot *snapshot, flushCh chan *flusherIntroduction)
 	case <-tst.loopCloser.CloseNotify():
 		return
 	}
-	select {
-	case <-ind.applied:
-	case <-tst.loopCloser.CloseNotify():
-	}
+	<-ind.applied
 	tst.incTotalFlushIntroLatency(time.Since(end).Seconds())
 }
 

--- a/banyand/stream/introducer.go
+++ b/banyand/stream/introducer.go
@@ -146,7 +146,22 @@ func (tst *tsTable) introducerLoop(flushCh chan *flusherIntroduction, mergeCh ch
 	for {
 		select {
 		case <-tst.loopCloser.CloseNotify():
-			return
+			// Drain pending introductions so senders don't block on applied.
+			for {
+				select {
+				case next := <-tst.introductions:
+					tst.introducePart(next, epoch)
+					epoch++
+				case next := <-flushCh:
+					tst.introduceFlushed(next, epoch)
+					epoch++
+				case next := <-mergeCh:
+					tst.introduceMerged(next, epoch)
+					epoch++
+				default:
+					return
+				}
+			}
 		case next := <-tst.introductions:
 			tst.incTotalIntroduceLoopStarted("mem")
 			tst.introducePart(next, epoch)
@@ -180,7 +195,25 @@ func (tst *tsTable) introducerLoopWithSync(flushCh chan *flusherIntroduction, me
 	for {
 		select {
 		case <-tst.loopCloser.CloseNotify():
-			return
+			// Drain pending introductions so senders don't block on applied.
+			for {
+				select {
+				case next := <-tst.introductions:
+					tst.introducePart(next, epoch)
+					epoch++
+				case next := <-flushCh:
+					tst.introduceFlushed(next, epoch)
+					epoch++
+				case next := <-mergeCh:
+					tst.introduceMerged(next, epoch)
+					epoch++
+				case next := <-syncCh:
+					tst.introduceSync(next, epoch)
+					epoch++
+				default:
+					return
+				}
+			}
 		case next := <-tst.introductions:
 			tst.incTotalIntroduceLoopStarted("mem")
 			tst.introducePart(next, epoch)

--- a/banyand/stream/introducer.go
+++ b/banyand/stream/introducer.go
@@ -159,6 +159,7 @@ func (tst *tsTable) introducerLoop(flushCh chan *flusherIntroduction, mergeCh ch
 					tst.introduceMerged(next, epoch)
 					epoch++
 				default:
+					tst.gc.clean()
 					return
 				}
 			}
@@ -211,6 +212,7 @@ func (tst *tsTable) introducerLoopWithSync(flushCh chan *flusherIntroduction, me
 					tst.introduceSync(next, epoch)
 					epoch++
 				default:
+					tst.gc.clean()
 					return
 				}
 			}

--- a/banyand/stream/merger.go
+++ b/banyand/stream/merger.go
@@ -162,11 +162,7 @@ func (tst *tsTable) mergePartsThenSendIntroduction(creator snapshotCreator, part
 	case <-tst.loopCloser.CloseNotify():
 		return newPart, errClosed
 	}
-	select {
-	case <-mi.applied:
-	case <-tst.loopCloser.CloseNotify():
-		return newPart, errClosed
-	}
+	<-mi.applied
 	return newPart, nil
 }
 

--- a/banyand/stream/syncer.go
+++ b/banyand/stream/syncer.go
@@ -439,11 +439,7 @@ func (tst *tsTable) sendSyncIntroduction(partsToSync []*part, syncCh chan *syncI
 	case <-tst.loopCloser.CloseNotify():
 		return errClosed
 	}
-	select {
-	case <-si.applied:
-	case <-tst.loopCloser.CloseNotify():
-		return errClosed
-	}
+	<-si.applied
 
 	return nil
 }

--- a/banyand/stream/tstable.go
+++ b/banyand/stream/tstable.go
@@ -375,10 +375,7 @@ func (tst *tsTable) mustAddFilePart(partID uint64) {
 		ind.part.decRef()
 		return
 	}
-	select {
-	case <-ind.applied:
-	case <-tst.loopCloser.CloseNotify():
-	}
+	<-ind.applied
 }
 
 func (tst *tsTable) mustAddMemPart(mp *memPart) {
@@ -399,10 +396,7 @@ func (tst *tsTable) mustAddMemPart(mp *memPart) {
 		ind.part.decRef()
 		return
 	}
-	select {
-	case <-ind.applied:
-	case <-tst.loopCloser.CloseNotify():
-	}
+	<-ind.applied
 	tst.incTotalWritten(int(totalCount))
 	tst.incTotalBatch(1)
 	tst.incTotalBatchIntroLatency(time.Since(startTime).Seconds())

--- a/banyand/trace/flusher.go
+++ b/banyand/trace/flusher.go
@@ -273,10 +273,7 @@ func (tst *tsTable) flush(snapshot *snapshot, flushCh chan *flusherIntroduction)
 		}
 		return
 	}
-	select {
-	case <-ind.applied:
-	case <-tst.loopCloser.CloseNotify():
-	}
+	<-ind.applied
 	tst.incTotalFlushIntroLatency(time.Since(end).Seconds())
 }
 

--- a/banyand/trace/introducer.go
+++ b/banyand/trace/introducer.go
@@ -172,6 +172,7 @@ func (tst *tsTable) introducerLoop(flushCh chan *flusherIntroduction, mergeCh ch
 					tst.introduceMerged(next, epoch)
 					epoch++
 				default:
+					tst.gc.clean()
 					return
 				}
 			}
@@ -224,6 +225,7 @@ func (tst *tsTable) introducerLoopWithSync(flushCh chan *flusherIntroduction, me
 					tst.introduceSync(next, epoch)
 					epoch++
 				default:
+					tst.gc.clean()
 					return
 				}
 			}

--- a/banyand/trace/introducer.go
+++ b/banyand/trace/introducer.go
@@ -159,7 +159,22 @@ func (tst *tsTable) introducerLoop(flushCh chan *flusherIntroduction, mergeCh ch
 	for {
 		select {
 		case <-tst.loopCloser.CloseNotify():
-			return
+			// Drain pending introductions so senders don't block on applied.
+			for {
+				select {
+				case next := <-tst.introductions:
+					tst.introducePart(next, epoch)
+					epoch++
+				case next := <-flushCh:
+					tst.introduceFlushed(next, epoch)
+					epoch++
+				case next := <-mergeCh:
+					tst.introduceMerged(next, epoch)
+					epoch++
+				default:
+					return
+				}
+			}
 		case next := <-tst.introductions:
 			tst.incTotalIntroduceLoopStarted("mem")
 			tst.introducePart(next, epoch)
@@ -193,7 +208,25 @@ func (tst *tsTable) introducerLoopWithSync(flushCh chan *flusherIntroduction, me
 	for {
 		select {
 		case <-tst.loopCloser.CloseNotify():
-			return
+			// Drain pending introductions so senders don't block on applied.
+			for {
+				select {
+				case next := <-tst.introductions:
+					tst.introducePart(next, epoch)
+					epoch++
+				case next := <-flushCh:
+					tst.introduceFlushedForSync(next, epoch)
+					epoch++
+				case next := <-mergeCh:
+					tst.introduceMerged(next, epoch)
+					epoch++
+				case next := <-syncCh:
+					tst.introduceSync(next, epoch)
+					epoch++
+				default:
+					return
+				}
+			}
 		case next := <-tst.introductions:
 			tst.incTotalIntroduceLoopStarted("mem")
 			tst.introducePart(next, epoch)

--- a/banyand/trace/merger.go
+++ b/banyand/trace/merger.go
@@ -370,11 +370,7 @@ func (tst *tsTable) mergePartsThenSendIntroduction(creator snapshotCreator, part
 	case <-tst.loopCloser.CloseNotify():
 		return newPart, errClosed
 	}
-	select {
-	case <-mi.applied:
-	case <-tst.loopCloser.CloseNotify():
-		return newPart, errClosed
-	}
+	<-mi.applied
 	return newPart, nil
 }
 

--- a/banyand/trace/merger_test.go
+++ b/banyand/trace/merger_test.go
@@ -1678,6 +1678,9 @@ func Test_mergeLaneWorker_cleansUpInFlight(t *testing.T) {
 	go func() {
 		defer close(mockIntroducerDone)
 		for mi := range merges {
+			if mi.newPart != nil {
+				mi.newPart.decRef()
+			}
 			if mi.applied != nil {
 				close(mi.applied)
 			}

--- a/banyand/trace/merger_test.go
+++ b/banyand/trace/merger_test.go
@@ -1673,6 +1673,17 @@ func Test_mergeLaneWorker_cleansUpInFlight(t *testing.T) {
 	ch := make(chan *mergeDispatchRequest, 1)
 	merges := make(chan *mergerIntroduction, 1)
 
+	// Start a mock introducer to consume from merges and close applied.
+	mockIntroducerDone := make(chan struct{})
+	go func() {
+		defer close(mockIntroducerDone)
+		for mi := range merges {
+			if mi.applied != nil {
+				close(mi.applied)
+			}
+		}
+	}()
+
 	// Start worker in background
 	workerDone := make(chan struct{})
 	go func() {
@@ -1689,9 +1700,7 @@ func Test_mergeLaneWorker_cleansUpInFlight(t *testing.T) {
 	}
 	close(ch)
 
-	// The worker will try to merge and send introduction.
-	// Since there's no introducerLoop, mergePartsThenSendIntroduction
-	// will block on mi.applied. Close the closer to unblock it.
+	// Close the closer to signal shutdown.
 	time.Sleep(100 * time.Millisecond)
 	closer.Done()
 	closer.CloseThenWait()
@@ -1702,6 +1711,8 @@ func Test_mergeLaneWorker_cleansUpInFlight(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("worker did not finish")
 	}
+	close(merges)
+	<-mockIntroducerDone
 
 	// Verify inFlight was cleaned up
 	tst.inFlightMu.RLock()

--- a/banyand/trace/syncer.go
+++ b/banyand/trace/syncer.go
@@ -475,11 +475,7 @@ func (tst *tsTable) handleSyncIntroductions(partsToSync []*part, syncCh chan *sy
 		return errClosed
 	}
 
-	select {
-	case <-si.applied:
-	case <-tst.loopCloser.CloseNotify():
-		return errClosed
-	}
+	<-si.applied
 	return nil
 }
 

--- a/banyand/trace/tstable.go
+++ b/banyand/trace/tstable.go
@@ -520,10 +520,7 @@ func (tst *tsTable) mustAddFilePart(partID uint64, sidxFilePartsMap map[string]s
 		ind.part.decRef()
 		return
 	}
-	select {
-	case <-ind.applied:
-	case <-tst.loopCloser.CloseNotify():
-	}
+	<-ind.applied
 }
 
 func (tst *tsTable) mustAddMemPart(mp *memPart, sidxReqsMap map[string]*sidx.MemPart) {
@@ -545,10 +542,7 @@ func (tst *tsTable) mustAddMemPart(mp *memPart, sidxReqsMap map[string]*sidx.Mem
 		ind.part.decRef()
 		return
 	}
-	select {
-	case <-ind.applied:
-	case <-tst.loopCloser.CloseNotify():
-	}
+	<-ind.applied
 	tst.incTotalWritten(int(totalCount))
 	tst.incTotalBatch(1)
 	tst.incTotalBatchIntroLatency(time.Since(startTime).Seconds())


### PR DESCRIPTION
## Summary

- Fix data race between flusher/merger/syncer senders and the introducer loop during shutdown, caught by the Go race detector under CI pressure.
- Replace the racing `select { case <-applied: case <-loopCloser: }` pattern with a plain `<-applied` in all 15 send/await sites across measure, stream, and trace modules.
- Add drain logic to all 6 introducer loops so pending introductions are processed and `applied` is closed before the introducer exits, preventing deadlock on shutdown.
- Update `Test_mergeLaneWorker_cleansUpInFlight` to provide a mock introducer matching the real production contract.

## Root cause

When `loopCloser` fires during shutdown, senders would shortcut the `applied` channel wait via `select`, allowing the deferred pool release to mutate the introduction object while the introducer goroutine was still reading it. This manifested as a Go race detector failure on `flusherIntroduction.flushed` map access.

## Test plan

- [x] `go test -race ./banyand/measure/` passes
- [x] `go test -race ./banyand/stream/` passes
- [x] `go test -race ./banyand/trace/` passes (including previously-failing `Test_mergeLaneWorker_cleansUpInFlight`)
- [x] Full CI check suite passes (license-check, build, lint, check)
- [x] Unit tests pass for banyand, bydbctl, pkg

🤖 Generated with [Claude Code](https://claude.com/claude-code)

via [HAPI](https://hapi.run)