### PR TITLE
ci(flaky-test): skip loadtest packages from ./... discovery

### DIFF
--- a/.github/workflows/flaky-test.yml
+++ b/.github/workflows/flaky-test.yml
@@ -33,4 +33,8 @@ jobs:
     with:
       test-name: Flaky Tests
       options:  --vv --repeat 0 --label-filter '(integration&&!slow)||banyand'
+      # Exclude ./test/load/... — those packages are gated behind build tags
+      # (e.g. //go:build loadtest) and trip Ginkgo's compile step on ./... .
+      # Run them via their own make targets (e.g. make load-test-barrier).
+      pkg: ./api/... ./banyand/... ./bydbctl/... ./fodc/... ./mcp/... ./pkg/... ./scripts/... ./test/cases/... ./test/integration/... ./test/property_repair/...
       timeout-minutes: 50

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Test integration and banyand
         env:
           LOAD_TEST_MINUTES: ${{ inputs.load-test-minutes }}
-        run: TEST_CI_OPTS="--cover --covermode atomic --coverprofile=coverage.out ${{ inputs.options }}" make test-ci PKG=${{ inputs.pkg }}
+        run: TEST_CI_OPTS="--cover --covermode atomic --coverprofile=coverage.out ${{ inputs.options }}" make test-ci "PKG=${{ inputs.pkg }}"
       - if: ${{ failure() }}
         run: |
           ls /tmp


### PR DESCRIPTION
## Summary

The hourly **Flaky Test** cron has been failing on every run since #1121 (CP-6 schema-barrier load harness) landed. The failure is not actually flaky — it's a deterministic Ginkgo setup error:

```
# github.com/apache/skywalking-banyandb/test/load/schema_barrier
package github.com/apache/skywalking-banyandb/test/load/schema_barrier:
  build constraints exclude all Go files
FAIL    github.com/apache/skywalking-banyandb/test/load/schema_barrier [setup failed]
##[error]Process completed with exit code 2.
```

Root cause: `test/load/schema_barrier/` contains only one file, `barrier_loadtest_test.go`, gated by `//go:build loadtest`. The flaky-test workflow runs `make test-ci PKG=./...`, so Ginkgo recurses into the directory and tries to compile the package without the tag — there are zero matching Go files, so the suite aborts.

This PR narrows the flaky cron's `PKG` to the Go roots that exclude `./test/load/...`. The harness remains runnable via `make load-test-barrier`; any future tag-gated load package added under `./test/load/...` will also be ignored by the cron with no further change.

- `.github/workflows/flaky-test.yml`: enumerate the per-root PKG list, excluding `./test/load/...`, with a comment explaining why.
- `.github/workflows/test.yml`: quote `"PKG=${{ inputs.pkg }}"` so a whitespace-separated multi-path input survives `make`'s argv parsing. Backward-compatible: the default `./...` (no whitespace) behaves identically; without the quoting, `make test-ci PKG=./a/... ./b/...` would bind only the first path and fail with `No rule to make target 'b/...'`.

Verified locally:
- `go list ./api/... ./banyand/... ... ./test/property_repair/...` resolves to 220 packages, zero under `./test/load/`.
- `make ... 'PKG=./a/... ./b/...'` → `PKG=./a/... ./b/...`; unquoted form errors as above.

## Test plan

- [ ] Next scheduled run of `Flaky Test` (cron `50 * * * *`) on `main` completes without the schema_barrier compile failure.
- [ ] Regular PR CI (`Test`, etc.) using `test.yml` with the default `pkg: ./...` continues to pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code) via [HAPI](https://hapi.run)