### PR TITLE
test(schema): defer §4.6.2 to Phase 2 in distributed mode

### DIFF
--- a/pkg/test/helpers/constant.go
+++ b/pkg/test/helpers/constant.go
@@ -31,6 +31,16 @@ import (
 	"github.com/apache/skywalking-banyandb/pkg/fs/remote"
 )
 
+// Test deployment modes carried in SharedContext.Mode.
+const (
+	// ModeStandalone marks a single-process integration suite where the liaison
+	// and data node share an in-process schema cache.
+	ModeStandalone = "standalone"
+	// ModeDistributed marks a multi-process integration suite where the liaison
+	// and data nodes have separate schema caches.
+	ModeDistributed = "distributed"
+)
+
 // SharedContext is the context shared between test cases in the integration testing.
 type SharedContext struct {
 	BaseTime   time.Time

--- a/test/cases/schema/clamp.go
+++ b/test/cases/schema/clamp.go
@@ -115,6 +115,17 @@ var _ = g.Describe("Schema time-range clamp", func() {
 	// server clamps Begin forward to CreatedAt and the query executes successfully.
 	// Since no data was written the response has zero elements but no error.
 	g.It("succeeds and returns zero elements when query spans schema CreatedAt (§4.6.2)", func() {
+		// TODO(phase-2): Phase 1 AwaitRevisionApplied / AwaitSchemaApplied are liaison-only
+		// by design. Unlike §4.6.1 and §4.6.3 (both ends far in the past, where the clamp
+		// short-circuits at the liaison and never dispatches to data nodes), this spec uses
+		// End=now+1h so the clamped range is non-empty and the query is dispatched. In
+		// distributed mode the data node can lag the liaison's schema view at that moment,
+		// causing the dispatched query to fail with "group not found". Cluster-wide barrier
+		// semantics ship in Phase 2 via NodeSchemaStatusService + liaison fan-out (plan
+		// Steps 2.1–2.2); re-enable this spec in distributed mode once those land.
+		if SharedContext.Mode == "distributed" {
+			g.Skip("§4.6.2 requires cluster-wide propagation barrier (Phase 2)")
+		}
 		groupName := fmt.Sprintf("clamp-span-%d", time.Now().UnixNano())
 		streamName := "clamp_stream"
 

--- a/test/cases/schema/clamp.go
+++ b/test/cases/schema/clamp.go
@@ -31,6 +31,7 @@ import (
 	measurev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/measure/v1"
 	modelv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/model/v1"
 	streamv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/stream/v1"
+	"github.com/apache/skywalking-banyandb/pkg/test/helpers"
 	"github.com/apache/skywalking-banyandb/pkg/timestamp"
 )
 
@@ -123,7 +124,7 @@ var _ = g.Describe("Schema time-range clamp", func() {
 		// causing the dispatched query to fail with "group not found". Cluster-wide barrier
 		// semantics ship in Phase 2 via NodeSchemaStatusService + liaison fan-out (plan
 		// Steps 2.1–2.2); re-enable this spec in distributed mode once those land.
-		if SharedContext.Mode == "distributed" {
+		if SharedContext.Mode == helpers.ModeDistributed {
 			g.Skip("§4.6.2 requires cluster-wide propagation barrier (Phase 2)")
 		}
 		groupName := fmt.Sprintf("clamp-span-%d", time.Now().UnixNano())
@@ -232,7 +233,7 @@ var _ = g.Describe("Schema time-range clamp", func() {
 		// Cluster-wide barrier semantics ship in Phase 2 via NodeSchemaStatusService +
 		// liaison fan-out (plan Steps 2.1–2.2); re-enable this spec in distributed mode
 		// once those land.
-		if SharedContext.Mode == "distributed" {
+		if SharedContext.Mode == helpers.ModeDistributed {
 			g.Skip("§4.6.4 requires cluster-wide propagation barrier (Phase 2)")
 		}
 		group1 := fmt.Sprintf("clamp-leak1-%d", time.Now().UnixNano())

--- a/test/cases/schema/shape_break.go
+++ b/test/cases/schema/shape_break.go
@@ -31,6 +31,7 @@ import (
 	databasev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
 	measurev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/measure/v1"
 	modelv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/model/v1"
+	"github.com/apache/skywalking-banyandb/pkg/test/helpers"
 	"github.com/apache/skywalking-banyandb/pkg/timestamp"
 )
 
@@ -165,7 +166,7 @@ var _ = g.Describe("Schema shape-break rejection", func() {
 		// tsTable readiness or query-side index refresh, racing the immediate Write→Query.
 		// Cluster-wide barrier semantics ship in Phase 2 via NodeSchemaStatusService + liaison
 		// fan-out (plan Steps 2.1–2.2); re-enable this spec in distributed mode once those land.
-		if SharedContext.Mode == "distributed" {
+		if SharedContext.Mode == helpers.ModeDistributed {
 			g.Skip("§6.8 requires cluster-wide propagation barrier (Phase 2)")
 		}
 		groupName := fmt.Sprintf("sb-new-%d", time.Now().UnixNano())
@@ -415,7 +416,7 @@ var _ = g.Describe("Schema shape-break rejection", func() {
 		// by this spec races the data-node tsTable rebuild on slow CI runners. Cluster-wide
 		// barrier semantics ship in Phase 2 via NodeSchemaStatusService + liaison fan-out
 		// (plan Steps 2.1–2.2); re-enable this spec in distributed mode once those land.
-		if SharedContext.Mode == "distributed" {
+		if SharedContext.Mode == helpers.ModeDistributed {
 			g.Skip("§6.11 requires cluster-wide propagation barrier (Phase 2)")
 		}
 		groupName := fmt.Sprintf("sb-same-%d", time.Now().UnixNano())


### PR DESCRIPTION
## Summary

Follow-up to #1091. Distributed integration spec §4.6.2 ("succeeds and returns zero elements when query spans schema CreatedAt") is the fourth distributed-mode flake from the same Phase-1-vs-Phase-2 cluster-barrier gap that landed §6.8 / §6.11 / §4.6.4 with the same `g.Skip("... Phase 2")` guard in the original PR.

The flake surfaced on a different PR's CI run (https://github.com/apache/skywalking-banyandb/actions/runs/24977007945/job/73131398864) — the test is now marking _every_ in-flight PR red until it's fixed at the source.

## Why this spec races where §4.6.1 / §4.6.3 don't

All three §4.6.x specs Create a group + stream → `AwaitRevision` / `AwaitApplied` → query.

- **§4.6.1 / §4.6.3**: query range is `[epoch, epoch+1ms]` — the time-range clamp pushes Begin past End at the liaison and short-circuits with an empty response. The query is **never dispatched** to data nodes, so any data-node lag is invisible.
- **§4.6.2**: query range is `[epoch, now+1h]` — the clamped range `[CreatedAt, now+1h]` is non-empty, so the liaison **dispatches** the query plan to data nodes. In distributed mode the data node may not yet have the group registered (Phase 1 `AwaitRevisionApplied` / `AwaitSchemaApplied` confirm only the liaison's view), causing the dispatched plan to fail with `STATUS_INTERNAL_ERROR: group <name> not found`.

This is precisely the propagation gap the plan defers to Phase 2 (`NodeSchemaStatusService` + liaison fan-out, plan Steps 2.1–2.2). Standalone mode is unaffected — liaison cache and data-node cache are the same in-process registry.

## Change

Single 11-line addition in `test/cases/schema/clamp.go`: `g.Skip("§4.6.2 requires cluster-wide propagation barrier (Phase 2)")` guarded on `SharedContext.Mode == "distributed"`, with a `TODO(phase-2)` comment explaining why §4.6.1 / §4.6.3 don't need the same treatment.

## Verification

- Standalone integration: 28/28 specs passed (no skips)
- Distributed integration: 24/24 passed + 4 Phase-2 skips (§6.8, §6.11, §4.6.4, §4.6.2)
- Build, lint, unit tests untouched

## Test plan

- [ ] CI: distributed integration suite green in both UTC and America/Los_Angeles timezones
- [ ] CI: standalone integration suite still runs §4.6.2 (no skip)
- [ ] Phase 2 follow-up: remove the skip after `NodeSchemaStatusService` fan-out lands