### PR TITLE
fix(measure,stream,trace): wait until all mem parts flushed in file_snapshot tests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -55,6 +55,7 @@ Release Notes.
 - Fix `FileSystemError` not satisfying `errors.Is(err, io/fs.ErrNotExist)`, which prevented the segment controller from cleaning up half-born segment directories and left groups in a permanent zombie state after a crash or partial sync.
 - Fix lifecycle migration panic when a stream shard's snapshot has no element index (`idx/`) directory.
 - Avoid FODC lifecycle inspection failing on busy data nodes by raising the per-broadcast `CollectDataInfo` / `CollectLiaisonInfo` deadline from 5s to 30s and parallelizing per-group inspection in the cluster-internal `InspectAll`.
+- Fix flaky `file_snapshot` subtest in measure/stream/trace by waiting until every introduced mem part has been flushed to disk, instead of only checking the latest snapshot creator.
 
 ### Chores
 

--- a/banyand/measure/query_test.go
+++ b/banyand/measure/query_test.go
@@ -1339,27 +1339,9 @@ func TestQueryResult(t *testing.T) {
 				// inspecting only snapshot.creator races with concurrent introductions
 				// (a flush of part N can land while part N+1 is still a mem part).
 				if len(tt.dpsList) > 0 {
-					for {
-						snp := tst.currentSnapshot()
-						if snp == nil {
-							time.Sleep(100 * time.Millisecond)
-							continue
-						}
-						hasMemPart := false
-						for _, pw := range snp.parts {
-							if pw.mp != nil {
-								hasMemPart = true
-								break
-							}
-						}
-						snp.decRef()
-						if hasMemPart {
-							time.Sleep(100 * time.Millisecond)
-							continue
-						}
-						tst.Close()
-						break
-					}
+					require.Eventually(t, allPartsFlushed(tst), 30*time.Second, 100*time.Millisecond,
+						"mem parts not flushed to disk in time")
+					tst.Close()
 				}
 
 				// reopen the table
@@ -1373,6 +1355,26 @@ func TestQueryResult(t *testing.T) {
 				verify(t, tst)
 			})
 		})
+	}
+}
+
+// allPartsFlushed returns a predicate that is true once tst's current
+// snapshot exists and every part is file-backed (no mp != nil).
+// It is used by file_snapshot tests to wait until every introduced mem
+// part has been flushed before closing/reopening the table.
+func allPartsFlushed(tst *tsTable) func() bool {
+	return func() bool {
+		snp := tst.currentSnapshot()
+		if snp == nil {
+			return false
+		}
+		defer snp.decRef()
+		for _, pw := range snp.parts {
+			if pw.mp != nil {
+				return false
+			}
+		}
+		return true
 	}
 }
 
