### PR TITLE
feat(queue): expose NodeSchemaStatus client borrow on queue.Client (Phase 2.2 prep)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,9 @@ Release Notes.
   - Add tombstone retention/GC (default 7 days, configurable via `--schema-server-tombstone-retention`) with a per-cache count cap to bound memory under bulk deletes.
   - Reject `Create` with `updated_at <= tombstone.delete_time` to prevent replayed creates from overwriting newer deletes.
   - Guard `pkg/schema/cache` against out-of-order `EventDelete` events; expose monotonic `LatestModRevision` watermark.
+- Schema consistency (Phase 2 in progress): cluster-wide barrier groundwork. Internal-only; no client-facing surface impact yet.
+  - Add `NodeSchemaStatusService` (`GetMaxRevision`, `GetKeyRevisions`, `GetAbsentKeys`) registered on every cluster member that holds a schema cache, so peer liaisons and data nodes can be probed identically by the upcoming barrier fan-out (#1108).
+  - Extend `queue.Client` with `NewNodeSchemaStatusClient(node)` so the barrier fan-out can borrow the existing tier1/tier2 connection pools instead of opening a parallel mesh.
 
 ### Bug Fixes
 

--- a/banyand/queue/local.go
+++ b/banyand/queue/local.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/apache/skywalking-banyandb/api/common"
+	clusterv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/cluster/v1"
 	databasev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
 	"github.com/apache/skywalking-banyandb/banyand/liaison/grpc/route"
 	"github.com/apache/skywalking-banyandb/banyand/metadata"
@@ -177,6 +178,13 @@ func (l *local) RegisterChunkedSyncHandler(_ bus.Topic, _ ChunkedSyncHandler) {
 
 func (l *local) NewChunkedSyncClient(node string, _ uint32) (ChunkedSyncClient, error) {
 	return &localChunkedSyncClient{local: l.local, node: node}, nil
+}
+
+// NewNodeSchemaStatusClient returns ErrNotImplemented because the standalone
+// pipeline has no peer to dial. The cluster barrier fan-out (Step 2.2) treats
+// this sentinel as a signal to degrade to in-process self-probing.
+func (*local) NewNodeSchemaStatusClient(_ string) (clusterv1.NodeSchemaStatusServiceClient, error) {
+	return nil, ErrNotImplemented
 }
 
 type localChunkedSyncClient struct {

--- a/banyand/queue/pub/pub.go
+++ b/banyand/queue/pub/pub.go
@@ -564,3 +564,17 @@ func (p *pub) NewChunkedSyncClientWithConfig(node string, config *ChunkedSyncCli
 func (p *pub) HealthyNodes() []string {
 	return p.connMgr.ActiveNames()
 }
+
+// NewNodeSchemaStatusClient borrows the underlying *grpc.ClientConn from the
+// connection pool and wraps it as a clusterv1.NodeSchemaStatusServiceClient
+// so the cluster-barrier fan-out (Step 2.2) can probe peer caches without
+// opening parallel connections. The returned client shares the conn's HTTP/2
+// streams with normal queue traffic; per-RPC contexts carry their own
+// deadlines.
+func (p *pub) NewNodeSchemaStatusClient(node string) (clusterv1.NodeSchemaStatusServiceClient, error) {
+	c, ok := p.connMgr.GetClient(node)
+	if !ok {
+		return nil, fmt.Errorf("no active client for node %s", node)
+	}
+	return clusterv1.NewNodeSchemaStatusServiceClient(c.conn), nil
+}

--- a/banyand/queue/queue.go
+++ b/banyand/queue/queue.go
@@ -19,6 +19,7 @@ package queue
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -31,6 +32,13 @@ import (
 	"github.com/apache/skywalking-banyandb/pkg/fs"
 	"github.com/apache/skywalking-banyandb/pkg/run"
 )
+
+// ErrNotImplemented is returned by Client implementations that have no peers
+// to dial — notably the standalone local pipeline. Callers (e.g. the cluster
+// barrier fan-out) treat this sentinel as "no peer to probe; skip" rather
+// than as a hard failure, so the standalone path degrades to in-process
+// self-probing without a special-cased branch in the caller.
+var ErrNotImplemented = errors.New("not implemented")
 
 // Queue builds a data transmission tunnel between subscribers and publishers.
 //
@@ -51,6 +59,12 @@ type Client interface {
 	route.TableProvider
 	NewBatchPublisher(timeout time.Duration) BatchPublisher
 	NewChunkedSyncClient(node string, chunkSize uint32) (ChunkedSyncClient, error)
+	// NewNodeSchemaStatusClient returns a client for the cluster.v1
+	// NodeSchemaStatusService against the named node, sharing the underlying
+	// *grpc.ClientConn from this queue client's existing connection pool.
+	// The standalone local pipeline returns ErrNotImplemented so callers can
+	// treat it as "no peer to probe" without a type-switch.
+	NewNodeSchemaStatusClient(node string) (clusterv1.NodeSchemaStatusServiceClient, error)
 	Register(bus.Topic, schema.EventHandler)
 	OnAddOrUpdate(md schema.Metadata)
 	GracefulStop()


### PR DESCRIPTION
### Phase 2.2 prep — borrow `NodeSchemaStatusServiceClient` over `queue.Client`'s existing connection pool

The Phase 2 cluster-barrier fan-out (Step 2.2, follow-up PR) probes peer liaisons and data nodes via the per-node `clusterv1.NodeSchemaStatusService` that landed in #1108. Rather than open a parallel connection mesh, the fan-out borrows the `*grpc.ClientConn` that `pub` already maintains for each tier — same conns, same auth, same health-checks, same lifecycle.

This PR is the enabling shim. No callers yet; the fan-out itself lands in a follow-up.

**What changes**

- `banyand/queue/queue.go`: add `NewNodeSchemaStatusClient(node)` to the `Client` interface, mirroring the existing `NewChunkedSyncClient` shape. Also add a sentinel `ErrNotImplemented` for backends with no peer to dial.
- `banyand/queue/pub/pub.go`: implement by calling `connMgr.GetClient(node)` and wrapping `c.conn` with `clusterv1.NewNodeSchemaStatusServiceClient`. ~10 LOC, identical pattern to `NewChunkedSyncClientWithConfig` (line 543).
- `banyand/queue/local.go`: stub returns `ErrNotImplemented` so the standalone path naturally degrades to in-process self-probing without a type switch on the queue client.
- `banyand/queue/pipeline_mock.go`: regenerated. Gitignored (per `.gitignore` line 60), so not committed; CI/dev regen on first build.
- `CHANGES.md`: open a "Schema consistency (Phase 2 in progress)" sub-group under `## 0.11.0`. Phase 2 work continues to land in 0.11.0 until that section closes; subsequent Step 2.2 / 2.3 / 2.4 PRs accrete sub-bullets here.

**Why ride pub's existing pools instead of opening a separate mesh**

- Avoids doubling the per-node connection count.
- Inherits the existing auth interceptor chain, TLS reloader, and circuit breaker.
- Inherits node add/remove events from `KindNode` schema watch, so the barrier's view of cluster membership is already up to date with whatever pub sees.
- The barrier RPCs are tiny (`GetMaxRevisionRequest{}` is empty; per-call ~1 ms turnaround), so HTTP/2 stream contention with normal queue traffic is rounding error at expected fan-out widths (≤ ~10 polls × N peers per 5-second budget). Will re-evaluate at Step 2.8 if metrics surface contention.

**Local CI** (mirrors `.github/workflows/ci.yml`): green on all phases — `make license-check / check-req / build / lint / check`, every unit-test package (`banyand/...`, `bydbctl/...`, `pkg/...`, `fodc/...`), both integration suites (`./test/integration/standalone/...` 28 specs, `./test/integration/distributed/...` 6 specs). Two flakes recovered on retry (`health_check_test.go:145` HTTP-server-port race; `query_gate.go:190` distributed schema race that Phase 2.2 itself is supposed to close), both unrelated to this prep change.

**Checklist (per `.github/PULL_REQUEST_TEMPLATE`)**

- [x] Non-trivial feature; design doc: refs #1091 (Phase 1 umbrella) and #1108 (Phase 2 Step 2.1).
- [x] Documentation: interface comments describe contract; CHANGES.md updated under existing 0.11.0 section.
- [ ] Tests added: this PR is a pure-internal interface addition with no behavioural change. The fan-out follow-up brings 11 unit tests + distributed integration.
- [ ] UI-related — N/A.
- [ ] Closes/resolves/fixes existing issue — N/A; tracking continues under #1091's umbrella.

**Out of scope (deferred to follow-ups)**

- Cluster-barrier fan-out for `AwaitRevisionApplied` — Step 2.2.
- Fan-out for `AwaitSchemaApplied` / `AwaitSchemaDeleted` — Steps 2.3 / 2.4.
- Distributed integration specs §6.12a/b/d — gated on `PauseDataNodeWatch` helper from Step 1.0 (not yet implemented).