### PR TITLE
docs: add snapshot retention flags and relative path version note

### DIFF
--- a/docs/operation/configuration.md
+++ b/docs/operation/configuration.md
@@ -2,7 +2,7 @@
 
 BanyanD is the BanyanDB server. There are two ways to configure BanyanD: using a bootstrap flag or using environment variables. The environment variable name has a prefix `BYDB_` followed by the flag name in uppercase. For example, the flag `--port` can be set using the environment variable `BYDB_PORT`.
 
-> BanyanDB supports both absolute and relative paths for directory and file configurations (such as data directories, TLS certificates, keys, etc.). Relative paths are resolved against the current working directory where the BanyanD process is started.
+> BanyanDB supports both absolute and relative paths for directory and file configurations (such as data directories, TLS certificates, keys, etc.). Relative paths are resolved against the current working directory where the BanyanD process is started. This feature is available since 0.10.0.
 
 ## Commands
 
@@ -145,6 +145,18 @@ The following flags are used to configure the memory protector:
 
 - `--allowed-bytes bytes`: Allowed bytes of memory usage. If the memory usage exceeds this value, the query services will stop. Setting a large value may evict data from the OS page cache, causing high disk I/O. (default 0B)
 - `--allowed-percent int`: Allowed percentage of total memory usage. If usage exceeds this value, the query services will stop. This takes effect only if `allowed-bytes` is 0. If usage is too high, it may cause OS page cache eviction. (default 75)
+
+### Snapshot Retention
+
+Each service supports a minimum snapshot age configuration to prevent recently created snapshots from being deleted prematurely:
+
+- `--measure-min-file-snapshot-age duration`: Minimum age for measure snapshots (default: 1h).
+- `--stream-min-file-snapshot-age duration`: Minimum age for stream snapshots (default: 1h).
+- `--trace-min-file-snapshot-age duration`: Minimum age for trace snapshots (default: 1h).
+- `--property-min-file-snapshot-age duration`: Minimum age for property snapshots (default: 1h).
+- `--schema-server-min-file-snapshot-age duration`: Minimum age for schema server snapshots (default: 1h).
+
+Snapshots can only be deleted after the configured minimum age has elapsed. This ensures that recent snapshots remain available for backup and recovery operations.
 
 ### Observability
 

--- a/docs/operation/configuration.md
+++ b/docs/operation/configuration.md
@@ -2,7 +2,7 @@
 
 BanyanD is the BanyanDB server. There are two ways to configure BanyanD: using a bootstrap flag or using environment variables. The environment variable name has a prefix `BYDB_` followed by the flag name in uppercase. For example, the flag `--port` can be set using the environment variable `BYDB_PORT`.
 
-> BanyanDB supports both absolute and relative paths for directory and file configurations (such as data directories, TLS certificates, keys, etc.). Relative paths are resolved against the current working directory where the BanyanD process is started. This feature is available since 0.10.0.
+> BanyanDB supports both absolute and relative paths for directory and file configurations (such as data directories, TLS certificates, keys, etc.). Relative paths are resolved against the current working directory where the BanyanD process is started. Available as of v0.10.0.
 
 ## Commands
 
@@ -156,7 +156,7 @@ Each service supports a minimum snapshot age configuration to prevent recently c
 - `--property-min-file-snapshot-age duration`: Minimum age for property snapshots (default: 1h).
 - `--schema-server-min-file-snapshot-age duration`: Minimum age for schema server snapshots (default: 1h).
 
-Snapshots can only be deleted after the configured minimum age has elapsed. This ensures that recent snapshots remain available for backup and recovery operations.
+During normal snapshot cleanup (triggered when a new snapshot is created), a snapshot is only deleted if it is older than the configured minimum age **and** the total snapshot count exceeds `*-max-file-snapshot-num` (default: 10). This ensures that recent snapshots remain available for backup and recovery operations.
 
 ### Observability
 


### PR DESCRIPTION
## Summary
- Document `--measure-min-file-snapshot-age`, `--stream-min-file-snapshot-age`, `--trace-min-file-snapshot-age`, and `--property-min-file-snapshot-age` flags
- Add "Snapshot Retention" subsection explaining minimum age behavior
- Add version annotation ("since 0.10.0") for relative path support

## Test plan
- [x] Verified snapshot flags exist in the codebase
- [x] Confirmed `--schema-server-min-file-snapshot-age` was already documented; these 4 were missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)