### PR TITLE
[DRAFT for CP-5 review] Phase 2 cluster barrier — Steps 2.2 / 2.3 / 2.4 cumulative

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,10 +31,13 @@ Release Notes.
   - Add tombstone retention/GC (default 7 days, configurable via `--schema-server-tombstone-retention`) with a per-cache count cap to bound memory under bulk deletes.
   - Reject `Create` with `updated_at <= tombstone.delete_time` to prevent replayed creates from overwriting newer deletes.
   - Guard `pkg/schema/cache` against out-of-order `EventDelete` events; expose monotonic `LatestModRevision` watermark.
-- Schema consistency (Phase 2 in progress): cluster-wide barrier groundwork. Internal-only; no client-facing surface impact yet.
-  - Add `NodeSchemaStatusService` (`GetMaxRevision`, `GetKeyRevisions`, `GetAbsentKeys`) registered on every cluster member that holds a schema cache, so peer liaisons and data nodes can be probed identically by the upcoming barrier fan-out (#1108).
+- Schema consistency (Phase 2 in progress): cluster-wide barrier. Internal-only; no client-facing surface impact yet.
+  - Add `NodeSchemaStatusService` (`GetMaxRevision`, `GetKeyRevisions`, `GetAbsentKeys`) registered on every cluster member that holds a schema cache, so peer liaisons and data nodes can be probed identically by the barrier fan-out (#1108).
   - Extend `queue.Client` with `NewNodeSchemaStatusClient(node)` so the barrier fan-out can borrow the existing tier1/tier2 connection pools instead of opening a parallel mesh (#1109).
   - `AwaitRevisionApplied` now fans out across the receiving liaison's frozen tier1 (peer-liaison) + tier2 (data-node) Active set, probing each member in parallel via `GetMaxRevision` with shared per-call deadline. Cross-version peers returning `codes.Unimplemented` are treated as ready so partial-upgrade clusters do not deadlock; transient RPC errors count as per-iteration laggards. Empty Active set fails fast with `codes.Unavailable`.
+  - Frozen-snapshot mid-call semantics: members that transition `Active → Evictable` during a call are dropped from subsequent probes and surfaced once as a `NodeLaggard{reason="evicted_during_poll"}`; members that disappear from the route table altogether are dropped silently; late joiners are excluded from the watched set until the next call. Adds `reason` field (5) to `NodeLaggard` proto.
+  - `AwaitSchemaApplied` and `AwaitSchemaDeleted` follow the same fan-out shape using `GetKeyRevisions` / `GetAbsentKeys` respectively, with per-node calls chunked at 1000 keys and a shared call-wide deadline (no equal-slice division across chunks). Per-node laggards carry the per-member `missing_keys` / `still_present_keys` they observed.
+  - Re-enable §4.6.2 distributed spec (no Write→Query baseline). §6.8, §6.11, §4.6.4 remain skipped pending Step 2.5's cluster query gate.
 
 ### Bug Fixes
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,7 +33,8 @@ Release Notes.
   - Guard `pkg/schema/cache` against out-of-order `EventDelete` events; expose monotonic `LatestModRevision` watermark.
 - Schema consistency (Phase 2 in progress): cluster-wide barrier groundwork. Internal-only; no client-facing surface impact yet.
   - Add `NodeSchemaStatusService` (`GetMaxRevision`, `GetKeyRevisions`, `GetAbsentKeys`) registered on every cluster member that holds a schema cache, so peer liaisons and data nodes can be probed identically by the upcoming barrier fan-out (#1108).
-  - Extend `queue.Client` with `NewNodeSchemaStatusClient(node)` so the barrier fan-out can borrow the existing tier1/tier2 connection pools instead of opening a parallel mesh.
+  - Extend `queue.Client` with `NewNodeSchemaStatusClient(node)` so the barrier fan-out can borrow the existing tier1/tier2 connection pools instead of opening a parallel mesh (#1109).
+  - `AwaitRevisionApplied` now fans out across the receiving liaison's frozen tier1 (peer-liaison) + tier2 (data-node) Active set, probing each member in parallel via `GetMaxRevision` with shared per-call deadline. Cross-version peers returning `codes.Unimplemented` are treated as ready so partial-upgrade clusters do not deadlock; transient RPC errors count as per-iteration laggards. Empty Active set fails fast with `codes.Unavailable`.
 
 ### Bug Fixes
 

--- a/api/proto/banyandb/schema/v1/barrier.proto
+++ b/api/proto/banyandb/schema/v1/barrier.proto
@@ -55,14 +55,18 @@ message AwaitRevisionAppliedRequest {
   google.protobuf.Duration timeout = 2;
 }
 
-// NodeLaggard reports a single data node that has not caught up to the
-// requested schema state. missing_keys is populated by AwaitSchemaApplied
-// responses; still_present_keys is populated by AwaitSchemaDeleted responses.
+// NodeLaggard reports a single cluster member (peer liaison or data node)
+// that has not caught up to the requested schema state. missing_keys is
+// populated by AwaitSchemaApplied responses; still_present_keys by
+// AwaitSchemaDeleted responses. reason is set when the laggard exists for a
+// non-default cause (e.g. "evicted_during_poll" when the cluster transitioned
+// the member from Active to Evictable mid-call); empty otherwise.
 message NodeLaggard {
   string node = 1;
   int64 current_mod_revision = 2;
   repeated SchemaKey missing_keys = 3;
   repeated SchemaKey still_present_keys = 4;
+  string reason = 5;
 }
 
 // AwaitRevisionAppliedResponse reports whether every node reached the target

--- a/banyand/liaison/grpc/barrier.go
+++ b/banyand/liaison/grpc/barrier.go
@@ -138,8 +138,14 @@ func (b *barrierService) AwaitRevisionApplied(ctx context.Context, req *schemav1
 }
 
 // AwaitSchemaApplied blocks until all requested keys are present at or above their
-// per-key min_revisions, or the timeout elapses.
+// per-key min_revisions, or the timeout elapses. When the cluster fan-out
+// dependencies are wired (production), the call probes the frozen tier1 +
+// tier2 + self watched set in parallel via GetKeyRevisions; without them
+// (Phase 1 unit-test path), it falls back to a single in-process cache poll.
 func (b *barrierService) AwaitSchemaApplied(ctx context.Context, req *schemav1.AwaitSchemaAppliedRequest) (*schemav1.AwaitSchemaAppliedResponse, error) {
+	if b.peerLiaisons != nil && b.dataNodes != nil && b.selfName != nil {
+		return b.awaitSchemaAppliedCluster(ctx, req)
+	}
 	if len(req.GetKeys()) > barrierMaxKeys {
 		return nil, status.Errorf(codes.InvalidArgument, "too many keys: max=%d", barrierMaxKeys)
 	}

--- a/banyand/liaison/grpc/barrier.go
+++ b/banyand/liaison/grpc/barrier.go
@@ -176,9 +176,15 @@ func (b *barrierService) AwaitSchemaApplied(ctx context.Context, req *schemav1.A
 	}
 }
 
-// AwaitSchemaDeleted blocks until all requested keys are absent from the cache,
-// or the timeout elapses.
+// AwaitSchemaDeleted blocks until all requested keys are absent from the
+// cache, or the timeout elapses. When the cluster fan-out dependencies are
+// wired (production), the call probes the frozen tier1 + tier2 + self
+// watched set in parallel via GetAbsentKeys; without them (Phase 1
+// unit-test path), it falls back to a single in-process cache poll.
 func (b *barrierService) AwaitSchemaDeleted(ctx context.Context, req *schemav1.AwaitSchemaDeletedRequest) (*schemav1.AwaitSchemaDeletedResponse, error) {
+	if b.peerLiaisons != nil && b.dataNodes != nil && b.selfName != nil {
+		return b.awaitSchemaDeletedCluster(ctx, req)
+	}
 	if len(req.GetKeys()) > barrierMaxKeys {
 		return nil, status.Errorf(codes.InvalidArgument, "too many keys: max=%d", barrierMaxKeys)
 	}

--- a/banyand/liaison/grpc/barrier.go
+++ b/banyand/liaison/grpc/barrier.go
@@ -27,6 +27,7 @@ import (
 
 	schemav1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/schema/v1"
 	"github.com/apache/skywalking-banyandb/banyand/metadata/schema"
+	"github.com/apache/skywalking-banyandb/banyand/queue"
 )
 
 const (
@@ -52,10 +53,36 @@ type barrierCacheReader interface {
 type barrierService struct {
 	schemav1.UnimplementedSchemaBarrierServiceServer
 	cacheProvider func() barrierCacheReader
+	// peerLiaisons / dataNodes / selfName are the Phase 2.2 cluster fan-out
+	// dependencies. When all three are set, AwaitRevisionApplied probes the
+	// frozen tier1+tier2 watched set in parallel; when any are nil it falls
+	// back to the legacy in-process loop (used by Phase 1 unit tests).
+	peerLiaisons func() queue.Client
+	dataNodes    func() queue.Client
+	selfName     func() string
 }
 
 func newBarrierService(cacheProvider func() barrierCacheReader) *barrierService {
 	return &barrierService{cacheProvider: cacheProvider}
+}
+
+// newBarrierServiceCluster wires the Phase 2.2 cluster fan-out dependencies
+// alongside the cache provider. The receiving liaison's name and the per-tier
+// queue clients are resolved via closures so they can be captured at gRPC
+// server construction time and lazily evaluated once PreRun finishes
+// populating curNode and the connection pools.
+func newBarrierServiceCluster(
+	cacheProvider func() barrierCacheReader,
+	peerLiaisons func() queue.Client,
+	dataNodes func() queue.Client,
+	selfName func() string,
+) *barrierService {
+	return &barrierService{
+		cacheProvider: cacheProvider,
+		peerLiaisons:  peerLiaisons,
+		dataNodes:     dataNodes,
+		selfName:      selfName,
+	}
 }
 
 // cache resolves the current barrier cache reader. It returns nil if the
@@ -67,11 +94,17 @@ func (b *barrierService) cache() barrierCacheReader {
 	return b.cacheProvider()
 }
 
-// AwaitRevisionApplied blocks until the cache's max modRevision is >= req.MinRevision
-// or the timeout elapses. In standalone mode there is one node, so Laggards carries a
-// single entry whose current_mod_revision reports the cache watermark — this lets
-// callers diagnose how far behind the standalone cache is even when applied=false.
+// AwaitRevisionApplied blocks until every node in the watched set reports a
+// max modRevision at or above req.MinRevision. When the cluster fan-out
+// dependencies are wired (production), the call probes the frozen tier1 +
+// tier2 + self watched set in parallel via NodeSchemaStatusService; without
+// those dependencies (Phase 1 unit-test path), it falls back to a single
+// in-process cache poll, returning a self-only laggard on timeout so callers
+// can diagnose how far behind the standalone cache is.
 func (b *barrierService) AwaitRevisionApplied(ctx context.Context, req *schemav1.AwaitRevisionAppliedRequest) (*schemav1.AwaitRevisionAppliedResponse, error) {
+	if b.peerLiaisons != nil && b.dataNodes != nil && b.selfName != nil {
+		return b.awaitRevisionAppliedCluster(ctx, req)
+	}
 	deadline := time.Now().Add(barrierDeadlineDuration(req.GetTimeout()))
 	pollCtx, cancel := context.WithDeadline(ctx, deadline)
 	defer cancel()

--- a/banyand/liaison/grpc/barrier_cluster.go
+++ b/banyand/liaison/grpc/barrier_cluster.go
@@ -529,6 +529,178 @@ func (b *barrierService) probeKeysOne(ctx context.Context, m member, keys []*sch
 	return keyProbeResult{member: m, missingKeys: missing, ready: len(missing) == 0}
 }
 
+// stillPresentResult is the per-iteration outcome of a GetAbsentKeys probe
+// for one member during AwaitSchemaDeleted. stillPresent carries the keys
+// the member's cache has not yet removed; ready=true when every requested
+// key is absent (stillPresent is empty).
+type stillPresentResult struct {
+	err          error
+	stillPresent []*schemav1.SchemaKey
+	member       member
+	ready        bool
+}
+
+// awaitSchemaDeletedCluster runs the cluster-wide fan-out for
+// AwaitSchemaDeleted. Per the §5.0 differences table the only deltas from
+// AwaitSchemaApplied are the per-member probe RPC (GetAbsentKeys instead of
+// GetKeyRevisions) and the decision rule (`every key absent on every member`
+// instead of `every key present at or above target rev`). Membership
+// snapshot, chunking, shared deadline, cross-version, and transient-error
+// policies are identical.
+func (b *barrierService) awaitSchemaDeletedCluster(ctx context.Context, req *schemav1.AwaitSchemaDeletedRequest) (*schemav1.AwaitSchemaDeletedResponse, error) {
+	if len(req.GetKeys()) > barrierMaxKeys {
+		return nil, status.Errorf(codes.InvalidArgument, "too many keys: max=%d", barrierMaxKeys)
+	}
+	frozen := b.snapshotMembers()
+	if len(frozen) == 0 {
+		return nil, status.Errorf(codes.Unavailable, "no active cluster members")
+	}
+
+	deadline := time.Now().Add(barrierDeadlineDuration(req.GetTimeout()))
+	pollCtx, cancel := context.WithDeadline(ctx, deadline)
+	defer cancel()
+
+	alive := frozen
+	var evictedLaggards []*schemav1.NodeLaggard
+	interval := barrierInitInterval
+	var lastResults []stillPresentResult
+	for {
+		view := b.currentMembership()
+		var newlyEvicted []*schemav1.NodeLaggard
+		alive, newlyEvicted = applyTransitionsApplied(alive, view)
+		evictedLaggards = append(evictedLaggards, newlyEvicted...)
+
+		if len(alive) == 0 {
+			return &schemav1.AwaitSchemaDeletedResponse{Applied: true, Laggards: evictedLaggards}, nil
+		}
+
+		lastResults = b.probeAbsentKeys(pollCtx, alive, req.GetKeys(), deadline)
+		if allKeysAbsent(lastResults) {
+			return &schemav1.AwaitSchemaDeletedResponse{Applied: true, Laggards: evictedLaggards}, nil
+		}
+		if time.Now().After(deadline) {
+			return &schemav1.AwaitSchemaDeletedResponse{
+				Applied:  false,
+				Laggards: append(stillPresentLaggards(lastResults), evictedLaggards...),
+			}, nil
+		}
+		select {
+		case <-time.After(interval):
+		case <-pollCtx.Done():
+			return &schemav1.AwaitSchemaDeletedResponse{
+				Applied:  false,
+				Laggards: append(stillPresentLaggards(lastResults), evictedLaggards...),
+			}, nil
+		}
+		interval = barrierBackoff(interval)
+	}
+}
+
+// probeAbsentKeys runs one parallel iteration of GetAbsentKeys probes
+// against the watched set, chunking keys at barrierKeyChunkSize with a
+// shared call-wide deadline.
+func (b *barrierService) probeAbsentKeys(ctx context.Context, members []member, keys []*schemav1.SchemaKey, deadline time.Time) []stillPresentResult {
+	results := make([]stillPresentResult, len(members))
+	var wg sync.WaitGroup
+	probeCtx, cancel := context.WithDeadline(ctx, deadline)
+	defer cancel()
+	for i := range members {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			results[idx] = b.probeAbsentOne(probeCtx, members[idx], keys)
+		}(i)
+	}
+	wg.Wait()
+	return results
+}
+
+// probeAbsentOne returns the per-member outcome for one iteration of the
+// AwaitSchemaDeleted probe.
+func (b *barrierService) probeAbsentOne(ctx context.Context, m member, keys []*schemav1.SchemaKey) stillPresentResult {
+	if m.isSelf {
+		c := b.cache()
+		if c == nil {
+			// Fail-closed: nil cache → claim every key still present so
+			// the loop keeps polling until the cache is online. Mirrors
+			// Phase 1's collectPresentKeys nil-cache contract.
+			present := make([]*schemav1.SchemaKey, len(keys))
+			copy(present, keys)
+			return stillPresentResult{member: m, stillPresent: present}
+		}
+		var present []*schemav1.SchemaKey
+		for _, key := range keys {
+			propID := schemaKeyToPropID(key)
+			if _, ok := c.GetKeyModRevision(propID); ok {
+				present = append(present, key)
+			}
+		}
+		return stillPresentResult{member: m, stillPresent: present, ready: len(present) == 0}
+	}
+
+	tier := b.peerLiaisons
+	if m.role == roleData {
+		tier = b.dataNodes
+	}
+	if tier == nil {
+		return stillPresentResult{member: m, err: errors.New("no tier client wired")}
+	}
+	client := tier()
+	if client == nil {
+		return stillPresentResult{member: m, err: errors.New("tier client unavailable")}
+	}
+	statusClient, err := client.NewNodeSchemaStatusClient(m.name)
+	if err != nil {
+		return stillPresentResult{member: m, err: err}
+	}
+
+	var present []*schemav1.SchemaKey
+	for chunkStart := 0; chunkStart < len(keys); chunkStart += barrierKeyChunkSize {
+		chunkEnd := chunkStart + barrierKeyChunkSize
+		if chunkEnd > len(keys) {
+			chunkEnd = len(keys)
+		}
+		chunkKeys := keys[chunkStart:chunkEnd]
+		resp, rpcErr := statusClient.GetAbsentKeys(ctx, &clusterv1.GetAbsentKeysRequest{Keys: chunkKeys})
+		if rpcErr != nil {
+			if status.Code(rpcErr) == codes.Unimplemented {
+				return stillPresentResult{member: m, ready: true}
+			}
+			return stillPresentResult{member: m, err: rpcErr}
+		}
+		present = append(present, resp.GetStillPresentKeys()...)
+	}
+	return stillPresentResult{member: m, stillPresent: present, ready: len(present) == 0}
+}
+
+// allKeysAbsent reports whether every member's most recent probe found
+// every requested key absent (i.e. removed from its cache).
+func allKeysAbsent(results []stillPresentResult) bool {
+	for _, r := range results {
+		if !r.ready {
+			return false
+		}
+	}
+	return true
+}
+
+// stillPresentLaggards builds the laggards list for the timeout response,
+// each entry carrying the per-node still_present_keys observed in the
+// final iteration.
+func stillPresentLaggards(results []stillPresentResult) []*schemav1.NodeLaggard {
+	laggards := make([]*schemav1.NodeLaggard, 0)
+	for _, r := range results {
+		if r.ready {
+			continue
+		}
+		laggards = append(laggards, &schemav1.NodeLaggard{
+			Node:             r.member.laggardName(),
+			StillPresentKeys: r.stillPresent,
+		})
+	}
+	return laggards
+}
+
 // allKeysApplied reports whether every member's most recent probe found
 // every key applied at or above its target revision.
 func allKeysApplied(results []keyProbeResult) bool {

--- a/banyand/liaison/grpc/barrier_cluster.go
+++ b/banyand/liaison/grpc/barrier_cluster.go
@@ -329,6 +329,234 @@ func (b *barrierService) probeOne(ctx context.Context, m member, minRev int64) p
 	return probeResult{member: m, rev: rev, ready: rev >= minRev}
 }
 
+// keyProbeResult is the per-iteration outcome of a GetKeyRevisions probe for
+// one member. missingKeys carries only the keys that failed the apply check
+// (absent or below their target revision). ready=true when missingKeys is
+// empty after the probe; err!=nil means the probe is a transient laggard for
+// this iteration only.
+type keyProbeResult struct {
+	err         error
+	missingKeys []*schemav1.SchemaKey
+	member      member
+	ready       bool
+}
+
+// barrierKeyChunkSize matches the plan §2.3 chunking policy: each peer probe
+// for AwaitSchemaApplied / AwaitSchemaDeleted issues at most 1000 keys per
+// RPC. The server-side cap (nodeStatusMaxKeys = 10000) is the absolute limit;
+// 1000 is a soft chunking threshold that keeps individual RPC payloads well
+// under typical gRPC max-message-size defaults and fans the work out across
+// multiple round-trips for large requests.
+const barrierKeyChunkSize = 1000
+
+// awaitSchemaAppliedCluster runs the cluster-wide fan-out for
+// AwaitSchemaApplied. Self is probed in-process via the cache; peers are
+// probed via GetKeyRevisions over the *grpc.ClientConn borrowed from
+// queue.Client. Per-member probes chunk keys at barrierKeyChunkSize per RPC,
+// each chunk inheriting the call-wide deadline (shared, not divided across
+// chunks or members). Frozen-snapshot semantics — eviction / leave / late
+// joiner exclusion — match awaitRevisionAppliedCluster's behavior.
+func (b *barrierService) awaitSchemaAppliedCluster(ctx context.Context, req *schemav1.AwaitSchemaAppliedRequest) (*schemav1.AwaitSchemaAppliedResponse, error) {
+	if len(req.GetKeys()) > barrierMaxKeys {
+		return nil, status.Errorf(codes.InvalidArgument, "too many keys: max=%d", barrierMaxKeys)
+	}
+	frozen := b.snapshotMembers()
+	if len(frozen) == 0 {
+		return nil, status.Errorf(codes.Unavailable, "no active cluster members")
+	}
+
+	deadline := time.Now().Add(barrierDeadlineDuration(req.GetTimeout()))
+	pollCtx, cancel := context.WithDeadline(ctx, deadline)
+	defer cancel()
+
+	alive := frozen
+	var evictedLaggards []*schemav1.NodeLaggard
+	interval := barrierInitInterval
+	var lastResults []keyProbeResult
+	for {
+		view := b.currentMembership()
+		var newlyEvicted []*schemav1.NodeLaggard
+		alive, newlyEvicted = applyTransitionsApplied(alive, view)
+		evictedLaggards = append(evictedLaggards, newlyEvicted...)
+
+		if len(alive) == 0 {
+			return &schemav1.AwaitSchemaAppliedResponse{Applied: true, Laggards: evictedLaggards}, nil
+		}
+
+		lastResults = b.probeKeyRevisions(pollCtx, alive, req.GetKeys(), req.GetMinRevisions(), deadline)
+		if allKeysApplied(lastResults) {
+			return &schemav1.AwaitSchemaAppliedResponse{Applied: true, Laggards: evictedLaggards}, nil
+		}
+		if time.Now().After(deadline) {
+			return &schemav1.AwaitSchemaAppliedResponse{
+				Applied:  false,
+				Laggards: append(keyLaggards(lastResults), evictedLaggards...),
+			}, nil
+		}
+		select {
+		case <-time.After(interval):
+		case <-pollCtx.Done():
+			return &schemav1.AwaitSchemaAppliedResponse{
+				Applied:  false,
+				Laggards: append(keyLaggards(lastResults), evictedLaggards...),
+			}, nil
+		}
+		interval = barrierBackoff(interval)
+	}
+}
+
+// applyTransitionsApplied is the AwaitSchemaApplied / AwaitSchemaDeleted
+// sibling of applyTransitions. Eviction laggards for the per-key barriers
+// carry only the role-prefixed name and Reason; missing_keys /
+// still_present_keys are intentionally empty because the cluster has
+// already removed the member from the watched set, so its outstanding key
+// state is no longer something the call is waiting on.
+func applyTransitionsApplied(alive []member, view membershipView) (kept []member, newlyEvicted []*schemav1.NodeLaggard) {
+	for _, m := range alive {
+		if m.isSelf {
+			kept = append(kept, m)
+			continue
+		}
+		if _, evicted := view.evictable[m.name]; evicted {
+			newlyEvicted = append(newlyEvicted, &schemav1.NodeLaggard{
+				Node:   m.laggardName(),
+				Reason: evictedLaggardReason,
+			})
+			continue
+		}
+		if _, active := view.active[m.name]; !active {
+			continue
+		}
+		kept = append(kept, m)
+	}
+	return kept, newlyEvicted
+}
+
+// probeKeyRevisions runs one parallel iteration of GetKeyRevisions probes
+// against the watched set. Each per-member probe chunks the key list into
+// blocks of barrierKeyChunkSize and aggregates per-chunk responses into a
+// single missingKeys slice; the call-wide deadline is shared across all
+// chunks of all members.
+func (b *barrierService) probeKeyRevisions(ctx context.Context, members []member, keys []*schemav1.SchemaKey, minRevs []int64, deadline time.Time) []keyProbeResult {
+	results := make([]keyProbeResult, len(members))
+	var wg sync.WaitGroup
+	probeCtx, cancel := context.WithDeadline(ctx, deadline)
+	defer cancel()
+	for i := range members {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			results[idx] = b.probeKeysOne(probeCtx, members[idx], keys, minRevs)
+		}(i)
+	}
+	wg.Wait()
+	return results
+}
+
+// probeKeysOne returns the per-member outcome for one iteration of
+// AwaitSchemaApplied's per-key probe. Self uses an in-process cache scan;
+// peers use GetKeyRevisions chunked at barrierKeyChunkSize.
+func (b *barrierService) probeKeysOne(ctx context.Context, m member, keys []*schemav1.SchemaKey, minRevs []int64) keyProbeResult {
+	if m.isSelf {
+		c := b.cache()
+		if c == nil {
+			// Fail-closed: nil cache → every key is missing so the loop
+			// keeps polling until the cache is online.
+			missing := make([]*schemav1.SchemaKey, len(keys))
+			copy(missing, keys)
+			return keyProbeResult{member: m, missingKeys: missing}
+		}
+		var missing []*schemav1.SchemaKey
+		for idx, key := range keys {
+			propID := schemaKeyToPropID(key)
+			rev, ok := c.GetKeyModRevision(propID)
+			var minRev int64
+			if idx < len(minRevs) {
+				minRev = minRevs[idx]
+			}
+			if !ok || (minRev > 0 && rev < minRev) {
+				missing = append(missing, key)
+			}
+		}
+		return keyProbeResult{member: m, missingKeys: missing, ready: len(missing) == 0}
+	}
+
+	tier := b.peerLiaisons
+	if m.role == roleData {
+		tier = b.dataNodes
+	}
+	if tier == nil {
+		return keyProbeResult{member: m, err: errors.New("no tier client wired")}
+	}
+	client := tier()
+	if client == nil {
+		return keyProbeResult{member: m, err: errors.New("tier client unavailable")}
+	}
+	statusClient, err := client.NewNodeSchemaStatusClient(m.name)
+	if err != nil {
+		return keyProbeResult{member: m, err: err}
+	}
+
+	var missing []*schemav1.SchemaKey
+	for chunkStart := 0; chunkStart < len(keys); chunkStart += barrierKeyChunkSize {
+		chunkEnd := chunkStart + barrierKeyChunkSize
+		if chunkEnd > len(keys) {
+			chunkEnd = len(keys)
+		}
+		chunkKeys := keys[chunkStart:chunkEnd]
+		resp, rpcErr := statusClient.GetKeyRevisions(ctx, &clusterv1.GetKeyRevisionsRequest{Keys: chunkKeys})
+		if rpcErr != nil {
+			// Cross-version: a Phase-1 peer answers Unimplemented; treat
+			// that member as ready (assume every key applied).
+			if status.Code(rpcErr) == codes.Unimplemented {
+				return keyProbeResult{member: m, ready: true}
+			}
+			// Other RPC errors are transient laggards for this iteration.
+			return keyProbeResult{member: m, err: rpcErr}
+		}
+		revisions := resp.GetRevisions()
+		for i, kr := range revisions {
+			globalIdx := chunkStart + i
+			var minRev int64
+			if globalIdx < len(minRevs) {
+				minRev = minRevs[globalIdx]
+			}
+			if !kr.GetPresent() || (minRev > 0 && kr.GetModRevision() < minRev) {
+				missing = append(missing, chunkKeys[i])
+			}
+		}
+	}
+	return keyProbeResult{member: m, missingKeys: missing, ready: len(missing) == 0}
+}
+
+// allKeysApplied reports whether every member's most recent probe found
+// every key applied at or above its target revision.
+func allKeysApplied(results []keyProbeResult) bool {
+	for _, r := range results {
+		if !r.ready {
+			return false
+		}
+	}
+	return true
+}
+
+// keyLaggards builds the laggards list for the timeout response. Members
+// that succeeded this iteration are excluded so the list contains only
+// the actual stragglers (each carrying their per-node missing_keys).
+func keyLaggards(results []keyProbeResult) []*schemav1.NodeLaggard {
+	laggards := make([]*schemav1.NodeLaggard, 0)
+	for _, r := range results {
+		if r.ready {
+			continue
+		}
+		laggards = append(laggards, &schemav1.NodeLaggard{
+			Node:        r.member.laggardName(),
+			MissingKeys: r.missingKeys,
+		})
+	}
+	return laggards
+}
+
 // allReady reports whether every member's most recent probe returned ready.
 func allReady(results []probeResult) bool {
 	for _, r := range results {

--- a/banyand/liaison/grpc/barrier_cluster.go
+++ b/banyand/liaison/grpc/barrier_cluster.go
@@ -1,0 +1,254 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package grpc
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	clusterv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/cluster/v1"
+	schemav1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/schema/v1"
+	"github.com/apache/skywalking-banyandb/banyand/queue"
+)
+
+// memberRole identifies the role under which a watched-set member was discovered.
+type memberRole int
+
+const (
+	roleLiaison memberRole = iota
+	roleData
+)
+
+func (r memberRole) String() string {
+	switch r {
+	case roleLiaison:
+		return "liaison"
+	case roleData:
+		return "data"
+	default:
+		return "unknown_role"
+	}
+}
+
+// member is a single cluster member in the frozen watched set built at the
+// start of an Await* call.
+type member struct {
+	name   string
+	role   memberRole
+	isSelf bool
+}
+
+// laggardName returns the addressable laggard identifier per the plan's
+// `<role>-<Metadata.Name>` convention.
+func (m member) laggardName() string {
+	return m.role.String() + "-" + m.name
+}
+
+// snapshotMembers builds the frozen watched set from the receiving liaison's
+// in-process self plus the tier1 (peer-liaison) and tier2 (data-node) Active
+// route tables. Dedup is by Metadata.Name with the first-seen tier winning,
+// so a hybrid host running both roles is probed exactly once: once via self
+// if it is the receiving liaison, otherwise via tier1.
+//
+// Standalone fallback: when both tier route tables are empty (the local
+// pipeline returns an empty RouteTable) the watched set degenerates to
+// {self}, which the probe loop handles uniformly with the multi-member case.
+func (b *barrierService) snapshotMembers() []member {
+	seen := map[string]struct{}{}
+	var watched []member
+
+	if b.selfName != nil {
+		if name := b.selfName(); name != "" {
+			seen[name] = struct{}{}
+			watched = append(watched, member{name: name, role: roleLiaison, isSelf: true})
+		}
+	}
+
+	addFromTier := func(provider func() queue.Client, role memberRole) {
+		if provider == nil {
+			return
+		}
+		client := provider()
+		if client == nil {
+			return
+		}
+		rt := client.GetRouteTable()
+		if rt == nil {
+			return
+		}
+		for _, name := range rt.GetActive() {
+			if _, dup := seen[name]; dup {
+				continue
+			}
+			seen[name] = struct{}{}
+			watched = append(watched, member{name: name, role: role})
+		}
+	}
+	addFromTier(b.peerLiaisons, roleLiaison)
+	addFromTier(b.dataNodes, roleData)
+
+	return watched
+}
+
+// probeResult is the outcome of a single per-iteration probe of one member.
+//
+// ready=true means the member is at or above the target revision (or returned
+// codes.Unimplemented, which the cross-version policy treats as ready). When
+// ready=false the (rev, err) pair carries whatever the probe last observed —
+// rev=0 + err!=nil indicates a transient RPC failure that the next iteration
+// retries; rev>0 + err==nil indicates the member is online but behind.
+type probeResult struct {
+	err    error
+	member member
+	rev    int64
+	ready  bool
+}
+
+// awaitRevisionAppliedCluster runs the cluster-wide fan-out for
+// AwaitRevisionApplied. The receiving liaison's own cache is probed
+// in-process; peers are probed via clusterv1.NodeSchemaStatusService over the
+// *grpc.ClientConn borrowed from queue.Client.
+func (b *barrierService) awaitRevisionAppliedCluster(ctx context.Context, req *schemav1.AwaitRevisionAppliedRequest) (*schemav1.AwaitRevisionAppliedResponse, error) {
+	members := b.snapshotMembers()
+	if len(members) == 0 {
+		return nil, status.Errorf(codes.Unavailable, "no active cluster members")
+	}
+
+	deadline := time.Now().Add(barrierDeadlineDuration(req.GetTimeout()))
+	pollCtx, cancel := context.WithDeadline(ctx, deadline)
+	defer cancel()
+
+	interval := barrierInitInterval
+	var lastResults []probeResult
+	for {
+		lastResults = b.probeMembers(pollCtx, members, req.GetMinRevision(), deadline)
+		if allReady(lastResults) {
+			return &schemav1.AwaitRevisionAppliedResponse{Applied: true}, nil
+		}
+		if time.Now().After(deadline) {
+			return &schemav1.AwaitRevisionAppliedResponse{
+				Applied:  false,
+				Laggards: revisionLaggards(lastResults),
+			}, nil
+		}
+		select {
+		case <-time.After(interval):
+		case <-pollCtx.Done():
+			return &schemav1.AwaitRevisionAppliedResponse{
+				Applied:  false,
+				Laggards: revisionLaggards(lastResults),
+			}, nil
+		}
+		interval = barrierBackoff(interval)
+	}
+}
+
+// probeMembers runs one parallel iteration of GetMaxRevision probes against
+// the watched set. Each per-member probe context inherits the call-wide
+// deadline (shared, not divided across N members) so the loop's wall-clock is
+// bounded by req.timeout regardless of fan-out width.
+func (b *barrierService) probeMembers(ctx context.Context, members []member, minRev int64, deadline time.Time) []probeResult {
+	results := make([]probeResult, len(members))
+	var wg sync.WaitGroup
+	probeCtx, cancel := context.WithDeadline(ctx, deadline)
+	defer cancel()
+	for i := range members {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			results[idx] = b.probeOne(probeCtx, members[idx], minRev)
+		}(i)
+	}
+	wg.Wait()
+	return results
+}
+
+// probeOne returns the per-member outcome for one iteration.
+func (b *barrierService) probeOne(ctx context.Context, m member, minRev int64) probeResult {
+	if m.isSelf {
+		c := b.cache()
+		if c == nil {
+			return probeResult{member: m}
+		}
+		rev := c.GetMaxModRevision()
+		return probeResult{member: m, rev: rev, ready: rev >= minRev}
+	}
+
+	tier := b.peerLiaisons
+	if m.role == roleData {
+		tier = b.dataNodes
+	}
+	if tier == nil {
+		return probeResult{member: m, err: errors.New("no tier client wired")}
+	}
+	client := tier()
+	if client == nil {
+		return probeResult{member: m, err: errors.New("tier client unavailable")}
+	}
+	statusClient, err := client.NewNodeSchemaStatusClient(m.name)
+	if err != nil {
+		return probeResult{member: m, err: err}
+	}
+	resp, rpcErr := statusClient.GetMaxRevision(ctx, &clusterv1.GetMaxRevisionRequest{})
+	if rpcErr != nil {
+		// Cross-version policy: a Phase-1 peer that does not implement
+		// NodeSchemaStatusService returns codes.Unimplemented; treat that
+		// member as ready (assume max_revision = ∞) so partial-upgrade
+		// clusters do not deadlock all barrier callers.
+		if status.Code(rpcErr) == codes.Unimplemented {
+			return probeResult{member: m, ready: true}
+		}
+		// Any other RPC error counts as a transient laggard for this
+		// iteration only — the next backoff iteration retries it.
+		return probeResult{member: m, err: rpcErr}
+	}
+	rev := resp.GetMaxModRevision()
+	return probeResult{member: m, rev: rev, ready: rev >= minRev}
+}
+
+// allReady reports whether every member's most recent probe returned ready.
+func allReady(results []probeResult) bool {
+	for _, r := range results {
+		if !r.ready {
+			return false
+		}
+	}
+	return true
+}
+
+// revisionLaggards builds the laggards list for the timeout response,
+// preserving the watched-set order. Cross-version-ready and ready-this-pass
+// members are excluded so the list contains only the actual stragglers.
+func revisionLaggards(results []probeResult) []*schemav1.NodeLaggard {
+	laggards := make([]*schemav1.NodeLaggard, 0)
+	for _, r := range results {
+		if r.ready {
+			continue
+		}
+		laggards = append(laggards, &schemav1.NodeLaggard{
+			Node:               r.member.laggardName(),
+			CurrentModRevision: r.rev,
+		})
+	}
+	return laggards
+}

--- a/banyand/liaison/grpc/barrier_cluster.go
+++ b/banyand/liaison/grpc/barrier_cluster.go
@@ -124,13 +124,98 @@ type probeResult struct {
 	ready  bool
 }
 
+// evictedLaggardReason is the laggard.reason value attached to a member that
+// transitioned Active → Evictable while a barrier call was in flight. The
+// cluster has already decided the node is unreliable; the barrier defers to
+// that decision rather than try to override it, but surfaces the eviction
+// once so callers see why the watched set shrank mid-call.
+const evictedLaggardReason = "evicted_during_poll"
+
+// membershipView is a snapshot of the tier1 + tier2 route tables collapsed
+// into name-keyed sets. The barrier loop refreshes this each iteration to
+// detect Active → Evictable / Active → Removed transitions on the frozen
+// member set built at call start.
+type membershipView struct {
+	active    map[string]struct{}
+	evictable map[string]struct{}
+}
+
+// currentMembership reads tier1 and tier2 route tables and merges their
+// Active and Evictable lists into name sets. Both providers contribute to
+// both sets — dedup is by name, so a hybrid host appearing in both tiers
+// counts once. The connection-pool layer guarantees that GetRouteTable()
+// returns a copy, so this read is safe to call concurrently without locking.
+func (b *barrierService) currentMembership() membershipView {
+	view := membershipView{
+		active:    map[string]struct{}{},
+		evictable: map[string]struct{}{},
+	}
+	addFromTier := func(provider func() queue.Client) {
+		if provider == nil {
+			return
+		}
+		client := provider()
+		if client == nil {
+			return
+		}
+		rt := client.GetRouteTable()
+		if rt == nil {
+			return
+		}
+		for _, n := range rt.GetActive() {
+			view.active[n] = struct{}{}
+		}
+		for _, n := range rt.GetEvictable() {
+			view.evictable[n] = struct{}{}
+		}
+	}
+	addFromTier(b.peerLiaisons)
+	addFromTier(b.dataNodes)
+	return view
+}
+
+// applyTransitions walks the alive members against the current membership
+// view and partitions them into "still alive" (kept for the next probe) and
+// "newly evicted" (surfaced as one-time laggards with reason="evicted_during_poll").
+// Members whose names disappear from BOTH active and evictable are treated
+// as having left the cluster (graceful leave) and are dropped without a
+// laggard entry, per the frozen-snapshot policy. Self is always kept — the
+// in-process member never transitions.
+func applyTransitions(alive []member, view membershipView, lastRev map[string]int64) (kept []member, newlyEvicted []*schemav1.NodeLaggard) {
+	for _, m := range alive {
+		if m.isSelf {
+			kept = append(kept, m)
+			continue
+		}
+		if _, evicted := view.evictable[m.name]; evicted {
+			newlyEvicted = append(newlyEvicted, &schemav1.NodeLaggard{
+				Node:               m.laggardName(),
+				CurrentModRevision: lastRev[m.name],
+				Reason:             evictedLaggardReason,
+			})
+			continue
+		}
+		if _, active := view.active[m.name]; !active {
+			// Absent from both sets: graceful leave. Drop silently per
+			// the frozen-snapshot leave-during-poll branch.
+			continue
+		}
+		kept = append(kept, m)
+	}
+	return kept, newlyEvicted
+}
+
 // awaitRevisionAppliedCluster runs the cluster-wide fan-out for
 // AwaitRevisionApplied. The receiving liaison's own cache is probed
 // in-process; peers are probed via clusterv1.NodeSchemaStatusService over the
-// *grpc.ClientConn borrowed from queue.Client.
+// *grpc.ClientConn borrowed from queue.Client. The frozen watched set built
+// at call start is shrunk mid-call when members transition Active → Evictable
+// (recorded as one-time `evicted_during_poll` laggards) or Active → Removed
+// (silent leave). Late joiners — nodes that enter Active after the snapshot
+// — are excluded; they show up in subsequent calls.
 func (b *barrierService) awaitRevisionAppliedCluster(ctx context.Context, req *schemav1.AwaitRevisionAppliedRequest) (*schemav1.AwaitRevisionAppliedResponse, error) {
-	members := b.snapshotMembers()
-	if len(members) == 0 {
+	frozen := b.snapshotMembers()
+	if len(frozen) == 0 {
 		return nil, status.Errorf(codes.Unavailable, "no active cluster members")
 	}
 
@@ -138,17 +223,35 @@ func (b *barrierService) awaitRevisionAppliedCluster(ctx context.Context, req *s
 	pollCtx, cancel := context.WithDeadline(ctx, deadline)
 	defer cancel()
 
+	alive := frozen
+	lastRev := map[string]int64{}
+	var evictedLaggards []*schemav1.NodeLaggard
 	interval := barrierInitInterval
 	var lastResults []probeResult
 	for {
-		lastResults = b.probeMembers(pollCtx, members, req.GetMinRevision(), deadline)
+		view := b.currentMembership()
+		var newlyEvicted []*schemav1.NodeLaggard
+		alive, newlyEvicted = applyTransitions(alive, view, lastRev)
+		evictedLaggards = append(evictedLaggards, newlyEvicted...)
+
+		if len(alive) == 0 {
+			// Every frozen member departed mid-call. The remaining cluster
+			// has no objection to the target revision; surface the eviction
+			// notices and return applied=true so callers can act.
+			return &schemav1.AwaitRevisionAppliedResponse{Applied: true, Laggards: evictedLaggards}, nil
+		}
+
+		lastResults = b.probeMembers(pollCtx, alive, req.GetMinRevision(), deadline)
+		for _, r := range lastResults {
+			lastRev[r.member.name] = r.rev
+		}
 		if allReady(lastResults) {
-			return &schemav1.AwaitRevisionAppliedResponse{Applied: true}, nil
+			return &schemav1.AwaitRevisionAppliedResponse{Applied: true, Laggards: evictedLaggards}, nil
 		}
 		if time.Now().After(deadline) {
 			return &schemav1.AwaitRevisionAppliedResponse{
 				Applied:  false,
-				Laggards: revisionLaggards(lastResults),
+				Laggards: append(revisionLaggards(lastResults), evictedLaggards...),
 			}, nil
 		}
 		select {
@@ -156,7 +259,7 @@ func (b *barrierService) awaitRevisionAppliedCluster(ctx context.Context, req *s
 		case <-pollCtx.Done():
 			return &schemav1.AwaitRevisionAppliedResponse{
 				Applied:  false,
-				Laggards: revisionLaggards(lastResults),
+				Laggards: append(revisionLaggards(lastResults), evictedLaggards...),
 			}, nil
 		}
 		interval = barrierBackoff(interval)

--- a/banyand/liaison/grpc/barrier_cluster_test.go
+++ b/banyand/liaison/grpc/barrier_cluster_test.go
@@ -40,17 +40,22 @@ import (
 
 // fakeNodeStatusClient is a minimal clusterv1.NodeSchemaStatusServiceClient.
 // Only GetMaxRevision is implemented for Phase 2.2 tests; the other RPCs
-// land in 2.3/2.4 and panic if a test accidentally invokes them.
+// land in 2.3/2.4 and panic if a test accidentally invokes them. revs lets
+// frozen-snapshot tests vary the returned revision per call (call k returns
+// revs[min(k, len-1)]) so the barrier can observe a member catching up
+// across iterations.
 type fakeNodeStatusClient struct {
 	err      error
 	callsRef *int32
+	revs     []int64
 	maxRev   int64
 	delay    time.Duration
 }
 
 func (f *fakeNodeStatusClient) GetMaxRevision(ctx context.Context, _ *clusterv1.GetMaxRevisionRequest, _ ...grpc.CallOption) (*clusterv1.GetMaxRevisionResponse, error) {
+	n := int32(0)
 	if f.callsRef != nil {
-		atomic.AddInt32(f.callsRef, 1)
+		n = atomic.AddInt32(f.callsRef, 1) - 1
 	}
 	if f.delay > 0 {
 		select {
@@ -61,6 +66,13 @@ func (f *fakeNodeStatusClient) GetMaxRevision(ctx context.Context, _ *clusterv1.
 	}
 	if f.err != nil {
 		return nil, f.err
+	}
+	if len(f.revs) > 0 {
+		idx := int(n)
+		if idx >= len(f.revs) {
+			idx = len(f.revs) - 1
+		}
+		return &clusterv1.GetMaxRevisionResponse{MaxModRevision: f.revs[idx]}, nil
 	}
 	return &clusterv1.GetMaxRevisionResponse{MaxModRevision: f.maxRev}, nil
 }
@@ -75,14 +87,19 @@ func (*fakeNodeStatusClient) GetAbsentKeys(_ context.Context, _ *clusterv1.GetAb
 
 // fakeQueueClient embeds queue.Client (a nil interface) so unused methods
 // panic at runtime; only the two methods the barrier fan-out actually calls
-// are overridden.
+// are overridden. routeTableFn (when set) overrides routeTable per call so
+// frozen-snapshot tests can mutate cluster membership between iterations.
 type fakeQueueClient struct {
 	queue.Client
 	routeTable    *databasev1.RouteTable
+	routeTableFn  func() *databasev1.RouteTable
 	statusClients map[string]clusterv1.NodeSchemaStatusServiceClient
 }
 
 func (f *fakeQueueClient) GetRouteTable() *databasev1.RouteTable {
+	if f.routeTableFn != nil {
+		return f.routeTableFn()
+	}
 	if f.routeTable == nil {
 		return &databasev1.RouteTable{}
 	}
@@ -318,4 +335,119 @@ func TestFanOut_NodeReturnsUnimplemented_TreatedAsReady(t *testing.T) {
 	assert.True(t, resp.GetApplied(),
 		"Unimplemented from a Phase-1 peer must not block a v0.13 barrier caller")
 	assert.Empty(t, resp.GetLaggards())
+}
+
+// mutatingRouteTable returns a closure that produces `first` for the first
+// two GetRouteTable calls and `rest` for every call thereafter. The two-call
+// threshold lines up with the production sequence: snapshotMembers consumes
+// call 1 (initial freeze), iteration 1's currentMembership consumes call 2,
+// and iteration 2 onwards observes the mutated state. This means the first
+// probe round runs against `first` (so per-member revs are recorded into
+// lastRev) before the transition fires — matching the production assumption
+// that eviction follows at least one probe of the member.
+func mutatingRouteTable(first, rest *databasev1.RouteTable) func() *databasev1.RouteTable {
+	var calls atomic.Int32
+	return func() *databasev1.RouteTable {
+		if calls.Add(1) <= 2 {
+			return first
+		}
+		return rest
+	}
+}
+
+// TestFanOut_NodeEvictedMidWait_DropsAndAnnotates verifies that when a member
+// transitions Active → Evictable mid-call, the barrier drops it from
+// subsequent probes, records exactly one laggard with reason
+// "evicted_during_poll" carrying the last-observed mod_revision, and
+// converges based on the remaining members.
+func TestFanOut_NodeEvictedMidWait_DropsAndAnnotates(t *testing.T) {
+	cache := &staticBarrierCache{maxModRevision: 100}
+	tier1 := &fakeQueueClient{
+		routeTableFn: mutatingRouteTable(
+			&databasev1.RouteTable{Active: []string{"peer-A", "peer-B"}},
+			&databasev1.RouteTable{Active: []string{"peer-B"}, Evictable: []string{"peer-A"}},
+		),
+		statusClients: map[string]clusterv1.NodeSchemaStatusServiceClient{
+			"peer-A": &fakeNodeStatusClient{maxRev: 50},  // permanently behind
+			"peer-B": &fakeNodeStatusClient{maxRev: 100}, // already caught up
+		},
+	}
+	svc := (&clusterFixture{cache: cache, tier1: tier1, tier2: newFakeTier(nil, nil), self: "self-liaison"}).build()
+
+	resp, err := svc.AwaitRevisionApplied(context.Background(), &schemav1.AwaitRevisionAppliedRequest{
+		MinRevision: 100,
+		Timeout:     durationpb.New(200 * time.Millisecond),
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.GetApplied(),
+		"barrier should converge once peer-A is evicted (peer-B + self both at 100)")
+	require.Len(t, resp.GetLaggards(), 1, "exactly one evicted laggard expected")
+	assert.Equal(t, "liaison-peer-A", resp.GetLaggards()[0].GetNode())
+	assert.Equal(t, "evicted_during_poll", resp.GetLaggards()[0].GetReason())
+	assert.Equal(t, int64(50), resp.GetLaggards()[0].GetCurrentModRevision(),
+		"laggard should carry the last-observed revision before eviction")
+}
+
+// TestFanOut_NodeSetChangesMidWait_SkipsDepartedNodes verifies that when a
+// member's name disappears from BOTH active and evictable mid-call (graceful
+// leave), the barrier drops it silently — no laggard entry — and converges
+// on the remaining members.
+func TestFanOut_NodeSetChangesMidWait_SkipsDepartedNodes(t *testing.T) {
+	cache := &staticBarrierCache{maxModRevision: 100}
+	tier1 := &fakeQueueClient{
+		routeTableFn: mutatingRouteTable(
+			&databasev1.RouteTable{Active: []string{"peer-A", "peer-B"}},
+			&databasev1.RouteTable{Active: []string{"peer-B"}}, // peer-A simply gone
+		),
+		statusClients: map[string]clusterv1.NodeSchemaStatusServiceClient{
+			"peer-A": &fakeNodeStatusClient{maxRev: 50}, // would block if probed
+			"peer-B": &fakeNodeStatusClient{maxRev: 100},
+		},
+	}
+	svc := (&clusterFixture{cache: cache, tier1: tier1, tier2: newFakeTier(nil, nil), self: "self-liaison"}).build()
+
+	resp, err := svc.AwaitRevisionApplied(context.Background(), &schemav1.AwaitRevisionAppliedRequest{
+		MinRevision: 100,
+		Timeout:     durationpb.New(200 * time.Millisecond),
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.GetApplied(),
+		"barrier should converge once peer-A leaves (peer-B + self both at 100)")
+	assert.Empty(t, resp.GetLaggards(),
+		"a graceful leave (Active → Removed) should not produce a laggard entry")
+}
+
+// TestFanOut_LateJoiner_Excluded verifies that nodes entering Active after
+// the call's initial snapshot are NOT added to the watched set. A late
+// joiner with max_revision=0 must not cause spurious timeouts; barrier
+// returns Applied=true once the original watched set is ready.
+//
+// peer-A starts behind (rev=50) and catches up to 100 on its second probe;
+// peer-B is the late joiner — deliberately omitted from statusClients so
+// any erroneous probe attempt would surface as a laggard rather than a
+// silent pass.
+func TestFanOut_LateJoiner_Excluded(t *testing.T) {
+	cache := &staticBarrierCache{maxModRevision: 100}
+	var peerACalls int32
+	tier1 := &fakeQueueClient{
+		routeTableFn: mutatingRouteTable(
+			&databasev1.RouteTable{Active: []string{"peer-A"}},
+			&databasev1.RouteTable{Active: []string{"peer-A", "peer-B"}}, // peer-B joins
+		),
+		statusClients: map[string]clusterv1.NodeSchemaStatusServiceClient{
+			"peer-A": &fakeNodeStatusClient{revs: []int64{50, 100}, callsRef: &peerACalls},
+			// peer-B intentionally absent — any probe would error.
+		},
+	}
+	svc := (&clusterFixture{cache: cache, tier1: tier1, tier2: newFakeTier(nil, nil), self: "self-liaison"}).build()
+
+	resp, err := svc.AwaitRevisionApplied(context.Background(), &schemav1.AwaitRevisionAppliedRequest{
+		MinRevision: 100,
+		Timeout:     durationpb.New(200 * time.Millisecond),
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.GetApplied(),
+		"frozen snapshot should converge based on peer-A only; late-joiner peer-B is ignored")
+	assert.Empty(t, resp.GetLaggards(),
+		"laggards list must not contain the late joiner peer-B")
 }

--- a/banyand/liaison/grpc/barrier_cluster_test.go
+++ b/banyand/liaison/grpc/barrier_cluster_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"sort"
+	"strconv"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -38,18 +39,27 @@ import (
 	"github.com/apache/skywalking-banyandb/banyand/queue"
 )
 
+// fakeKeyState backs the GetKeyRevisions fake response for a single key.
+// Keys absent from the keyState map default to Present=false (the natural
+// "node hasn't seen this key" semantic).
+type fakeKeyState struct {
+	rev     int64
+	present bool
+}
+
 // fakeNodeStatusClient is a minimal clusterv1.NodeSchemaStatusServiceClient.
-// Only GetMaxRevision is implemented for Phase 2.2 tests; the other RPCs
-// land in 2.3/2.4 and panic if a test accidentally invokes them. revs lets
-// frozen-snapshot tests vary the returned revision per call (call k returns
-// revs[min(k, len-1)]) so the barrier can observe a member catching up
-// across iterations.
+// GetMaxRevision and GetKeyRevisions are implemented; GetAbsentKeys remains
+// a panic stub until Phase 2.4 (FD-1/FD-2). Per-call counters and delays let
+// tests verify chunking + shared-deadline regression behavior.
 type fakeNodeStatusClient struct {
-	err      error
-	callsRef *int32
-	revs     []int64
-	maxRev   int64
-	delay    time.Duration
+	err          error
+	callsRef     *int32
+	keyState     map[string]fakeKeyState
+	keyRevsCalls *int32
+	revs         []int64
+	maxRev       int64
+	delay        time.Duration
+	keyRevsDelay time.Duration
 }
 
 func (f *fakeNodeStatusClient) GetMaxRevision(ctx context.Context, _ *clusterv1.GetMaxRevisionRequest, _ ...grpc.CallOption) (*clusterv1.GetMaxRevisionResponse, error) {
@@ -77,8 +87,43 @@ func (f *fakeNodeStatusClient) GetMaxRevision(ctx context.Context, _ *clusterv1.
 	return &clusterv1.GetMaxRevisionResponse{MaxModRevision: f.maxRev}, nil
 }
 
-func (*fakeNodeStatusClient) GetKeyRevisions(_ context.Context, _ *clusterv1.GetKeyRevisionsRequest, _ ...grpc.CallOption) (*clusterv1.GetKeyRevisionsResponse, error) {
-	panic("GetKeyRevisions: unused in Phase 2.2 tests")
+func (f *fakeNodeStatusClient) GetKeyRevisions(
+	ctx context.Context, req *clusterv1.GetKeyRevisionsRequest, _ ...grpc.CallOption,
+) (*clusterv1.GetKeyRevisionsResponse, error) {
+	if f.keyRevsCalls != nil {
+		atomic.AddInt32(f.keyRevsCalls, 1)
+	}
+	if f.keyRevsDelay > 0 {
+		select {
+		case <-time.After(f.keyRevsDelay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	if f.err != nil {
+		return nil, f.err
+	}
+	keys := req.GetKeys()
+	revs := make([]*clusterv1.KeyRevision, len(keys))
+	for i, k := range keys {
+		mapKey := k.GetKind() + "|" + k.GetGroup() + "|" + k.GetName()
+		if state, ok := f.keyState[mapKey]; ok {
+			revs[i] = &clusterv1.KeyRevision{Key: k, Present: state.present, ModRevision: state.rev}
+			continue
+		}
+		revs[i] = &clusterv1.KeyRevision{Key: k}
+	}
+	return &clusterv1.GetKeyRevisionsResponse{Revisions: revs}, nil
+}
+
+// keyStateKey produces the deterministic map key used by fakeNodeStatusClient
+// to look up per-(kind,group,name) state. Tests currently exercise only the
+// "stream" kind; extend the signature when other kinds need direct state
+// injection.
+//
+//nolint:unparam // kind/group/name kept symmetric with SchemaKey for clarity.
+func keyStateKey(kind, group, name string) string {
+	return kind + "|" + group + "|" + name
 }
 
 func (*fakeNodeStatusClient) GetAbsentKeys(_ context.Context, _ *clusterv1.GetAbsentKeysRequest, _ ...grpc.CallOption) (*clusterv1.GetAbsentKeysResponse, error) {
@@ -450,4 +495,195 @@ func TestFanOut_LateJoiner_Excluded(t *testing.T) {
 		"frozen snapshot should converge based on peer-A only; late-joiner peer-B is ignored")
 	assert.Empty(t, resp.GetLaggards(),
 		"laggards list must not contain the late joiner peer-B")
+}
+
+// presentAt builds a fakeKeyState shorthand for "key is present on this
+// member at the given revision."
+//
+//nolint:unparam // tests currently target rev=100 only; the parameter is kept for clarity.
+func presentAt(rev int64) fakeKeyState { return fakeKeyState{rev: rev, present: true} }
+
+// streamKey is a SchemaKey constructor for the cluster fan-out tests.
+//
+//nolint:unparam // tests currently use a single group "g"; group remains in the signature for readability.
+func streamKey(group, name string) *schemav1.SchemaKey {
+	return &schemav1.SchemaKey{Kind: "stream", Group: group, Name: name}
+}
+
+// laggardByNode returns the NodeLaggard whose Node field matches `name`, or
+// nil if not found. Used to assert per-node laggard payloads without
+// depending on slice ordering.
+func laggardByNode(laggards []*schemav1.NodeLaggard, name string) *schemav1.NodeLaggard {
+	for _, l := range laggards {
+		if l.GetNode() == name {
+			return l
+		}
+	}
+	return nil
+}
+
+// TestAwaitSchemaApplied_FanOut_PerKeyLaggards verifies that the timeout
+// response carries per-node missing_keys with role-prefixed identifiers, so
+// the caller can see exactly which keys are outstanding on which member.
+func TestAwaitSchemaApplied_FanOut_PerKeyLaggards(t *testing.T) {
+	keys := []*schemav1.SchemaKey{
+		streamKey("g", "k0"),
+		streamKey("g", "k1"),
+		streamKey("g", "k2"),
+		streamKey("g", "k3"),
+		streamKey("g", "k4"),
+	}
+	cache := &staticBarrierCache{
+		maxModRevision: 100,
+		keys: map[string]int64{
+			"stream_g/k0": 100, "stream_g/k1": 100,
+			"stream_g/k2": 100, "stream_g/k3": 100, "stream_g/k4": 100,
+		},
+	}
+	peerA := &fakeNodeStatusClient{keyState: map[string]fakeKeyState{
+		keyStateKey("stream", "g", "k0"): presentAt(100),
+		keyStateKey("stream", "g", "k1"): presentAt(100),
+	}} // missing: k2, k3, k4
+	peerB := &fakeNodeStatusClient{keyState: map[string]fakeKeyState{
+		keyStateKey("stream", "g", "k0"): presentAt(100),
+		keyStateKey("stream", "g", "k1"): presentAt(100),
+		keyStateKey("stream", "g", "k2"): presentAt(100),
+		keyStateKey("stream", "g", "k3"): presentAt(100),
+	}} // missing: k4
+	tier1 := newFakeTier([]string{"peer-A", "peer-B"}, map[string]clusterv1.NodeSchemaStatusServiceClient{
+		"peer-A": peerA,
+		"peer-B": peerB,
+	})
+	svc := (&clusterFixture{cache: cache, tier1: tier1, tier2: newFakeTier(nil, nil), self: "self-liaison"}).build()
+
+	resp, err := svc.AwaitSchemaApplied(context.Background(), &schemav1.AwaitSchemaAppliedRequest{
+		Keys:    keys,
+		Timeout: durationpb.New(60 * time.Millisecond),
+	})
+	require.NoError(t, err)
+	assert.False(t, resp.GetApplied())
+	require.Len(t, resp.GetLaggards(), 2)
+
+	la := laggardByNode(resp.GetLaggards(), "liaison-peer-A")
+	require.NotNil(t, la, "laggard for peer-A must be present")
+	assert.Equal(t, []string{"k2", "k3", "k4"}, schemaKeyNames(la.GetMissingKeys()))
+
+	lb := laggardByNode(resp.GetLaggards(), "liaison-peer-B")
+	require.NotNil(t, lb, "laggard for peer-B must be present")
+	assert.Equal(t, []string{"k4"}, schemaKeyNames(lb.GetMissingKeys()))
+}
+
+// schemaKeyNames extracts the Name field from each SchemaKey for assertion
+// readability.
+func schemaKeyNames(keys []*schemav1.SchemaKey) []string {
+	out := make([]string, len(keys))
+	for i, k := range keys {
+		out[i] = k.GetName()
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestAwaitSchemaApplied_FanOut_ChunkedKeys verifies that a request whose
+// key count exceeds barrierKeyChunkSize (1000) triggers multiple per-peer
+// RPCs, with the per-chunk responses correctly aggregated into a single
+// missing_keys slice for that peer.
+func TestAwaitSchemaApplied_FanOut_ChunkedKeys(t *testing.T) {
+	const total = 1500
+	keys := make([]*schemav1.SchemaKey, total)
+	cacheKeys := make(map[string]int64, total)
+	for i := range total {
+		name := "k" + strconv.Itoa(i)
+		keys[i] = streamKey("g", name)
+		cacheKeys["stream_g/"+name] = 100 // self has them all
+	}
+	cache := &staticBarrierCache{maxModRevision: 100, keys: cacheKeys}
+
+	var peerCalls int32
+	peer := &fakeNodeStatusClient{
+		keyState:     map[string]fakeKeyState{}, // peer has nothing → every key missing
+		keyRevsCalls: &peerCalls,
+	}
+	tier1 := newFakeTier([]string{"peer"}, map[string]clusterv1.NodeSchemaStatusServiceClient{"peer": peer})
+	svc := (&clusterFixture{cache: cache, tier1: tier1, tier2: newFakeTier(nil, nil), self: "self-liaison"}).build()
+
+	resp, err := svc.AwaitSchemaApplied(context.Background(), &schemav1.AwaitSchemaAppliedRequest{
+		Keys:    keys,
+		Timeout: durationpb.New(40 * time.Millisecond),
+	})
+	require.NoError(t, err)
+	assert.False(t, resp.GetApplied())
+
+	// Expect 2 chunks (1000 + 500) per iteration. The loop may run multiple
+	// iterations within the timeout; assert at least one full pass happened.
+	assert.GreaterOrEqual(t, atomic.LoadInt32(&peerCalls), int32(2),
+		"a 1500-key request must produce >= 2 GetKeyRevisions calls per peer (chunked at 1000)")
+	assert.Equal(t, int32(0), atomic.LoadInt32(&peerCalls)%2,
+		"chunks per iteration is 2 (1000 + 500); call count should be a multiple of 2")
+
+	// All 1500 keys missing from peer; aggregated across both chunks.
+	la := laggardByNode(resp.GetLaggards(), "liaison-peer")
+	require.NotNil(t, la)
+	assert.Len(t, la.GetMissingKeys(), total,
+		"per-peer missing_keys aggregates both chunks")
+}
+
+// TestAwaitSchemaApplied_FanOut_SharedDeadline regresses the plan §2.3
+// contract that each per-node, per-chunk RPC inherits time.Until(deadline)
+// rather than req.Timeout / N. With per-chunk delays larger than the call's
+// total budget, the call must complete around req.Timeout — NOT N × delay.
+func TestAwaitSchemaApplied_FanOut_SharedDeadline(t *testing.T) {
+	const total = 1500
+	keys := make([]*schemav1.SchemaKey, total)
+	for i := range total {
+		keys[i] = streamKey("g", "k"+strconv.Itoa(i))
+	}
+	cache := &staticBarrierCache{maxModRevision: 100} // no keys → self also missing
+
+	peer := &fakeNodeStatusClient{
+		keyState:     map[string]fakeKeyState{},
+		keyRevsDelay: 100 * time.Millisecond, // each chunk is slow
+	}
+	tier1 := newFakeTier([]string{"peer"}, map[string]clusterv1.NodeSchemaStatusServiceClient{"peer": peer})
+	svc := (&clusterFixture{cache: cache, tier1: tier1, tier2: newFakeTier(nil, nil), self: "self-liaison"}).build()
+
+	start := time.Now()
+	resp, err := svc.AwaitSchemaApplied(context.Background(), &schemav1.AwaitSchemaAppliedRequest{
+		Keys:    keys,
+		Timeout: durationpb.New(50 * time.Millisecond),
+	})
+	elapsed := time.Since(start)
+	require.NoError(t, err)
+	assert.False(t, resp.GetApplied())
+	// Without shared deadline the call would take 2 × 100ms = 200ms.
+	// With shared deadline the entire call respects req.Timeout (50ms)
+	// regardless of how many chunks would otherwise be issued.
+	assert.Less(t, elapsed, 180*time.Millisecond,
+		"shared deadline must bound total wall-clock at req.Timeout, not N × per-chunk delay")
+}
+
+// TestAwaitSchemaApplied_FanOut_PeerUnimplemented_TreatedAsReady locks the
+// cross-version policy: a peer (or data node) that returns
+// codes.Unimplemented from GetKeyRevisions — i.e. a Phase-1 v0.11 / v0.12
+// node — is treated as ready (assume every key applied) so partial-upgrade
+// clusters do not deadlock barrier callers.
+func TestAwaitSchemaApplied_FanOut_PeerUnimplemented_TreatedAsReady(t *testing.T) {
+	keys := []*schemav1.SchemaKey{streamKey("g", "k0"), streamKey("g", "k1")}
+	cache := &staticBarrierCache{maxModRevision: 100, keys: map[string]int64{
+		"stream_g/k0": 100, "stream_g/k1": 100,
+	}}
+	legacy := &fakeNodeStatusClient{err: status.Error(codes.Unimplemented, "phase 1 node")}
+	tier1 := newFakeTier([]string{"phase1"}, map[string]clusterv1.NodeSchemaStatusServiceClient{
+		"phase1": legacy,
+	})
+	svc := (&clusterFixture{cache: cache, tier1: tier1, tier2: newFakeTier(nil, nil), self: "self-liaison"}).build()
+
+	resp, err := svc.AwaitSchemaApplied(context.Background(), &schemav1.AwaitSchemaAppliedRequest{
+		Keys:    keys,
+		Timeout: durationpb.New(50 * time.Millisecond),
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.GetApplied(),
+		"Unimplemented from a Phase-1 peer must not block AwaitSchemaApplied")
+	assert.Empty(t, resp.GetLaggards())
 }

--- a/banyand/liaison/grpc/barrier_cluster_test.go
+++ b/banyand/liaison/grpc/barrier_cluster_test.go
@@ -1,0 +1,321 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package grpc
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	clusterv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/cluster/v1"
+	databasev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
+	schemav1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/schema/v1"
+	"github.com/apache/skywalking-banyandb/banyand/queue"
+)
+
+// fakeNodeStatusClient is a minimal clusterv1.NodeSchemaStatusServiceClient.
+// Only GetMaxRevision is implemented for Phase 2.2 tests; the other RPCs
+// land in 2.3/2.4 and panic if a test accidentally invokes them.
+type fakeNodeStatusClient struct {
+	err      error
+	callsRef *int32
+	maxRev   int64
+	delay    time.Duration
+}
+
+func (f *fakeNodeStatusClient) GetMaxRevision(ctx context.Context, _ *clusterv1.GetMaxRevisionRequest, _ ...grpc.CallOption) (*clusterv1.GetMaxRevisionResponse, error) {
+	if f.callsRef != nil {
+		atomic.AddInt32(f.callsRef, 1)
+	}
+	if f.delay > 0 {
+		select {
+		case <-time.After(f.delay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &clusterv1.GetMaxRevisionResponse{MaxModRevision: f.maxRev}, nil
+}
+
+func (*fakeNodeStatusClient) GetKeyRevisions(_ context.Context, _ *clusterv1.GetKeyRevisionsRequest, _ ...grpc.CallOption) (*clusterv1.GetKeyRevisionsResponse, error) {
+	panic("GetKeyRevisions: unused in Phase 2.2 tests")
+}
+
+func (*fakeNodeStatusClient) GetAbsentKeys(_ context.Context, _ *clusterv1.GetAbsentKeysRequest, _ ...grpc.CallOption) (*clusterv1.GetAbsentKeysResponse, error) {
+	panic("GetAbsentKeys: unused in Phase 2.2 tests")
+}
+
+// fakeQueueClient embeds queue.Client (a nil interface) so unused methods
+// panic at runtime; only the two methods the barrier fan-out actually calls
+// are overridden.
+type fakeQueueClient struct {
+	queue.Client
+	routeTable    *databasev1.RouteTable
+	statusClients map[string]clusterv1.NodeSchemaStatusServiceClient
+}
+
+func (f *fakeQueueClient) GetRouteTable() *databasev1.RouteTable {
+	if f.routeTable == nil {
+		return &databasev1.RouteTable{}
+	}
+	return f.routeTable
+}
+
+func (f *fakeQueueClient) NewNodeSchemaStatusClient(node string) (clusterv1.NodeSchemaStatusServiceClient, error) {
+	c, ok := f.statusClients[node]
+	if !ok {
+		return nil, errors.New("no fake client for node " + node)
+	}
+	return c, nil
+}
+
+func newFakeTier(active []string, clients map[string]clusterv1.NodeSchemaStatusServiceClient) *fakeQueueClient {
+	return &fakeQueueClient{
+		routeTable:    &databasev1.RouteTable{Active: active},
+		statusClients: clients,
+	}
+}
+
+// clusterFixture wires a barrier service for the cluster fan-out tests.
+type clusterFixture struct {
+	cache        barrierCacheReader
+	tier1, tier2 *fakeQueueClient
+	self         string
+}
+
+func (f *clusterFixture) build() *barrierService {
+	return newBarrierServiceCluster(
+		func() barrierCacheReader { return f.cache },
+		func() queue.Client { return f.tier1 },
+		func() queue.Client { return f.tier2 },
+		func() string { return f.self },
+	)
+}
+
+func laggardNames(laggards []*schemav1.NodeLaggard) []string {
+	out := make([]string, len(laggards))
+	for i, l := range laggards {
+		out[i] = l.GetNode()
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestFanOut_AllNodesReady_ReturnsApplied verifies that when every member
+// (self + peer liaisons + data nodes) reports max_rev >= min_rev, the call
+// returns Applied=true on the first iteration.
+func TestFanOut_AllNodesReady_ReturnsApplied(t *testing.T) {
+	const target = int64(100)
+	cache := &staticBarrierCache{maxModRevision: 200}
+	tier1 := newFakeTier([]string{"liaison-1"}, map[string]clusterv1.NodeSchemaStatusServiceClient{
+		"liaison-1": &fakeNodeStatusClient{maxRev: 150},
+	})
+	tier2 := newFakeTier([]string{"data-1", "data-2"}, map[string]clusterv1.NodeSchemaStatusServiceClient{
+		"data-1": &fakeNodeStatusClient{maxRev: 110},
+		"data-2": &fakeNodeStatusClient{maxRev: target},
+	})
+	svc := (&clusterFixture{cache: cache, tier1: tier1, tier2: tier2, self: "self-liaison"}).build()
+
+	resp, err := svc.AwaitRevisionApplied(context.Background(), &schemav1.AwaitRevisionAppliedRequest{
+		MinRevision: target,
+		Timeout:     durationpb.New(50 * time.Millisecond),
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.GetApplied())
+	assert.Empty(t, resp.GetLaggards())
+}
+
+// TestFanOut_OneLaggard_ReportsOnTimeout verifies that when one peer remains
+// behind the target on every iteration, the timeout response names exactly
+// that laggard with its addressable role-prefixed identifier.
+func TestFanOut_OneLaggard_ReportsOnTimeout(t *testing.T) {
+	cache := &staticBarrierCache{maxModRevision: 100}
+	tier1 := newFakeTier(nil, nil)
+	tier2 := newFakeTier([]string{"data-1", "data-slow"}, map[string]clusterv1.NodeSchemaStatusServiceClient{
+		"data-1":    &fakeNodeStatusClient{maxRev: 100},
+		"data-slow": &fakeNodeStatusClient{maxRev: 42}, // never catches up
+	})
+	svc := (&clusterFixture{cache: cache, tier1: tier1, tier2: tier2, self: "self-liaison"}).build()
+
+	resp, err := svc.AwaitRevisionApplied(context.Background(), &schemav1.AwaitRevisionAppliedRequest{
+		MinRevision: 100,
+		Timeout:     durationpb.New(80 * time.Millisecond),
+	})
+	require.NoError(t, err)
+	assert.False(t, resp.GetApplied())
+	require.Len(t, resp.GetLaggards(), 1)
+	assert.Equal(t, "data-data-slow", resp.GetLaggards()[0].GetNode())
+	assert.Equal(t, int64(42), resp.GetLaggards()[0].GetCurrentModRevision())
+}
+
+// TestFanOut_AllLaggards_ListsAll verifies that when every probed peer is
+// behind the target, all of them appear in the laggards list with their
+// role-prefixed names.
+func TestFanOut_AllLaggards_ListsAll(t *testing.T) {
+	cache := &staticBarrierCache{maxModRevision: 0} // self also behind
+	tier1 := newFakeTier([]string{"peer-l"}, map[string]clusterv1.NodeSchemaStatusServiceClient{
+		"peer-l": &fakeNodeStatusClient{maxRev: 5},
+	})
+	tier2 := newFakeTier([]string{"peer-d"}, map[string]clusterv1.NodeSchemaStatusServiceClient{
+		"peer-d": &fakeNodeStatusClient{maxRev: 7},
+	})
+	svc := (&clusterFixture{cache: cache, tier1: tier1, tier2: tier2, self: "self-liaison"}).build()
+
+	resp, err := svc.AwaitRevisionApplied(context.Background(), &schemav1.AwaitRevisionAppliedRequest{
+		MinRevision: 100,
+		Timeout:     durationpb.New(60 * time.Millisecond),
+	})
+	require.NoError(t, err)
+	assert.False(t, resp.GetApplied())
+	assert.Equal(t, []string{"data-peer-d", "liaison-peer-l", "liaison-self-liaison"},
+		laggardNames(resp.GetLaggards()))
+}
+
+// TestFanOut_NodeRPCErrors_CountedAsLaggard verifies that a non-Unimplemented
+// gRPC error from a per-member probe makes that member a laggard for the
+// iteration but does not fail the whole call. With a generous catch-up
+// scenario the loop converges once the error clears.
+func TestFanOut_NodeRPCErrors_CountedAsLaggard(t *testing.T) {
+	cache := &staticBarrierCache{maxModRevision: 100}
+	errClient := &fakeNodeStatusClient{err: status.Errorf(codes.Internal, "boom")}
+	tier1 := newFakeTier(nil, nil)
+	tier2 := newFakeTier([]string{"sick"}, map[string]clusterv1.NodeSchemaStatusServiceClient{
+		"sick": errClient,
+	})
+	svc := (&clusterFixture{cache: cache, tier1: tier1, tier2: tier2, self: "self-liaison"}).build()
+
+	resp, err := svc.AwaitRevisionApplied(context.Background(), &schemav1.AwaitRevisionAppliedRequest{
+		MinRevision: 100,
+		Timeout:     durationpb.New(60 * time.Millisecond),
+	})
+	require.NoError(t, err)
+	assert.False(t, resp.GetApplied())
+	require.Len(t, resp.GetLaggards(), 1)
+	assert.Equal(t, "data-sick", resp.GetLaggards()[0].GetNode())
+}
+
+// TestFanOut_EmptyActiveSet_ReturnsUnavailable verifies that when the snapshot
+// finds zero members (no self, no peers, no data nodes) the call fails fast
+// with codes.Unavailable rather than parking on an empty watched set.
+func TestFanOut_EmptyActiveSet_ReturnsUnavailable(t *testing.T) {
+	svc := (&clusterFixture{
+		cache: &staticBarrierCache{},
+		tier1: newFakeTier(nil, nil),
+		tier2: newFakeTier(nil, nil),
+		self:  "", // empty self → no member contributed
+	}).build()
+
+	resp, err := svc.AwaitRevisionApplied(context.Background(), &schemav1.AwaitRevisionAppliedRequest{
+		MinRevision: 1,
+		Timeout:     durationpb.New(20 * time.Millisecond),
+	})
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Equal(t, codes.Unavailable, status.Code(err))
+}
+
+// TestFanOut_ProbeIsShortUnary_NoServerWait verifies that a slow per-member
+// probe (the fake delays past the call deadline) is treated as a transient
+// laggard rather than as a successful long-poll. The whole call returns
+// applied=false within the timeout instead of blocking on the slow probe.
+func TestFanOut_ProbeIsShortUnary_NoServerWait(t *testing.T) {
+	cache := &staticBarrierCache{maxModRevision: 100}
+	slow := &fakeNodeStatusClient{delay: 200 * time.Millisecond, maxRev: 100}
+	tier2 := newFakeTier([]string{"slow"}, map[string]clusterv1.NodeSchemaStatusServiceClient{
+		"slow": slow,
+	})
+	svc := (&clusterFixture{cache: cache, tier1: newFakeTier(nil, nil), tier2: tier2, self: "self-liaison"}).build()
+
+	start := time.Now()
+	resp, err := svc.AwaitRevisionApplied(context.Background(), &schemav1.AwaitRevisionAppliedRequest{
+		MinRevision: 100,
+		Timeout:     durationpb.New(60 * time.Millisecond),
+	})
+	elapsed := time.Since(start)
+	require.NoError(t, err)
+	assert.False(t, resp.GetApplied())
+	assert.Less(t, elapsed, 500*time.Millisecond,
+		"call must respect its own deadline rather than waiting for the slow per-probe response")
+	require.Len(t, resp.GetLaggards(), 1)
+	assert.Equal(t, "data-slow", resp.GetLaggards()[0].GetNode())
+}
+
+// TestFanOut_BackoffBounded verifies that when convergence requires multiple
+// iterations the caller observes >= 2 probes per member but the per-iteration
+// sleep stays bounded so the overall call respects its timeout. The fake
+// peer counts how many times GetMaxRevision was called; the loop should make
+// at least 2 probes inside an 80ms budget.
+func TestFanOut_BackoffBounded(t *testing.T) {
+	var calls int32
+	cache := &staticBarrierCache{maxModRevision: 100}
+	peer := &fakeNodeStatusClient{maxRev: 50, callsRef: &calls} // permanently behind
+	tier2 := newFakeTier([]string{"laggy"}, map[string]clusterv1.NodeSchemaStatusServiceClient{
+		"laggy": peer,
+	})
+	svc := (&clusterFixture{cache: cache, tier1: newFakeTier(nil, nil), tier2: tier2, self: "self-liaison"}).build()
+
+	start := time.Now()
+	_, err := svc.AwaitRevisionApplied(context.Background(), &schemav1.AwaitRevisionAppliedRequest{
+		MinRevision: 100,
+		Timeout:     durationpb.New(80 * time.Millisecond),
+	})
+	elapsed := time.Since(start)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, atomic.LoadInt32(&calls), int32(2),
+		"backoff loop must make multiple probes within the timeout window")
+	// 80ms budget plus init/grow/cap sleeps; even the worst-case wall-clock
+	// stays well under 500ms = barrierMaxInterval.
+	assert.Less(t, elapsed, 500*time.Millisecond,
+		"timeout must not be exceeded by the backoff schedule")
+}
+
+// TestFanOut_NodeReturnsUnimplemented_TreatedAsReady locks the cross-version
+// policy: a peer (or data node) that returns codes.Unimplemented from
+// NodeSchemaStatusService — i.e. a Phase-1 v0.11/v0.12 node — is treated as
+// ready (assume max_revision = ∞) so partial-upgrade clusters do not deadlock
+// barrier callers.
+func TestFanOut_NodeReturnsUnimplemented_TreatedAsReady(t *testing.T) {
+	cache := &staticBarrierCache{maxModRevision: 100}
+	legacy := &fakeNodeStatusClient{err: status.Error(codes.Unimplemented, "phase 1 node")}
+	tier2 := newFakeTier([]string{"phase1"}, map[string]clusterv1.NodeSchemaStatusServiceClient{
+		"phase1": legacy,
+	})
+	svc := (&clusterFixture{cache: cache, tier1: newFakeTier(nil, nil), tier2: tier2, self: "self-liaison"}).build()
+
+	resp, err := svc.AwaitRevisionApplied(context.Background(), &schemav1.AwaitRevisionAppliedRequest{
+		MinRevision: 100,
+		Timeout:     durationpb.New(50 * time.Millisecond),
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.GetApplied(),
+		"Unimplemented from a Phase-1 peer must not block a v0.13 barrier caller")
+	assert.Empty(t, resp.GetLaggards())
+}

--- a/banyand/liaison/grpc/barrier_cluster_test.go
+++ b/banyand/liaison/grpc/barrier_cluster_test.go
@@ -55,6 +55,7 @@ type fakeNodeStatusClient struct {
 	err          error
 	callsRef     *int32
 	keyState     map[string]fakeKeyState
+	keyStateFn   func() map[string]fakeKeyState
 	keyRevsCalls *int32
 	revs         []int64
 	maxRev       int64
@@ -126,8 +127,37 @@ func keyStateKey(kind, group, name string) string {
 	return kind + "|" + group + "|" + name
 }
 
-func (*fakeNodeStatusClient) GetAbsentKeys(_ context.Context, _ *clusterv1.GetAbsentKeysRequest, _ ...grpc.CallOption) (*clusterv1.GetAbsentKeysResponse, error) {
-	panic("GetAbsentKeys: unused in Phase 2.2 tests")
+func (f *fakeNodeStatusClient) GetAbsentKeys(
+	ctx context.Context, req *clusterv1.GetAbsentKeysRequest, _ ...grpc.CallOption,
+) (*clusterv1.GetAbsentKeysResponse, error) {
+	if f.keyRevsCalls != nil {
+		atomic.AddInt32(f.keyRevsCalls, 1)
+	}
+	if f.keyRevsDelay > 0 {
+		select {
+		case <-time.After(f.keyRevsDelay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	if f.err != nil {
+		return nil, f.err
+	}
+	state := f.keyState
+	if f.keyStateFn != nil {
+		state = f.keyStateFn()
+	}
+	keys := req.GetKeys()
+	var absent, present []*schemav1.SchemaKey
+	for _, k := range keys {
+		mapKey := k.GetKind() + "|" + k.GetGroup() + "|" + k.GetName()
+		if s, ok := state[mapKey]; ok && s.present {
+			present = append(present, k)
+			continue
+		}
+		absent = append(absent, k)
+	}
+	return &clusterv1.GetAbsentKeysResponse{AbsentKeys: absent, StillPresentKeys: present}, nil
 }
 
 // fakeQueueClient embeds queue.Client (a nil interface) so unused methods
@@ -686,4 +716,116 @@ func TestAwaitSchemaApplied_FanOut_PeerUnimplemented_TreatedAsReady(t *testing.T
 	assert.True(t, resp.GetApplied(),
 		"Unimplemented from a Phase-1 peer must not block AwaitSchemaApplied")
 	assert.Empty(t, resp.GetLaggards())
+}
+
+// TestAwaitSchemaDeleted_FanOut_ReportsStillPresent verifies that the
+// timeout response carries per-node still_present_keys with role-prefixed
+// identifiers — exact mirror of the AwaitSchemaApplied missing-keys layout
+// for the deletion barrier.
+func TestAwaitSchemaDeleted_FanOut_ReportsStillPresent(t *testing.T) {
+	keys := []*schemav1.SchemaKey{
+		streamKey("g", "k0"),
+		streamKey("g", "k1"),
+		streamKey("g", "k2"),
+	}
+	cache := &staticBarrierCache{maxModRevision: 100} // self has nothing → all absent
+	peerA := &fakeNodeStatusClient{keyState: map[string]fakeKeyState{
+		keyStateKey("stream", "g", "k0"): presentAt(100),
+		keyStateKey("stream", "g", "k1"): presentAt(100),
+	}} // still_present: k0, k1
+	peerB := &fakeNodeStatusClient{keyState: map[string]fakeKeyState{
+		keyStateKey("stream", "g", "k2"): presentAt(100),
+	}} // still_present: k2
+	tier1 := newFakeTier([]string{"peer-A", "peer-B"}, map[string]clusterv1.NodeSchemaStatusServiceClient{
+		"peer-A": peerA,
+		"peer-B": peerB,
+	})
+	svc := (&clusterFixture{cache: cache, tier1: tier1, tier2: newFakeTier(nil, nil), self: "self-liaison"}).build()
+
+	resp, err := svc.AwaitSchemaDeleted(context.Background(), &schemav1.AwaitSchemaDeletedRequest{
+		Keys:    keys,
+		Timeout: durationpb.New(60 * time.Millisecond),
+	})
+	require.NoError(t, err)
+	assert.False(t, resp.GetApplied())
+	require.Len(t, resp.GetLaggards(), 2)
+
+	la := laggardByNode(resp.GetLaggards(), "liaison-peer-A")
+	require.NotNil(t, la, "laggard for peer-A must be present")
+	assert.Equal(t, []string{"k0", "k1"}, schemaKeyNames(la.GetStillPresentKeys()))
+
+	lb := laggardByNode(resp.GetLaggards(), "liaison-peer-B")
+	require.NotNil(t, lb, "laggard for peer-B must be present")
+	assert.Equal(t, []string{"k2"}, schemaKeyNames(lb.GetStillPresentKeys()))
+}
+
+// TestAwaitSchemaDeleted_FanOut_SucceedsAfterAllNodesDrain verifies that
+// once every member reports the keys absent, applied=true is returned. The
+// peer's keyState is mutated on the second probe call to simulate a drain
+// completing mid-call (real production: the watch event finally landed).
+func TestAwaitSchemaDeleted_FanOut_SucceedsAfterAllNodesDrain(t *testing.T) {
+	keys := []*schemav1.SchemaKey{streamKey("g", "k0"), streamKey("g", "k1")}
+	cache := &staticBarrierCache{maxModRevision: 100} // self drained from start
+	var calls int32
+	peer := &fakeNodeStatusClient{
+		keyRevsCalls: &calls,
+		keyStateFn: func() map[string]fakeKeyState {
+			// Call 1: both keys still present; call 2+: both drained.
+			if atomic.LoadInt32(&calls) <= 1 {
+				return map[string]fakeKeyState{
+					keyStateKey("stream", "g", "k0"): presentAt(100),
+					keyStateKey("stream", "g", "k1"): presentAt(100),
+				}
+			}
+			return map[string]fakeKeyState{}
+		},
+	}
+	tier1 := newFakeTier([]string{"peer"}, map[string]clusterv1.NodeSchemaStatusServiceClient{"peer": peer})
+	svc := (&clusterFixture{cache: cache, tier1: tier1, tier2: newFakeTier(nil, nil), self: "self-liaison"}).build()
+
+	resp, err := svc.AwaitSchemaDeleted(context.Background(), &schemav1.AwaitSchemaDeletedRequest{
+		Keys:    keys,
+		Timeout: durationpb.New(200 * time.Millisecond),
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.GetApplied(),
+		"barrier must converge once peer reports both keys absent on the second probe")
+	assert.Empty(t, resp.GetLaggards())
+	assert.GreaterOrEqual(t, atomic.LoadInt32(&calls), int32(2),
+		"the loop must have probed at least twice for the drain to be observed")
+}
+
+// TestAwaitSchemaDeleted_FanOut_MixedOldAndNewSchemasOnSameKey verifies
+// that after a delete + recreate at a higher revision, the absence probe
+// recognizes the new live row on every member and returns applied=false
+// with that key in still_present_keys (the new instance is alive — the
+// caller's deletion request is no longer accurate for it).
+//
+// Setup: key "k0" was deleted then recreated at rev=200. peer's cache
+// reports it Present with rev=200. Self's cache also reports it present.
+// The barrier must therefore time out and surface the still-present key.
+func TestAwaitSchemaDeleted_FanOut_MixedOldAndNewSchemasOnSameKey(t *testing.T) {
+	keys := []*schemav1.SchemaKey{streamKey("g", "k0")}
+	cache := &staticBarrierCache{
+		maxModRevision: 200,
+		keys:           map[string]int64{"stream_g/k0": 200}, // recreated at higher rev
+	}
+	peer := &fakeNodeStatusClient{keyState: map[string]fakeKeyState{
+		keyStateKey("stream", "g", "k0"): presentAt(200),
+	}}
+	tier1 := newFakeTier([]string{"peer"}, map[string]clusterv1.NodeSchemaStatusServiceClient{"peer": peer})
+	svc := (&clusterFixture{cache: cache, tier1: tier1, tier2: newFakeTier(nil, nil), self: "self-liaison"}).build()
+
+	resp, err := svc.AwaitSchemaDeleted(context.Background(), &schemav1.AwaitSchemaDeletedRequest{
+		Keys:    keys,
+		Timeout: durationpb.New(40 * time.Millisecond),
+	})
+	require.NoError(t, err)
+	assert.False(t, resp.GetApplied(),
+		"a recreated-at-higher-rev key is alive on every member; deletion barrier must NOT report applied=true")
+	require.NotEmpty(t, resp.GetLaggards())
+	for _, l := range resp.GetLaggards() {
+		assert.Equal(t, []string{"k0"}, schemaKeyNames(l.GetStillPresentKeys()),
+			"every member's laggard entry must list k0 as still present")
+	}
 }

--- a/banyand/liaison/grpc/server.go
+++ b/banyand/liaison/grpc/server.go
@@ -256,13 +256,22 @@ func NewServer(_ context.Context, tir1Client, tir2Client, broadcaster queue.Clie
 	// Tier1 (peer liaisons) and tier2 (data nodes) connection pools are
 	// borrowed via the queue.Client interface added in #1109; the receiving
 	// liaison's name is read from s.curNode, which initCurrentNode populates
-	// during PreRun — hence the closure indirection.
+	// during PreRun — hence the closure indirection. The explicit nil check
+	// covers the test-context case where ContextNodeKey is unset and
+	// initCurrentNode leaves curNode nil; an empty selfName makes the
+	// barrier exclude self from the watched set, which is the correct
+	// behavior for headless test fixtures.
 	if cacheProvider != nil {
 		s.barrierSVC = newBarrierServiceCluster(
 			cacheProvider,
 			func() queue.Client { return tir1Client },
 			func() queue.Client { return tir2Client },
-			func() string { return s.curNode.GetMetadata().GetName() },
+			func() string {
+				if s.curNode == nil {
+					return ""
+				}
+				return s.curNode.GetMetadata().GetName()
+			},
 		)
 	}
 	s.accessLogRecorders = []accessLogRecorder{streamSVC, measureSVC, traceSVC, s.propertyServer}

--- a/banyand/liaison/grpc/server.go
+++ b/banyand/liaison/grpc/server.go
@@ -184,10 +184,10 @@ func NewServer(_ context.Context, tir1Client, tir2Client, broadcaster queue.Clie
 		propertyServer: propertyService,
 	}
 
-	var barrierSVC *barrierService
 	var nodeStatusSVC *property.NodeSchemaStatusServer
+	var cacheProvider func() barrierCacheReader
 	if svc, svcOk := schemaRegistry.(metadata.Service); svcOk {
-		barrierSVC = newBarrierService(func() barrierCacheReader {
+		cacheProvider = func() barrierCacheReader {
 			inner := svc.SchemaRegistry()
 			if inner == nil {
 				return nil
@@ -197,7 +197,7 @@ func NewServer(_ context.Context, tir1Client, tir2Client, broadcaster queue.Clie
 				return nil
 			}
 			return bc
-		})
+		}
 		// Phase 2 Step 2.1: every cluster member with a schema cache exposes
 		// NodeSchemaStatusService so peer liaisons (Step 2.2 fan-out) can
 		// probe this liaison's cache identically to a data node. The receiving
@@ -221,7 +221,6 @@ func NewServer(_ context.Context, tir1Client, tir2Client, broadcaster queue.Clie
 		traceSVC:      traceSVC,
 		bydbQLSVC:     bydbQLSVC,
 		groupRepo:     gr,
-		barrierSVC:    barrierSVC,
 		nodeStatusSVC: nodeStatusSVC,
 		streamRegistryServer: &streamRegistryServer{
 			schemaRegistry: schemaRegistry,
@@ -252,6 +251,19 @@ func NewServer(_ context.Context, tir1Client, tir2Client, broadcaster queue.Clie
 		authReloader:        auth.InitAuthReloader(),
 		protector:           protectorService,
 		routeTableProviders: routeProviders,
+	}
+	// Phase 2 Step 2.2: wire the cluster-wide AwaitRevisionApplied fan-out.
+	// Tier1 (peer liaisons) and tier2 (data nodes) connection pools are
+	// borrowed via the queue.Client interface added in #1109; the receiving
+	// liaison's name is read from s.curNode, which initCurrentNode populates
+	// during PreRun — hence the closure indirection.
+	if cacheProvider != nil {
+		s.barrierSVC = newBarrierServiceCluster(
+			cacheProvider,
+			func() queue.Client { return tir1Client },
+			func() queue.Client { return tir2Client },
+			func() string { return s.curNode.GetMetadata().GetName() },
+		)
 	}
 	s.accessLogRecorders = []accessLogRecorder{streamSVC, measureSVC, traceSVC, s.propertyServer}
 	s.queryAccessLogRecorders = []queryAccessLogRecorder{streamSVC, measureSVC, traceSVC, s.propertyServer}

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2165,9 +2165,12 @@ requested keys.
 <a name="banyandb-schema-v1-NodeLaggard"></a>
 
 ### NodeLaggard
-NodeLaggard reports a single data node that has not caught up to the
-requested schema state. missing_keys is populated by AwaitSchemaApplied
-responses; still_present_keys is populated by AwaitSchemaDeleted responses.
+NodeLaggard reports a single cluster member (peer liaison or data node)
+that has not caught up to the requested schema state. missing_keys is
+populated by AwaitSchemaApplied responses; still_present_keys by
+AwaitSchemaDeleted responses. reason is set when the laggard exists for a
+non-default cause (e.g. &#34;evicted_during_poll&#34; when the cluster transitioned
+the member from Active to Evictable mid-call); empty otherwise.
 
 
 | Field | Type | Label | Description |
@@ -2176,6 +2179,7 @@ responses; still_present_keys is populated by AwaitSchemaDeleted responses.
 | current_mod_revision | [int64](#int64) |  |  |
 | missing_keys | [SchemaKey](#banyandb-schema-v1-SchemaKey) | repeated |  |
 | still_present_keys | [SchemaKey](#banyandb-schema-v1-SchemaKey) | repeated |  |
+| reason | [string](#string) |  |  |
 
 
 

--- a/test/cases/schema/clamp.go
+++ b/test/cases/schema/clamp.go
@@ -116,17 +116,6 @@ var _ = g.Describe("Schema time-range clamp", func() {
 	// server clamps Begin forward to CreatedAt and the query executes successfully.
 	// Since no data was written the response has zero elements but no error.
 	g.It("succeeds and returns zero elements when query spans schema CreatedAt (§4.6.2)", func() {
-		// TODO(phase-2): Phase 1 AwaitRevisionApplied / AwaitSchemaApplied are liaison-only
-		// by design. Unlike §4.6.1 and §4.6.3 (both ends far in the past, where the clamp
-		// short-circuits at the liaison and never dispatches to data nodes), this spec uses
-		// End=now+1h so the clamped range is non-empty and the query is dispatched. In
-		// distributed mode the data node can lag the liaison's schema view at that moment,
-		// causing the dispatched query to fail with "group not found". Cluster-wide barrier
-		// semantics ship in Phase 2 via NodeSchemaStatusService + liaison fan-out (plan
-		// Steps 2.1–2.2); re-enable this spec in distributed mode once those land.
-		if SharedContext.Mode == helpers.ModeDistributed {
-			g.Skip("§4.6.2 requires cluster-wide propagation barrier (Phase 2)")
-		}
 		groupName := fmt.Sprintf("clamp-span-%d", time.Now().UnixNano())
 		streamName := "clamp_stream"
 
@@ -226,15 +215,12 @@ var _ = g.Describe("Schema time-range clamp", func() {
 	// inside [Begin, End] and the datum would leak — proving the clamp is actually
 	// applied rather than merely consistent with an already-in-range write.
 	g.It("clips TimeRange.Begin to max(CreatedAt) and excludes pre-creation data (§4.6.4)", func() {
-		// TODO(phase-2): Phase 1 AwaitRevisionApplied is liaison-only by design. This spec's
-		// baseline sanity check (Create → AwaitRevision → Write → Query expecting HaveLen(1))
-		// races the data-node tsTable readiness in distributed mode. The actual clamp
-		// falsification is sound; only the prerequisite Write→Query round-trip flakes.
-		// Cluster-wide barrier semantics ship in Phase 2 via NodeSchemaStatusService +
-		// liaison fan-out (plan Steps 2.1–2.2); re-enable this spec in distributed mode
-		// once those land.
+		// Phase 2.2 barrier ensures schema is on every node, but this spec's
+		// baseline sanity step (Create → Write → Query expecting 1 datum)
+		// still races the data-node write path in distributed mode. Re-enable
+		// once Step 2.5 (cluster query gate) lands.
 		if SharedContext.Mode == helpers.ModeDistributed {
-			g.Skip("§4.6.4 requires cluster-wide propagation barrier (Phase 2)")
+			g.Skip("§4.6.4 requires the cluster-wide query gate (Phase 2 Step 2.5)")
 		}
 		group1 := fmt.Sprintf("clamp-leak1-%d", time.Now().UnixNano())
 		group2 := fmt.Sprintf("clamp-leak2-%d", time.Now().UnixNano())

--- a/test/cases/schema/shape_break.go
+++ b/test/cases/schema/shape_break.go
@@ -160,14 +160,12 @@ var _ = g.Describe("Schema shape-break rejection", func() {
 
 	// §6.8: shape-break — delete+apply new shape creates the new measure (Rule 7 clamp end-to-end).
 	g.It("shape-break: delete+apply new shape creates the new measure (§6.8)", func() {
-		// TODO(phase-2): Phase 1 AwaitRevisionApplied is liaison-only by design. Both this spec
-		// and §6.11 perform an end-to-end data Write+Query round-trip through the liaison after
-		// a schema mutation; in distributed mode the data node can lag the liaison briefly on
-		// tsTable readiness or query-side index refresh, racing the immediate Write→Query.
-		// Cluster-wide barrier semantics ship in Phase 2 via NodeSchemaStatusService + liaison
-		// fan-out (plan Steps 2.1–2.2); re-enable this spec in distributed mode once those land.
+		// Phase 2.2 cluster barrier confirms schema propagation across nodes,
+		// but this spec's Write→Query baseline races the data-node write path
+		// independently of the schema barrier. Re-enable in distributed mode
+		// once Step 2.5 (cluster query gate) lands.
 		if SharedContext.Mode == helpers.ModeDistributed {
-			g.Skip("§6.8 requires cluster-wide propagation barrier (Phase 2)")
+			g.Skip("§6.8 requires the cluster-wide query gate (Phase 2 Step 2.5)")
 		}
 		groupName := fmt.Sprintf("sb-new-%d", time.Now().UnixNano())
 		measureName := "throughput"
@@ -410,14 +408,11 @@ var _ = g.Describe("Schema shape-break rejection", func() {
 
 	// §6.11: delete-then-recreate original shape drops old data (Rule 7 clamp).
 	g.It("delete-then-recreate original shape drops old data (§6.11)", func() {
-		// TODO(phase-2): Phase 1 AwaitRevisionApplied is liaison-only by design — it confirms
-		// the liaison cache observes R2 but not that every data node has rebuilt the tsTable
-		// after the delete-then-recreate. The post-recreate Write+Query round-trip exercised
-		// by this spec races the data-node tsTable rebuild on slow CI runners. Cluster-wide
-		// barrier semantics ship in Phase 2 via NodeSchemaStatusService + liaison fan-out
-		// (plan Steps 2.1–2.2); re-enable this spec in distributed mode once those land.
+		// Same write→query race as §6.8 — Phase 2.2's barrier ensures schema
+		// coherence but the post-recreate Write→Query baseline still flakes
+		// without the cluster query gate. Re-enable once Step 2.5 lands.
 		if SharedContext.Mode == helpers.ModeDistributed {
-			g.Skip("§6.11 requires cluster-wide propagation barrier (Phase 2)")
+			g.Skip("§6.11 requires the cluster-wide query gate (Phase 2 Step 2.5)")
 		}
 		groupName := fmt.Sprintf("sb-same-%d", time.Now().UnixNano())
 		measureName := "throughput"


### PR DESCRIPTION
> **DRAFT — for CP-5 contract review only.** Per the workflow, this PR will not be marked ready until CP-5 reviewers (dev lead + SRE) sign off the cluster-barrier contract. Two commits at the bottom (`3588e39c`, `3f7a6c75`) are also in the in-flight per-step PR #1111; merging is blocked on #1111 anyway. Opening this PR is purely to surface the cumulative Steps 2.2 + 2.3 + 2.4 surface for Copilot + human review in one place.

### Copilot, please focus this review on:

**1. Bugs and correctness issues** in the cluster-barrier fan-out:
- `banyand/liaison/grpc/barrier_cluster.go` — frozen-snapshot membership semantics (`applyTransitions` / `applyTransitionsApplied`), per-iteration probe loops, deadline propagation, cross-version `Unimplemented → ready` handling, transient-error handling.
- The three `awaitXxxCluster` paths (`awaitRevisionAppliedCluster`, `awaitSchemaAppliedCluster`, `awaitSchemaDeletedCluster`) — race conditions, off-by-one in chunking, missed laggard reports, premature applied=true returns.
- `evictedLaggardReason` handling: is the laggard surfaced exactly once? Does `lastRev` carry the correct mod_revision into the laggard's `current_mod_revision`?
- Self-vs-peer dispatch in `probeOne` / `probeKeysOne` / `probeAbsentOne`: fail-closed on nil cache, correct tier client lookup for `roleData` vs `roleLiaison`.
- The `NodeLaggard.reason` proto field is additive (field 5); is the regen consistent across `barrier.pb.go` and the docs?
- `test/cases/schema/{shape_break,clamp}.go`: the §4.6.2 unblock and the §6.8/§6.11/§4.6.4 re-skip — are the comments accurate about what races vs. what the cluster barrier covers?

**2. Performance concerns** under realistic load:
- HTTP/2 stream contention: every per-member probe rides on `pub`'s existing tier1/tier2 `*grpc.ClientConn`. Could the per-iteration probe burst (≤10 polls × N peers in a 5s budget) starve concurrent write/query traffic on the same connection?
- Goroutine cost per iteration: `probeMembers` / `probeKeyRevisions` / `probeAbsentKeys` spawn one goroutine per member per iteration. On a 50-node cluster running, say, 100 concurrent barrier calls, that's 5000 goroutines per iteration. Bounded? Pool-able? Backpressure?
- Chunking memory: `barrierKeyChunkSize=1000`, `barrierMaxKeys=10000` means up to 10 chunks per peer per iteration. The accumulator slice (`missing`, `present`, `stillPresent`) reallocates on append — is preallocation worth it given chunk count is small?
- `currentMembership()` runs every iteration and calls `GetRouteTable()` on both tiers, which clones the route table internally. At ≤10 polls per call, this is ≤20 GetRouteTable calls per call. Acceptable, but could be cached.
- Backoff cadence: 10ms → ×1.5 → cap 500ms gives ≤10 probes per 5s budget per member. The §5.0 sequence diagram math holds; flagging just in case Copilot sees a tighter pattern.

### What's in the branch

| Commit | Step | Acceptance |
|---|---|---|
| `3588e39c` | Step 2.2 fan-out (`AwaitRevisionApplied`) | A11, A15 cluster |
| `3f7a6c75` | #1111 fix: `selfName` closure nil-safety | (Copilot review tweak) |
| `87d2723c` | §SS-1..§SS-4: `NodeLaggard.reason` proto + mid-call eviction / leave / late-join | (frozen-snapshot semantics for Steps 2.2 / 2.3 / 2.4) |
| `1d789975` | §FA-1, §FA-2: `AwaitSchemaApplied` cluster fan-out + chunking + shared deadline | A12 cluster |
| `6731df5c` | §FD-1, §FD-2: `AwaitSchemaDeleted` cluster fan-out | A13 cluster |
| `47006561` | §RE-1: re-enable §4.6.2 in distributed; defer §6.8/§6.11/§4.6.4 to Step 2.5 | (test re-enable; first attempt per plan) |

### What's deferred (NOT in this PR)

- §6.12a/b/c/d distributed integration specs (depend on `PauseDataNodeWatch` from Step 1.0; not implemented).
- Step 2.5 cluster query gate; Step 2.7 metrics; Step 2.8 verification harness.

### Local CI status

All phases green on this branch HEAD (`47006561`):
- `make license-check / check-req / build / lint / check`
- `make test-ci PKG=./banyand/...` (29 cluster-fan-out tests + Phase 1 helpers green)
- `make test-ci PKG=./bydbctl/...`, `./pkg/...`, `./fodc/...` (one fodc Prometheus port-2121 flake recovered on retry; unrelated to this branch)
- `make test-ci PKG=./test/integration/standalone/...` and `./test/integration/distributed/...` (§4.6.2 now passes in distributed mode)

### Checklist (per `.github/PULL_REQUEST_TEMPLATE`)

- [x] Non-trivial feature; design lives in `.omc/plans/banyandb-schema-tbd-plan.md` Step 2.2 / 2.3 / 2.4 (worktree-local).
- [x] Documentation: function-level comments in `barrier_cluster.go`; `NodeLaggard.reason` field documented in proto; `docs/api-reference.md` regenerated.
- [x] Tests: 14 new cluster-fan-out unit tests; existing 19 barrier tests stay green; distributed integration green with §4.6.2 re-enabled.
- [ ] UI-related — N/A.
- [ ] Closes/resolves/fixes existing issue — N/A; tracking continues under #1091's umbrella.