### PR TITLE
Phase 2 Step 2.1: NodeSchemaStatusService

### DIFF
--- a/banyand/liaison/grpc/server.go
+++ b/banyand/liaison/grpc/server.go
@@ -39,6 +39,7 @@ import (
 
 	"github.com/apache/skywalking-banyandb/api/common"
 	bydbqlv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/bydbql/v1"
+	clusterv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/cluster/v1"
 	commonv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/common/v1"
 	databasev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
 	measurev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/measure/v1"
@@ -51,6 +52,7 @@ import (
 	"github.com/apache/skywalking-banyandb/banyand/liaison/pkg/auth"
 	"github.com/apache/skywalking-banyandb/banyand/metadata"
 	"github.com/apache/skywalking-banyandb/banyand/metadata/schema"
+	"github.com/apache/skywalking-banyandb/banyand/metadata/schema/property"
 	"github.com/apache/skywalking-banyandb/banyand/observability"
 	"github.com/apache/skywalking-banyandb/banyand/protector"
 	"github.com/apache/skywalking-banyandb/banyand/queue"
@@ -105,8 +107,9 @@ type server struct {
 	stopCh     chan struct{}
 	*indexRuleRegistryServer
 	*measureRegistryServer
-	streamSVC  *streamService
-	barrierSVC *barrierService
+	streamSVC     *streamService
+	barrierSVC    *barrierService
+	nodeStatusSVC *property.NodeSchemaStatusServer
 	*streamRegistryServer
 	measureSVC *measureService
 	bydbQLSVC  *bydbQLService
@@ -182,6 +185,7 @@ func NewServer(_ context.Context, tir1Client, tir2Client, broadcaster queue.Clie
 	}
 
 	var barrierSVC *barrierService
+	var nodeStatusSVC *property.NodeSchemaStatusServer
 	if svc, svcOk := schemaRegistry.(metadata.Service); svcOk {
 		barrierSVC = newBarrierService(func() barrierCacheReader {
 			inner := svc.SchemaRegistry()
@@ -194,15 +198,24 @@ func NewServer(_ context.Context, tir1Client, tir2Client, broadcaster queue.Clie
 			}
 			return bc
 		})
+		// Phase 2 Step 2.1: every cluster member with a schema cache exposes
+		// NodeSchemaStatusService so peer liaisons (Step 2.2 fan-out) can
+		// probe this liaison's cache identically to a data node. The receiving
+		// liaison probes itself in-process via the barrier above; remote peers
+		// reach this same cache through the gRPC service.
+		if reg, regOk := svc.SchemaRegistry().(*property.SchemaRegistry); regOk && reg != nil {
+			nodeStatusSVC = property.NewNodeSchemaStatusServerForRegistry(reg)
+		}
 	}
 	s := &server{
-		omr:        omr,
-		streamSVC:  streamSVC,
-		measureSVC: measureSVC,
-		traceSVC:   traceSVC,
-		bydbQLSVC:  bydbQLSVC,
-		groupRepo:  gr,
-		barrierSVC: barrierSVC,
+		omr:           omr,
+		streamSVC:     streamSVC,
+		measureSVC:    measureSVC,
+		traceSVC:      traceSVC,
+		bydbQLSVC:     bydbQLSVC,
+		groupRepo:     gr,
+		barrierSVC:    barrierSVC,
+		nodeStatusSVC: nodeStatusSVC,
 		streamRegistryServer: &streamRegistryServer{
 			schemaRegistry: schemaRegistry,
 		},
@@ -508,6 +521,9 @@ func (s *server) Serve() run.StopNotify {
 	databasev1.RegisterNodeQueryServiceServer(s.ser, s)
 	if s.barrierSVC != nil {
 		schemav1.RegisterSchemaBarrierServiceServer(s.ser, s.barrierSVC)
+	}
+	if s.nodeStatusSVC != nil {
+		clusterv1.RegisterNodeSchemaStatusServiceServer(s.ser, s.nodeStatusSVC)
 	}
 	grpc_health_v1.RegisterHealthServer(s.ser, health.NewServer())
 

--- a/banyand/metadata/schema/property/cache.go
+++ b/banyand/metadata/schema/property/cache.go
@@ -194,6 +194,59 @@ func (c *schemaCache) GetKeyModRevision(propID string) (int64, bool) {
 	return entry.modRevision, true
 }
 
+// KeyRevision pairs a property ID with its observed mod_revision and a
+// presence flag. Returned by GetKeyRevisions in the same order the caller
+// supplied propIDs so the cluster RPC handler can join the result with its
+// proto SchemaKey input slice.
+type KeyRevision struct {
+	PropID      string
+	ModRevision int64
+	Present     bool
+}
+
+// GetKeyRevisions returns presence + mod_revision for each propID in a single
+// read-lock pass. It applies the same downstream-coherence gate as
+// GetKeyModRevision: an entry present in the cache map whose mod_revision
+// exceeds notifiedModRevision is reported as Present=false, ModRevision=0.
+// An empty input returns a non-nil empty slice.
+func (c *schemaCache) GetKeyRevisions(propIDs []string) []KeyRevision {
+	out := make([]KeyRevision, len(propIDs))
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	for i, pid := range propIDs {
+		out[i].PropID = pid
+		entry, ok := c.entries[pid]
+		if !ok {
+			continue
+		}
+		if entry.modRevision > c.notifiedModRevision {
+			continue
+		}
+		out[i].ModRevision = entry.modRevision
+		out[i].Present = true
+	}
+	return out
+}
+
+// IsAbsent partitions propIDs into "absent from the cache" and "still present"
+// in a single read-lock pass. The split mirrors GetKeyModRevision's gate:
+// entries whose mod_revision exceeds notifiedModRevision count as absent
+// because downstream handlers have not yet observed them. The returned slices
+// preserve input order within each subset.
+func (c *schemaCache) IsAbsent(propIDs []string) (absent, present []string) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	for _, pid := range propIDs {
+		entry, ok := c.entries[pid]
+		if !ok || entry.modRevision > c.notifiedModRevision {
+			absent = append(absent, pid)
+			continue
+		}
+		present = append(present, pid)
+	}
+	return absent, present
+}
+
 // AdvanceNotified pushes the downstream-handler watermark forward monotonically.
 // Callers must invoke this only after notifyHandlers returns for the given revision,
 // so downstream caches (groupRepo, entityRepo, pkg/schema.schemaRepo, …) are coherent

--- a/banyand/metadata/schema/property/converter.go
+++ b/banyand/metadata/schema/property/converter.go
@@ -149,6 +149,47 @@ func KindFromString(kindStr string) (schema.Kind, error) {
 	return 0, fmt.Errorf("unknown kind string: %s", kindStr)
 }
 
+// kindFromProtoString maps the proto-style kind string from SchemaKey
+// (underscore_case for compound kinds) to the corresponding schema.Kind. The
+// proto schema keeps SchemaKey.kind on a fixed set of values: "stream",
+// "measure", "trace", "property", "index_rule", "index_rule_binding",
+// "group", "top_n_aggregation". An unknown value returns 0 and the caller
+// should treat the SchemaKey as referring to no live entry.
+func kindFromProtoString(protoKind string) schema.Kind {
+	switch protoKind {
+	case "stream":
+		return schema.KindStream
+	case "measure":
+		return schema.KindMeasure
+	case "trace":
+		return schema.KindTrace
+	case "property":
+		return schema.KindProperty
+	case "index_rule":
+		return schema.KindIndexRule
+	case "index_rule_binding":
+		return schema.KindIndexRuleBinding
+	case "group":
+		return schema.KindGroup
+	case "top_n_aggregation":
+		return schema.KindTopNAggregation
+	default:
+		return 0
+	}
+}
+
+// BuildPropertyIDFromSchemaKey converts a SchemaKey from the cluster
+// node-status proto into the property-ID string used internally by the
+// schema cache. Returns an empty string when the kind is unrecognised so
+// the caller can short-circuit instead of looking up a malformed propID.
+func BuildPropertyIDFromSchemaKey(key *schemav1.SchemaKey) string {
+	kind := kindFromProtoString(key.GetKind())
+	if kind == 0 {
+		return ""
+	}
+	return BuildPropertyID(kind, &commonv1.Metadata{Group: key.GetGroup(), Name: key.GetName()})
+}
+
 // ParsedTags holds pre-extracted tag values from a property.
 type ParsedTags struct {
 	Group     string

--- a/banyand/metadata/schema/property/node_status.go
+++ b/banyand/metadata/schema/property/node_status.go
@@ -1,0 +1,161 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package property
+
+import (
+	"context"
+
+	clusterv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/cluster/v1"
+	schemav1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/schema/v1"
+)
+
+// NodeSchemaStatusServer implements clusterv1.NodeSchemaStatusServiceServer
+// against a local SchemaRegistry cache. The same implementation runs on every
+// cluster member that holds a schema cache: liaisons (Role_ROLE_LIAISON) and
+// data nodes (Role_ROLE_DATA). The "Node" prefix in the service name is a
+// misnomer inherited from the original proto draft — treat the service as
+// "cluster-member schema status" regardless of the role serving it.
+//
+// The cache the server reads (the SchemaRegistry's schemaCache) is the same
+// one downstream consumers (pkg/schema.schemaRepo, groupRepo, entityRepo)
+// observe through the property watch loop. The schemaCache.notifiedModRevision
+// watermark only advances after every registered handler has processed the
+// relevant event, so a positive answer from this server (Present=true,
+// rev=R) implies every downstream cache has also observed R. This is the
+// load-bearing prerequisite for the Phase 2 cluster barrier — without it,
+// the barrier would confirm a cache the data-node query executor never reads.
+type NodeSchemaStatusServer struct {
+	clusterv1.UnimplementedNodeSchemaStatusServiceServer
+	cacheProvider func() *schemaCache
+}
+
+// NewNodeSchemaStatusServer wires the server to a cache provider. The
+// provider is called per request so the server tolerates SchemaRegistry
+// initialisation racing the gRPC server boot — an early call simply gets a
+// nil cache and returns zero-valued results, which liaison-side fan-out
+// treats as "node not yet ready, retry on the next backoff iteration"
+// rather than a hard error.
+func NewNodeSchemaStatusServer(cacheProvider func() *schemaCache) *NodeSchemaStatusServer {
+	return &NodeSchemaStatusServer{cacheProvider: cacheProvider}
+}
+
+// NewNodeSchemaStatusServerForRegistry is a convenience constructor for the
+// common case where the caller has a *SchemaRegistry instance and wants the
+// server to read its cache directly.
+func NewNodeSchemaStatusServerForRegistry(reg *SchemaRegistry) *NodeSchemaStatusServer {
+	return &NodeSchemaStatusServer{
+		cacheProvider: func() *schemaCache {
+			if reg == nil {
+				return nil
+			}
+			return reg.cache
+		},
+	}
+}
+
+// GetMaxRevision returns the highest mod_revision currently observed by the
+// node's local schema cache. When the cache is not yet initialised the
+// response carries 0, which the liaison's barrier loop interprets as
+// "node not yet caught up" and continues polling.
+func (s *NodeSchemaStatusServer) GetMaxRevision(_ context.Context, _ *clusterv1.GetMaxRevisionRequest) (*clusterv1.GetMaxRevisionResponse, error) {
+	c := s.cacheProvider()
+	if c == nil {
+		return &clusterv1.GetMaxRevisionResponse{}, nil
+	}
+	return &clusterv1.GetMaxRevisionResponse{MaxModRevision: c.GetMaxModRevision()}, nil
+}
+
+// GetKeyRevisions returns per-key (mod_revision, present) pairs in the same
+// order the caller supplied keys. A key referencing a group the node has
+// not observed maps to mod_revision=0, present=false — the call does not
+// error on missing groups so the liaison can treat group-not-yet-registered
+// as a normal laggard rather than a server fault.
+//
+// An empty request is valid and produces an empty response.
+func (s *NodeSchemaStatusServer) GetKeyRevisions(_ context.Context, req *clusterv1.GetKeyRevisionsRequest) (*clusterv1.GetKeyRevisionsResponse, error) {
+	keys := req.GetKeys()
+	resp := &clusterv1.GetKeyRevisionsResponse{
+		Revisions: make([]*clusterv1.KeyRevision, len(keys)),
+	}
+	for i, key := range keys {
+		resp.Revisions[i] = &clusterv1.KeyRevision{Key: key}
+	}
+	c := s.cacheProvider()
+	if c == nil || len(keys) == 0 {
+		return resp, nil
+	}
+	propIDs := schemaKeysToPropIDs(keys)
+	statuses := c.GetKeyRevisions(propIDs)
+	for i, status := range statuses {
+		resp.Revisions[i].ModRevision = status.ModRevision
+		resp.Revisions[i].Present = status.Present
+	}
+	return resp, nil
+}
+
+// GetAbsentKeys partitions the requested keys into "absent" (i.e. not in the
+// node's live cache or pending downstream notification) and "still_present".
+// A SchemaKey with an unknown kind value is reported in absent_keys without
+// erroring so the caller can rely on the partition adding up to the input.
+func (s *NodeSchemaStatusServer) GetAbsentKeys(_ context.Context, req *clusterv1.GetAbsentKeysRequest) (*clusterv1.GetAbsentKeysResponse, error) {
+	keys := req.GetKeys()
+	resp := &clusterv1.GetAbsentKeysResponse{}
+	if len(keys) == 0 {
+		return resp, nil
+	}
+	c := s.cacheProvider()
+	if c == nil {
+		// Cache not yet initialised — every requested key is treated as absent
+		// from the local perspective. The liaison's barrier will retry on the
+		// next backoff iteration once the cache is online.
+		resp.AbsentKeys = append([]*schemav1.SchemaKey(nil), keys...)
+		return resp, nil
+	}
+	propIDs := schemaKeysToPropIDs(keys)
+	for i, key := range keys {
+		propID := propIDs[i]
+		if propID == "" {
+			// Unknown kind — treat as absent so the caller's "every key absent"
+			// invariant holds without surfacing a parse error.
+			resp.AbsentKeys = append(resp.AbsentKeys, key)
+			continue
+		}
+		// GetKeyModRevision handles both the cache-map lookup and the
+		// notifiedModRevision gate atomically under the cache's read lock,
+		// matching the semantics that AwaitSchemaDeleted's collectPresentKeys
+		// already relies on.
+		if _, ok := c.GetKeyModRevision(propID); !ok {
+			resp.AbsentKeys = append(resp.AbsentKeys, key)
+			continue
+		}
+		resp.StillPresentKeys = append(resp.StillPresentKeys, key)
+	}
+	return resp, nil
+}
+
+// schemaKeysToPropIDs converts a slice of SchemaKey messages into the
+// internal propID strings used by the schema cache. Keys with unknown kind
+// strings produce an empty propID at the corresponding index — callers
+// must check for "" before using the result as a cache lookup key.
+func schemaKeysToPropIDs(keys []*schemav1.SchemaKey) []string {
+	out := make([]string, len(keys))
+	for i, key := range keys {
+		out[i] = BuildPropertyIDFromSchemaKey(key)
+	}
+	return out
+}

--- a/banyand/metadata/schema/property/node_status_test.go
+++ b/banyand/metadata/schema/property/node_status_test.go
@@ -1,0 +1,266 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package property
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	clusterv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/cluster/v1"
+	schemav1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/schema/v1"
+	"github.com/apache/skywalking-banyandb/banyand/metadata/schema"
+)
+
+// nodeStatusFixture builds a NodeSchemaStatusServer backed by a fresh schemaCache
+// pre-loaded with the supplied entries. The notifiedModRevision watermark is
+// advanced to the highest entry revision so every entry is downstream-coherent
+// (the production path advances the watermark only after handlers process the
+// event; tests bypass the handler chain by setting it directly).
+func nodeStatusFixture(t *testing.T, entries map[string]*cacheEntry) *NodeSchemaStatusServer {
+	t.Helper()
+	c := newSchemaCache()
+	var maxRev int64
+	for propID, entry := range entries {
+		c.entries[propID] = entry
+		if entry.modRevision > maxRev {
+			maxRev = entry.modRevision
+		}
+		if entry.latestUpdateAt > c.latestUpdateAt {
+			c.latestUpdateAt = entry.latestUpdateAt
+		}
+	}
+	c.notifiedModRevision = maxRev
+	return NewNodeSchemaStatusServer(func() *schemaCache { return c })
+}
+
+func makeEntry(kind schema.Kind, group, name string, rev int64) (string, *cacheEntry) {
+	propID := kind.String() + "_"
+	if kind == schema.KindGroup {
+		propID += name
+	} else {
+		propID += group + "/" + name
+	}
+	return propID, &cacheEntry{
+		group:          group,
+		name:           name,
+		kind:           kind,
+		modRevision:    rev,
+		latestUpdateAt: rev,
+	}
+}
+
+func TestGetMaxRevision_ReflectsLatestApply(t *testing.T) {
+	id, entry := makeEntry(schema.KindMeasure, "g1", "m1", 42)
+	srv := nodeStatusFixture(t, map[string]*cacheEntry{id: entry})
+
+	resp, err := srv.GetMaxRevision(context.Background(), &clusterv1.GetMaxRevisionRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, int64(42), resp.GetMaxModRevision())
+}
+
+func TestGetMaxRevision_UnchangedByQuery(t *testing.T) {
+	id, entry := makeEntry(schema.KindStream, "g1", "s1", 100)
+	srv := nodeStatusFixture(t, map[string]*cacheEntry{id: entry})
+
+	first, err := srv.GetMaxRevision(context.Background(), &clusterv1.GetMaxRevisionRequest{})
+	require.NoError(t, err)
+	second, err := srv.GetMaxRevision(context.Background(), &clusterv1.GetMaxRevisionRequest{})
+	require.NoError(t, err)
+	third, err := srv.GetMaxRevision(context.Background(), &clusterv1.GetMaxRevisionRequest{})
+	require.NoError(t, err)
+
+	assert.Equal(t, first.GetMaxModRevision(), second.GetMaxModRevision())
+	assert.Equal(t, second.GetMaxModRevision(), third.GetMaxModRevision())
+}
+
+func TestGetMaxRevision_NilCache_ReturnsZero(t *testing.T) {
+	srv := NewNodeSchemaStatusServer(func() *schemaCache { return nil })
+
+	resp, err := srv.GetMaxRevision(context.Background(), &clusterv1.GetMaxRevisionRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), resp.GetMaxModRevision())
+}
+
+func TestGetKeyRevisions_PresentAndAbsent(t *testing.T) {
+	idMeasure, entryMeasure := makeEntry(schema.KindMeasure, "g1", "m1", 50)
+	idStream, entryStream := makeEntry(schema.KindStream, "g1", "s1", 70)
+	srv := nodeStatusFixture(t, map[string]*cacheEntry{
+		idMeasure: entryMeasure,
+		idStream:  entryStream,
+	})
+
+	req := &clusterv1.GetKeyRevisionsRequest{
+		Keys: []*schemav1.SchemaKey{
+			{Kind: "measure", Group: "g1", Name: "m1"},     // present, rev 50
+			{Kind: "measure", Group: "g1", Name: "absent"}, // absent
+			{Kind: "stream", Group: "g1", Name: "s1"},      // present, rev 70
+			{Kind: "trace", Group: "g1", Name: "absent"},   // absent (group with no entries)
+		},
+	}
+
+	resp, err := srv.GetKeyRevisions(context.Background(), req)
+	require.NoError(t, err)
+	require.Len(t, resp.GetRevisions(), 4, "response preserves input order and length")
+
+	assert.True(t, resp.Revisions[0].GetPresent())
+	assert.Equal(t, int64(50), resp.Revisions[0].GetModRevision())
+	assert.Equal(t, "m1", resp.Revisions[0].GetKey().GetName())
+
+	assert.False(t, resp.Revisions[1].GetPresent())
+	assert.Equal(t, int64(0), resp.Revisions[1].GetModRevision())
+
+	assert.True(t, resp.Revisions[2].GetPresent())
+	assert.Equal(t, int64(70), resp.Revisions[2].GetModRevision())
+
+	assert.False(t, resp.Revisions[3].GetPresent())
+	assert.Equal(t, int64(0), resp.Revisions[3].GetModRevision())
+}
+
+func TestGetKeyRevisions_UnknownKind_ReportedAbsent(t *testing.T) {
+	srv := nodeStatusFixture(t, map[string]*cacheEntry{})
+
+	req := &clusterv1.GetKeyRevisionsRequest{
+		Keys: []*schemav1.SchemaKey{
+			{Kind: "not_a_real_kind", Group: "g1", Name: "x"},
+		},
+	}
+
+	resp, err := srv.GetKeyRevisions(context.Background(), req)
+	require.NoError(t, err)
+	require.Len(t, resp.GetRevisions(), 1)
+	assert.False(t, resp.Revisions[0].GetPresent())
+}
+
+func TestGetKeyRevisions_NotYetNotified_ReportedAbsent(t *testing.T) {
+	// Entry exists in cache map but its mod_revision exceeds notifiedModRevision —
+	// downstream handlers have not yet processed it. Per the gate semantics in
+	// GetKeyModRevision, the server must report it as not present.
+	c := newSchemaCache()
+	id, entry := makeEntry(schema.KindMeasure, "g1", "m1", 100)
+	c.entries[id] = entry
+	c.notifiedModRevision = 50 // below entry's rev
+	srv := NewNodeSchemaStatusServer(func() *schemaCache { return c })
+
+	req := &clusterv1.GetKeyRevisionsRequest{
+		Keys: []*schemav1.SchemaKey{
+			{Kind: "measure", Group: "g1", Name: "m1"},
+		},
+	}
+
+	resp, err := srv.GetKeyRevisions(context.Background(), req)
+	require.NoError(t, err)
+	require.Len(t, resp.GetRevisions(), 1)
+	assert.False(t, resp.Revisions[0].GetPresent(),
+		"entry not yet notified to downstream handlers must report Present=false")
+	assert.Equal(t, int64(0), resp.Revisions[0].GetModRevision())
+}
+
+func TestGetAbsentKeys_PostDelete(t *testing.T) {
+	// Two entries exist; one will be removed; the third reference is to an
+	// entry that never existed. Expectation: the deleted key and the
+	// never-existed key end up in absent_keys; the surviving key in
+	// still_present_keys.
+	idAlive, entryAlive := makeEntry(schema.KindMeasure, "g1", "alive", 30)
+	idDead, entryDead := makeEntry(schema.KindMeasure, "g1", "dead", 40)
+	c := newSchemaCache()
+	c.entries[idAlive] = entryAlive
+	c.entries[idDead] = entryDead
+	c.notifiedModRevision = 40
+	c.latestUpdateAt = 40
+	// Simulate a delete event for the "dead" key at a higher revision.
+	require.True(t, c.Delete(idDead, 50))
+	c.AdvanceNotified(50)
+	srv := NewNodeSchemaStatusServer(func() *schemaCache { return c })
+
+	req := &clusterv1.GetAbsentKeysRequest{
+		Keys: []*schemav1.SchemaKey{
+			{Kind: "measure", Group: "g1", Name: "alive"},
+			{Kind: "measure", Group: "g1", Name: "dead"},
+			{Kind: "measure", Group: "g1", Name: "never"},
+		},
+	}
+
+	resp, err := srv.GetAbsentKeys(context.Background(), req)
+	require.NoError(t, err)
+	require.Len(t, resp.GetStillPresentKeys(), 1)
+	assert.Equal(t, "alive", resp.GetStillPresentKeys()[0].GetName())
+
+	require.Len(t, resp.GetAbsentKeys(), 2)
+	absentNames := []string{
+		resp.GetAbsentKeys()[0].GetName(),
+		resp.GetAbsentKeys()[1].GetName(),
+	}
+	assert.Contains(t, absentNames, "dead")
+	assert.Contains(t, absentNames, "never")
+}
+
+func TestGetAbsentKeys_NilCache_AllAbsent(t *testing.T) {
+	srv := NewNodeSchemaStatusServer(func() *schemaCache { return nil })
+
+	req := &clusterv1.GetAbsentKeysRequest{
+		Keys: []*schemav1.SchemaKey{
+			{Kind: "measure", Group: "g1", Name: "x"},
+			{Kind: "stream", Group: "g1", Name: "y"},
+		},
+	}
+
+	resp, err := srv.GetAbsentKeys(context.Background(), req)
+	require.NoError(t, err)
+	assert.Len(t, resp.GetAbsentKeys(), 2,
+		"nil cache reports every requested key as absent so the liaison fan-out retries")
+	assert.Empty(t, resp.GetStillPresentKeys())
+}
+
+func TestGetKeyRevisions_ChunkedAtLimit(t *testing.T) {
+	// Server accepts a request well above the typical 1000-key chunk size used
+	// by the liaison fan-out. The proto does not enforce a hard cap on
+	// GetKeyRevisions — chunking is the caller's responsibility — so the server
+	// must process whatever it is handed without truncation or error.
+	const total = 1500
+	entries := make(map[string]*cacheEntry, total)
+	keys := make([]*schemav1.SchemaKey, total)
+	for i := range total {
+		name := "m" + strconv.Itoa(i)
+		id, entry := makeEntry(schema.KindMeasure, "g1", name, int64(i+1))
+		entries[id] = entry
+		keys[i] = &schemav1.SchemaKey{Kind: "measure", Group: "g1", Name: name}
+	}
+	srv := nodeStatusFixture(t, entries)
+
+	resp, err := srv.GetKeyRevisions(context.Background(), &clusterv1.GetKeyRevisionsRequest{Keys: keys})
+	require.NoError(t, err)
+	require.Len(t, resp.GetRevisions(), total)
+	for i := range total {
+		assert.True(t, resp.Revisions[i].GetPresent(), "key %d must be present", i)
+		assert.Equal(t, int64(i+1), resp.Revisions[i].GetModRevision(),
+			"key %d carries its assigned revision", i)
+	}
+}
+
+func TestGetKeyRevisions_EmptyRequest_ReturnsEmpty(t *testing.T) {
+	srv := nodeStatusFixture(t, map[string]*cacheEntry{})
+
+	resp, err := srv.GetKeyRevisions(context.Background(), &clusterv1.GetKeyRevisionsRequest{})
+	require.NoError(t, err)
+	assert.Empty(t, resp.GetRevisions(),
+		"empty key list yields empty response without panic")
+}

--- a/banyand/queue/sub/server.go
+++ b/banyand/queue/sub/server.go
@@ -48,6 +48,7 @@ import (
 	tracev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/trace/v1"
 	"github.com/apache/skywalking-banyandb/banyand/liaison/grpc/route"
 	"github.com/apache/skywalking-banyandb/banyand/metadata"
+	"github.com/apache/skywalking-banyandb/banyand/metadata/schema/property"
 	"github.com/apache/skywalking-banyandb/banyand/observability"
 	"github.com/apache/skywalking-banyandb/banyand/queue"
 	"github.com/apache/skywalking-banyandb/pkg/bus"
@@ -291,6 +292,17 @@ func (s *server) Serve() run.StopNotify {
 	tracev1.RegisterTraceServiceServer(s.ser, &traceService{ser: s})
 	if s.metadataRepo != nil {
 		fodcv1.RegisterGroupLifecycleServiceServer(s.ser, s)
+		// Phase 2 Step 2.1: data nodes expose NodeSchemaStatusService so the
+		// liaison's barrier fan-out (Step 2.2) can probe each node's local
+		// schema cache. The cache the server reads is the same SchemaRegistry
+		// instance the data-node query executor consults — see
+		// banyand/metadata/schema/property/node_status.go for the coherence
+		// argument.
+		if svc, svcOk := s.metadataRepo.(metadata.Service); svcOk {
+			if reg, regOk := svc.SchemaRegistry().(*property.SchemaRegistry); regOk && reg != nil {
+				clusterv1.RegisterNodeSchemaStatusServiceServer(s.ser, property.NewNodeSchemaStatusServerForRegistry(reg))
+			}
+		}
 	}
 
 	var ctx context.Context


### PR DESCRIPTION
## Summary

Step 2.1 of the BanyanDB schema-consistency Phase 2 plan: introduces `NodeSchemaStatusService`, the per-cluster-member RPC that the liaison's distributed barrier fan-out (Steps 2.2 / 2.3 / 2.4) will use to probe every liaison's and every data node's local schema cache.

Phase 1 (#1091, shipped in v0.11.0) made `AwaitRevisionApplied` / `AwaitSchemaApplied` / `AwaitSchemaDeleted` confirm only the **receiving liaison's** cache. This step lays the groundwork for confirming the **whole cluster** — liaisons + data nodes — without touching the existing wire surface.

This PR targets **v0.13.0**. The 0.13.0 milestone does not exist in the repo yet; please set it on this PR if/when it's created.

## Deliverables

- **Cache batch helpers** in `banyand/metadata/schema/property/cache.go`:
  - `GetKeyRevisions(propIDs) []KeyRevision` — single-pass batch lookup; same downstream-coherence gate as the existing `GetKeyModRevision`.
  - `IsAbsent(propIDs) (absent, present []string)` — partitions a propID list under one read lock.

- **Schema-key conversion** in `banyand/metadata/schema/property/converter.go`:
  - `BuildPropertyIDFromSchemaKey(*schemav1.SchemaKey) string` and `kindFromProtoString` translate the proto SchemaKey (underscore_case kind) into the internal propID format.

- **Server implementation** in `banyand/metadata/schema/property/node_status.go`:
  - `NodeSchemaStatusServer` implements all three RPCs against a `*SchemaRegistry`.
  - The cache it reads is the same `SchemaRegistry` instance the data-node query executor consults via `pkg/schema.schemaRepo` — so a positive answer (`Present=true, rev=R`) implies every downstream cache observed `R`. This satisfies the cache-layer prerequisite called out in the plan for Step 2.5.
  - Missing-group semantics: `GetKeyRevisions` returns `mod_revision=0, present=false` (no error) for unknown groups so the liaison can treat group-not-yet-registered as a normal laggard.
  - Nil-cache tolerance: an early call before `SchemaRegistry` is initialised returns zero-valued results so the liaison's barrier loop simply retries.

- **Server registration**:
  - `banyand/liaison/grpc/server.go` — registered alongside `SchemaBarrierService` so peer liaisons can probe each other.
  - `banyand/queue/sub/server.go` — registered on data nodes via the existing `metadataRepo` handle, behind the same nil-check that gates other metadata-dependent services.

## Cross-version compatibility (forward-looking)

During a v0.12 → v0.13 rolling upgrade, a v0.13 liaison may probe a v0.11/v0.12 data node that does not implement `NodeSchemaStatusService`. The data node returns `codes.Unimplemented`. The liaison-side caller in **Step 2.2** (not in this PR) must treat this as "node ready" (`max_revision = ∞`) so partial-upgrade clusters do not deadlock all barrier callers. The server itself is wire-compatible; only the caller needs the policy.

## Tests

`banyand/metadata/schema/property/node_status_test.go`:

- `TestGetMaxRevision_ReflectsLatestApply` — after store at rev=R, RPC returns R
- `TestGetMaxRevision_UnchangedByQuery` — repeated calls read the same snapshot
- `TestGetMaxRevision_NilCache_ReturnsZero` — defensive default
- `TestGetKeyRevisions_PresentAndAbsent` — mixed presence preserves input order
- `TestGetKeyRevisions_UnknownKind_ReportedAbsent` — invalid SchemaKey kind doesn't error
- `TestGetKeyRevisions_NotYetNotified_ReportedAbsent` — entry with `modRevision > notifiedModRevision` reports absent (downstream-coherence regression)
- `TestGetKeyRevisions_ChunkedAtLimit` — 1500-key request, no truncation
- `TestGetKeyRevisions_EmptyRequest_ReturnsEmpty` — empty input handled
- `TestGetAbsentKeys_PostDelete` — partitions correctly across alive / deleted / never-existed keys
- `TestGetAbsentKeys_NilCache_AllAbsent` — defensive default

All 10 new tests pass; no regressions in the existing property / liaison-grpc test suites.

## CI verified locally

- `make license-check && make check-req && make build && make lint && make check` — green
- `make test-ci PKG=./banyand/...` — green
- `make test-ci PKG=./pkg/...` — green

## Out of scope

- **No client-proto sync** — `NodeSchemaStatusService` is internal liaison↔data-node RPC, not part of the OAP-facing surface.
- **No barrier fan-out** — the liaison's per-cluster-member fan-out is Step 2.2.
- **No query-gate work** — Step 2.5 layers the cluster-wide query gate on top of these primitives.

## References

- Phase 1: #1091 (merged in v0.11.0)
- Plan: `.omc/plans/banyandb-schema-tbd-plan.md` §5 Step 2.1 (gitignored; happy to share excerpts)