@@ -1450,27 +1452,9 @@ func TestQueryResult_QuotaExceeded(t *testing.T) {
 			// inspecting only snapshot.creator races with concurrent introductions
 			// (a flush of part N can land while part N+1 is still a mem part).
 			if len(tt.dpsList) > 0 {
-				for {
-					snp := tst.currentSnapshot()
-					if snp == nil {
-						time.Sleep(100 * time.Millisecond)
-						continue
-					}
-					hasMemPart := false
-					for _, pw := range snp.parts {
-						if pw.mp != nil {
-							hasMemPart = true
-							break
-						}
-					}
-					snp.decRef()
-					if hasMemPart {
-						time.Sleep(100 * time.Millisecond)
-						continue
-					}
-					tst.Close()
-					break
-				}
+				require.Eventually(t, allPartsFlushed(tst), 30*time.Second, 100*time.Millisecond,
+					"mem parts not flushed to disk in time")
+				tst.Close()
 			}
 
 			// reopen the table

--- a/banyand/measure/query_test.go
+++ b/banyand/measure/query_test.go
@@ -1335,7 +1335,9 @@ func TestQueryResult(t *testing.T) {
 					tst.mustAddDataPoints(dps)
 					time.Sleep(100 * time.Millisecond)
 				}
-				// wait until the introducer is done
+				// wait until every introduced mem part has been flushed to disk;
+				// inspecting only snapshot.creator races with concurrent introductions
+				// (a flush of part N can land while part N+1 is still a mem part).
 				if len(tt.dpsList) > 0 {
 					for {
 						snp := tst.currentSnapshot()
@@ -1343,12 +1345,18 @@ func TestQueryResult(t *testing.T) {
 							time.Sleep(100 * time.Millisecond)
 							continue
 						}
-						if snp.creator == snapshotCreatorMemPart {
-							snp.decRef()
+						hasMemPart := false
+						for _, pw := range snp.parts {
+							if pw.mp != nil {
+								hasMemPart = true
+								break
+							}
+						}
+						snp.decRef()
+						if hasMemPart {
 							time.Sleep(100 * time.Millisecond)
 							continue
 						}
-						snp.decRef()
 						tst.Close()
 						break
 					}
@@ -1438,7 +1446,9 @@ func TestQueryResult_QuotaExceeded(t *testing.T) {
 				tst.mustAddDataPoints(dps)
 				time.Sleep(100 * time.Millisecond)
 			}
-			// wait until the introducer is done
+			// wait until every introduced mem part has been flushed to disk;
+			// inspecting only snapshot.creator races with concurrent introductions
+			// (a flush of part N can land while part N+1 is still a mem part).
 			if len(tt.dpsList) > 0 {
 				for {
 					snp := tst.currentSnapshot()
@@ -1446,12 +1456,18 @@ func TestQueryResult_QuotaExceeded(t *testing.T) {
 						time.Sleep(100 * time.Millisecond)
 						continue
 					}
-					if snp.creator == snapshotCreatorMemPart {
-						snp.decRef()
+					hasMemPart := false
+					for _, pw := range snp.parts {
+						if pw.mp != nil {
+							hasMemPart = true
+							break
+						}
+					}
+					snp.decRef()
+					if hasMemPart {
 						time.Sleep(100 * time.Millisecond)
 						continue
 					}
-					snp.decRef()
 					tst.Close()
 					break
 				}

--- a/banyand/stream/block_scanner_test.go
+++ b/banyand/stream/block_scanner_test.go
@@ -87,7 +87,9 @@ func TestBlockScanner_QuotaExceeded(t *testing.T) {
 				tst.mustAddElements(es)
 				time.Sleep(100 * time.Millisecond)
 			}
-			// wait until the introducer is done
+			// wait until every introduced mem part has been flushed to disk;
+			// inspecting only snapshot.creator races with concurrent introductions
+			// (a flush of part N can land while part N+1 is still a mem part).
 			if len(tt.esList) > 0 {
 				for {
 					snp := tst.currentSnapshot()
@@ -95,12 +97,18 @@ func TestBlockScanner_QuotaExceeded(t *testing.T) {
 						time.Sleep(100 * time.Millisecond)
 						continue
 					}
-					if snp.creator == snapshotCreatorMemPart {
-						snp.decRef()
+					hasMemPart := false
+					for _, pw := range snp.parts {
+						if pw.mp != nil {
+							hasMemPart = true
+							break
+						}
+					}
+					snp.decRef()
+					if hasMemPart {
 						time.Sleep(100 * time.Millisecond)
 						continue
 					}
-					snp.decRef()
 					tst.Close()
 					break
 				}

--- a/banyand/stream/block_scanner_test.go
+++ b/banyand/stream/block_scanner_test.go
@@ -91,27 +91,9 @@ func TestBlockScanner_QuotaExceeded(t *testing.T) {
 			// inspecting only snapshot.creator races with concurrent introductions
 			// (a flush of part N can land while part N+1 is still a mem part).
 			if len(tt.esList) > 0 {
-				for {
-					snp := tst.currentSnapshot()
-					if snp == nil {
-						time.Sleep(100 * time.Millisecond)
-						continue
-					}
-					hasMemPart := false
-					for _, pw := range snp.parts {
-						if pw.mp != nil {
-							hasMemPart = true
-							break
-						}
-					}
-					snp.decRef()
-					if hasMemPart {
-						time.Sleep(100 * time.Millisecond)
-						continue
-					}
-					tst.Close()
-					break
-				}
+				require.Eventually(t, allPartsFlushed(tst), 30*time.Second, 100*time.Millisecond,
+					"mem parts not flushed to disk in time")
+				tst.Close()
 			}
 
 			// reopen the table
@@ -210,5 +192,25 @@ func TestBlockScanner_QuotaExceeded(t *testing.T) {
 				t.Errorf("Unexpected blockMetadata (-got +want):\n%s", diff)
 			}
 		})
+	}
+}
+
+// allPartsFlushed returns a predicate that is true once tst's current
+// snapshot exists and every part is file-backed (no mp != nil).
+// It is used by file_snapshot tests to wait until every introduced mem
+// part has been flushed before closing/reopening the table.
+func allPartsFlushed(tst *tsTable) func() bool {
+	return func() bool {
+		snp := tst.currentSnapshot()
+		if snp == nil {
+			return false
+		}
+		defer snp.decRef()
+		for _, pw := range snp.parts {
+			if pw.mp != nil {
+				return false
+			}
+		}
+		return true
 	}
 }

--- a/banyand/stream/query_by_idx_test.go
+++ b/banyand/stream/query_by_idx_test.go
@@ -89,27 +89,9 @@ func TestQueryResult_QuotaExceeded(t *testing.T) {
 			// inspecting only snapshot.creator races with concurrent introductions
 			// (a flush of part N can land while part N+1 is still a mem part).
 			if len(tt.esList) > 0 {
-				for {
-					snp := tst.currentSnapshot()
-					if snp == nil {
-						time.Sleep(100 * time.Millisecond)
-						continue
-					}
-					hasMemPart := false
-					for _, pw := range snp.parts {
-						if pw.mp != nil {
-							hasMemPart = true
-							break
-						}
-					}
-					snp.decRef()
-					if hasMemPart {
-						time.Sleep(100 * time.Millisecond)
-						continue
-					}
-					tst.Close()
-					break
-				}
+				require.Eventually(t, allPartsFlushed(tst), 30*time.Second, 100*time.Millisecond,
+					"mem parts not flushed to disk in time")
+				tst.Close()
 			}
 
 			// reopen the table

--- a/banyand/stream/query_by_idx_test.go
+++ b/banyand/stream/query_by_idx_test.go
@@ -85,7 +85,9 @@ func TestQueryResult_QuotaExceeded(t *testing.T) {
 				tst.mustAddElements(es)
 				time.Sleep(100 * time.Millisecond)
 			}
-			// wait until the introducer is done
+			// wait until every introduced mem part has been flushed to disk;
+			// inspecting only snapshot.creator races with concurrent introductions
+			// (a flush of part N can land while part N+1 is still a mem part).
 			if len(tt.esList) > 0 {
 				for {
 					snp := tst.currentSnapshot()
@@ -93,12 +95,18 @@ func TestQueryResult_QuotaExceeded(t *testing.T) {
 						time.Sleep(100 * time.Millisecond)
 						continue
 					}
-					if snp.creator == snapshotCreatorMemPart {
-						snp.decRef()
+					hasMemPart := false
+					for _, pw := range snp.parts {
+						if pw.mp != nil {
+							hasMemPart = true
+							break
+						}
+					}
+					snp.decRef()
+					if hasMemPart {
 						time.Sleep(100 * time.Millisecond)
 						continue
 					}
-					snp.decRef()
 					tst.Close()
 					break
 				}

--- a/banyand/trace/query_test.go
+++ b/banyand/trace/query_test.go
@@ -202,7 +202,9 @@ func TestQueryResult(t *testing.T) {
 					tst.mustAddTraces(traces, nil)
 					time.Sleep(100 * time.Millisecond)
 				}
-				// wait until the introducer is done
+				// wait until every introduced mem part has been flushed to disk;
+				// inspecting only snapshot.creator races with concurrent introductions
+				// (a flush of part N can land while part N+1 is still a mem part).
 				if len(tt.tracesList) > 0 {
 					for {
 						snp := tst.currentSnapshot()
@@ -210,12 +212,18 @@ func TestQueryResult(t *testing.T) {
 							time.Sleep(100 * time.Millisecond)
 							continue
 						}
-						if snp.creator == snapshotCreatorMemPart {
-							snp.decRef()
+						hasMemPart := false
+						for _, pw := range snp.parts {
+							if pw.mp != nil {
+								hasMemPart = true
+								break
+							}
+						}
+						snp.decRef()
+						if hasMemPart {
 							time.Sleep(100 * time.Millisecond)
 							continue
 						}
-						snp.decRef()
 						tst.Close()
 						break
 					}

--- a/banyand/trace/query_test.go
+++ b/banyand/trace/query_test.go
@@ -206,27 +206,9 @@ func TestQueryResult(t *testing.T) {
 				// inspecting only snapshot.creator races with concurrent introductions
 				// (a flush of part N can land while part N+1 is still a mem part).
 				if len(tt.tracesList) > 0 {
-					for {
-						snp := tst.currentSnapshot()
-						if snp == nil {
-							time.Sleep(100 * time.Millisecond)
-							continue
-						}
-						hasMemPart := false
-						for _, pw := range snp.parts {
-							if pw.mp != nil {
-								hasMemPart = true
-								break
-							}
-						}
-						snp.decRef()
-						if hasMemPart {
-							time.Sleep(100 * time.Millisecond)
-							continue
-						}
-						tst.Close()
-						break
-					}
+					require.Eventually(t, allPartsFlushed(tst), 30*time.Second, 100*time.Millisecond,
+						"mem parts not flushed to disk in time")
+					tst.Close()
 				}
 
 				// reopen the table
@@ -463,5 +445,25 @@ func TestQueryResultMultipleBatches(t *testing.T) {
 				verify(t, tst)
 			})
 		})
+	}
+}
+
+// allPartsFlushed returns a predicate that is true once tst's current
+// snapshot exists and every part is file-backed (no mp != nil).
+// It is used by file_snapshot tests to wait until every introduced mem
+// part has been flushed before closing/reopening the table.
+func allPartsFlushed(tst *tsTable) func() bool {
+	return func() bool {
+		snp := tst.currentSnapshot()
+		if snp == nil {
+			return false
+		}
+		defer snp.decRef()
+		for _, pw := range snp.parts {
+			if pw.mp != nil {
+				return false
+			}
+		}
+		return true
 	}
 }


### PR DESCRIPTION
## Summary

- Fixes the flaky `TestQueryResult/.../order_by_Series_1/file_snapshot` failure observed in [run 25009241257](https://github.com/apache/skywalking-banyandb/actions/runs/25009241257/job/73243233950).
- The `file_snapshot` wait loop only inspected `snapshot.creator`, which races with concurrent introductions: with `flushTimeout: 0`, the flusher fires per-part, so a flush of part N can flip `creator` to `Flusher` while part N+1 is still a mem part. The test then closes the table and the still-in-memory part is dropped, so the reopened table is missing data.
- Replace the creator check with a scan over `snapshot.parts` for any `partWrapper.mp != nil`. Applied in five wait loops sharing the same idiom: `banyand/measure/query_test.go` (TestQueryResult and TestQueryResult_QuotaExceeded), `banyand/stream/block_scanner_test.go`, `banyand/stream/query_by_idx_test.go`, and `banyand/trace/query_test.go`.

## Why only Series_1 failed

Series_2 has the dpsList in the opposite order (lower-version part second). Even when the second part is dropped, the surviving higher-version part matches the expected dedup result, so the race is silently masked there. Series_1 happens to expose the race.

## Test plan

- [x] `make license-check`, `make build`, `make lint`, `make check` clean
- [x] Unit tests under `./banyand/...`, `./bydbctl/...`, `./pkg/...`, `./fodc/...` pass
- [x] `go test -count=20 -run 'TestQueryResult$/Test_with_multiple_parts_with_duplicated_data_with_different_versions_order_by_Series_1$' ./banyand/measure/` — 20/20 pass
- [x] Broader `TestQueryResult` and `*_QuotaExceeded` in measure/stream/trace pass under repeated counts
- [x] Integration suites `./test/integration/standalone/...` and `./test/integration/distributed/...` pass when run sequentially (the unrelated `TestBackup` / `TestPropertySchemaDeletion` only fail when both suites run concurrently with shared ports/disks)