### PR TITLE
Fix lifecycle migration of non-multiple segment intervals via row-replay

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -98,6 +98,7 @@ Release Notes.
 - Fail fast on incompatible storage version at boot. Previously the server would start in a degraded `SERVING` state with affected groups un-loaded because the property schema-registry retry loop swallowed the version-incompatibility panic. Compatible versions are listed in `banyand/internal/storage/versions.yml`.
 - Release bluge index writers on segment rotation so `analysisWorker` pools sized from `GOMAXPROCS` don't accumulate across rotations. Two layered defects kept the existing idle-segment reclaim path from running: `segmentIdleTimeout` defaulted to `0` (which disabled the 10-minute reclaim ticker), and `incRef` refreshed `lastAccessed` on every rotation tick so `closeIdleSegments` never observed an idle segment. Defaults to `time.Hour`, moves the `lastAccessed` bump to real read/write call sites, and rewrites `closeIdleSegments` to take its own CAS-bumped snapshot so a concurrent reopen cannot have its only ref dropped under the reclaimer (apache/skywalking#13874).
 - Fix incorrect counts and missing trace fields in the lifecycle migration report.
+- Fix lifecycle migration placing data in the wrong target segment when the source segment interval is not a multiple of the target stage's interval, by row-level replaying parts that straddle a target-segment boundary instead of chunk-copying them into a single segment.
 
 ### Chores
 

--- a/api/proto/banyandb/stream/v1/write.proto
+++ b/api/proto/banyandb/stream/v1/write.proto
@@ -72,4 +72,10 @@ message InternalWriteRequest {
   uint32 shard_id = 1;
   repeated model.v1.TagValue entity_values = 2;
   WriteRequest request = 3;
+  // raw_element_id carries the original storage-internal eID (an already-hashed uint64)
+  // forwarded by lifecycle row-replay. When non-zero, the receiver uses it directly
+  // and skips the HashStr step on element.element_id, so a logical element migrated
+  // through both chunk-sync and row-replay paths keeps the same target-side eID and
+  // query-layer dedup stays consistent. SDK and topN write paths leave this unset (0).
+  uint64 raw_element_id = 4;
 }

--- a/banyand/backup/lifecycle/measure_migration_visitor.go
+++ b/banyand/backup/lifecycle/measure_migration_visitor.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/apache/skywalking-banyandb/api/common"
@@ -30,6 +31,7 @@ import (
 	commonv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/common/v1"
 	"github.com/apache/skywalking-banyandb/banyand/internal/storage"
 	"github.com/apache/skywalking-banyandb/banyand/measure"
+	"github.com/apache/skywalking-banyandb/banyand/metadata"
 	"github.com/apache/skywalking-banyandb/banyand/queue"
 	"github.com/apache/skywalking-banyandb/pkg/fs"
 	"github.com/apache/skywalking-banyandb/pkg/logger"
@@ -39,22 +41,26 @@ import (
 
 // measureMigrationVisitor implements the measure.Visitor interface for file-based migration.
 type measureMigrationVisitor struct {
-	selector            node.Selector                      // From parseGroup - node selector
-	client              queue.Client                       // From parseGroup - queue client
-	chunkedClients      map[string]queue.ChunkedSyncClient // Per-node chunked sync clients cache
-	logger              *logger.Logger
-	progress            *Progress // Progress tracker for migration states
-	lfs                 fs.FileSystem
-	group               string
-	targetShardNum      uint32               // From parseGroup - target shard count
-	replicas            uint32               // From parseGroup - replica count
-	chunkSize           int                  // Chunk size for streaming data
-	targetStageInterval storage.IntervalRule // NEW: target stage's segment interval
+	client                  queue.Client
+	lfs                     fs.FileSystem
+	metadata                metadata.Repo
+	selector                node.Selector
+	chunkedClients          map[string]queue.ChunkedSyncClient
+	logger                  *logger.Logger
+	progress                *Progress
+	replayer                *measureRowReplayer
+	group                   string
+	targetStageInterval     storage.IntervalRule
+	chunkSize               int
+	partsCopiedSingleTarget uint64
+	partsReplayedRowLevel   uint64
+	targetShardNum          uint32
+	replicas                uint32
 }
 
 // newMeasureMigrationVisitor creates a new file-based migration visitor.
 func newMeasureMigrationVisitor(group *commonv1.Group, shardNum, replicas uint32, selector node.Selector, client queue.Client,
-	l *logger.Logger, progress *Progress, chunkSize int, targetStageInterval storage.IntervalRule,
+	l *logger.Logger, progress *Progress, chunkSize int, targetStageInterval storage.IntervalRule, md metadata.Repo,
 ) *measureMigrationVisitor {
 	return &measureMigrationVisitor{
 		group:               group.Metadata.Name,
@@ -67,8 +73,28 @@ func newMeasureMigrationVisitor(group *commonv1.Group, shardNum, replicas uint32
 		progress:            progress,
 		chunkSize:           chunkSize,
 		targetStageInterval: targetStageInterval,
+		metadata:            md,
 		lfs:                 fs.NewLocalFileSystem(),
 	}
+}
+
+// CounterSnapshot returns the current (chunk-sync, row-replay) part counts.
+func (mv *measureMigrationVisitor) CounterSnapshot() (chunkSync, rowReplay uint64) {
+	return atomic.LoadUint64(&mv.partsCopiedSingleTarget), atomic.LoadUint64(&mv.partsReplayedRowLevel)
+}
+
+// ensureReplayer lazily constructs the measureRowReplayer on first use.
+func (mv *measureMigrationVisitor) ensureReplayer(ctx context.Context) (*measureRowReplayer, error) {
+	if mv.replayer != nil {
+		return mv.replayer, nil
+	}
+	r, err := newMeasureRowReplayer(ctx, mv.group, mv.targetShardNum, mv.selector, mv.client, mv.metadata,
+		mv.lfs, mv.logger, &mv.partsReplayedRowLevel)
+	if err != nil {
+		return nil, fmt.Errorf("create measure row replayer: %w", err)
+	}
+	mv.replayer = r
+	return r, nil
 }
 
 // VisitSeries implements measure.Visitor.
@@ -102,10 +128,11 @@ func (mv *measureMigrationVisitor) VisitSeries(segmentTR *timestamp.TimeRange, s
 		Str("path", seriesIndexPath).
 		Msg("found measure segment files for migration")
 
-	// Calculate ALL target segments this series index should go to
+	// Calculate ALL target segments this series index should go to from the
+	// source segment's own [start, end) boundaries.
 	targetSegments := calculateTargetSegments(
-		segmentTR.Start.UnixNano(),
-		segmentTR.End.UnixNano(),
+		segmentTR.Start,
+		segmentTR.End,
 		mv.targetStageInterval,
 	)
 
@@ -114,7 +141,29 @@ func (mv *measureMigrationVisitor) VisitSeries(segmentTR *timestamp.TimeRange, s
 		Int64("series_min_ts", segmentTR.Start.UnixNano()).
 		Int64("series_max_ts", segmentTR.End.UnixNano()).
 		Str("group", mv.group).
-		Msg("migrating measure series index to multiple target segments")
+		Msg("migrating measure series index")
+
+	// When the source series-index spans multiple target segments, the row-replay
+	// path (VisitPart -> visitPartRowReplay) will republish every row through the
+	// real write API, and the receiver's writeCallback rebuilds the series index
+	// on the fly. Shipping the source .seg files would land them all in one
+	// target segment via Standard(MinTimestamp), so skip the file-based sync.
+	if len(targetSegments) > 1 {
+		mv.logger.Info().
+			Str("path", seriesIndexPath).
+			Int("target_segments_count", len(targetSegments)).
+			Str("group", mv.group).
+			Msg("source series index spans multiple target segments; skipping file-based sync (rebuilt by writeCallback)")
+		for _, segmentFileName := range segmentFiles {
+			fileSegmentIDStr := strings.TrimSuffix(segmentFileName, ".seg")
+			segmentID, parseErr := strconv.ParseUint(fileSegmentIDStr, 16, 64)
+			if parseErr != nil {
+				continue
+			}
+			mv.progress.MarkSourceMeasureSeriesCompleted(mv.group, seriesIndexPath, common.ShardID(segmentID))
+		}
+		return nil
+	}
 
 	// Send series index to EACH target segment that overlaps with its time range
 	for i, targetSegmentTime := range targetSegments {
@@ -171,12 +220,7 @@ func (mv *measureMigrationVisitor) VisitSeries(segmentTR *timestamp.TimeRange, s
 				return fmt.Errorf("failed to open measure segment file %s: %w", segmentFilePath, err)
 			}
 
-			// Close the file reader
-			defer func() {
-				if i == len(targetSegments)-1 { // Only close on last iteration
-					segmentFile.Close()
-				}
-			}()
+			defer segmentFile.Close()
 
 			files = append(files, fileInfo{
 				file: segmentFile,
@@ -223,7 +267,7 @@ func (mv *measureMigrationVisitor) VisitSeries(segmentTR *timestamp.TimeRange, s
 }
 
 // VisitPart implements measure.Visitor - core migration logic.
-func (mv *measureMigrationVisitor) VisitPart(_ *timestamp.TimeRange, sourceShardID common.ShardID, partPath string) error {
+func (mv *measureMigrationVisitor) VisitPart(segmentTR *timestamp.TimeRange, sourceShardID common.ShardID, partPath string) error {
 	partData, err := measure.ParsePartMetadata(mv.lfs, partPath)
 	if err != nil {
 		return fmt.Errorf("failed to parse measure part metadata: %w", err)
@@ -232,29 +276,48 @@ func (mv *measureMigrationVisitor) VisitPart(_ *timestamp.TimeRange, sourceShard
 	if err != nil {
 		return fmt.Errorf("failed to parse part ID from path: %w", err)
 	}
-	// Calculate ALL target segments this part should go to
+	// Decide the routing from the source segment's own [start, end) boundaries,
+	// the same range VisitSeries uses, so the per-part chunk-sync/row-replay
+	// decision stays consistent with whether the series index is file-synced.
 	targetSegments := calculateTargetSegments(
-		partData.MinTimestamp,
-		partData.MaxTimestamp,
+		segmentTR.Start,
+		segmentTR.End,
 		mv.targetStageInterval,
 	)
+
+	// Cross-segment guard: when the source segment covers more than one target
+	// segment, the chunk-sync path duplicates the same part bytes to every
+	// target with identical Min/Max timestamps so the receiver's
+	// Standard(MinTimestamp) routing lands every copy in a single target
+	// segment. Row-replay sidesteps this by publishing rows through the
+	// real write API, letting the receiver pick the target segment per row.
+	if len(targetSegments) > 1 {
+		return mv.visitPartRowReplay(context.Background(), segmentTR, sourceShardID, partID, partPath, targetSegments)
+	}
+	atomic.AddUint64(&mv.partsCopiedSingleTarget, 1)
+	mv.progress.AddMeasureChunkSyncPart(mv.group)
+
+	// Part completion is keyed by the SOURCE segment (segmentTR), not the target
+	// segment: part IDs reset per source segment, so two distinct source segments
+	// can both carry part_id=1 on the same shard. Keying by the target segment
+	// would let the second source part collide with the first and be skipped,
+	// dropping its data. Mirrors trace's source-keyed VisitShard.
+	sourceSegmentIDStr := segmentTR.String()
 
 	mv.logger.Info().
 		Uint64("part_id", partID).
 		Uint32("source_shard", uint32(sourceShardID)).
-		Int("target_segments_count", len(targetSegments)).
 		Int64("part_min_ts", partData.MinTimestamp).
 		Int64("part_max_ts", partData.MaxTimestamp).
 		Str("group", mv.group).
-		Msg("migrating measure part to multiple target segments")
+		Msg("migrating measure part via chunk-sync to single target segment")
 
 	// Send part to EACH target segment that overlaps with its time range
 	for i, targetSegmentTime := range targetSegments {
 		targetShardID := mv.calculateTargetShardID(uint32(sourceShardID))
 
-		// Check if this part has already been completed for this segment
-		segmentIDStr := getSegmentTimeRange(targetSegmentTime, mv.targetStageInterval).String()
-		if mv.progress.IsMeasurePartCompleted(mv.group, segmentIDStr, sourceShardID, partID) {
+		// Check if this part has already been completed (keyed by source segment).
+		if mv.progress.IsMeasurePartCompleted(mv.group, sourceSegmentIDStr, sourceShardID, partID) {
 			mv.logger.Debug().
 				Uint64("part_id", partID).
 				Uint32("source_shard", uint32(sourceShardID)).
@@ -266,11 +329,7 @@ func (mv *measureMigrationVisitor) VisitPart(_ *timestamp.TimeRange, sourceShard
 
 		// Create file readers for this part
 		files, release := measure.CreatePartFileReaderFromPath(partPath, mv.lfs)
-		defer func() {
-			if i == len(targetSegments)-1 { // Only release on last iteration
-				release()
-			}
-		}()
+		defer release()
 
 		// Clone part data for this target segment
 		targetPartData := partData
@@ -282,12 +341,12 @@ func (mv *measureMigrationVisitor) VisitPart(_ *timestamp.TimeRange, sourceShard
 		// Stream part to target segment
 		if err := mv.streamPartToTargetShard(targetPartData); err != nil {
 			errorMsg := fmt.Sprintf("failed to stream measure part to target segment %s: %v", targetSegmentTime.Format(time.RFC3339), err)
-			mv.progress.MarkMeasurePartError(mv.group, segmentIDStr, sourceShardID, partID, errorMsg)
+			mv.progress.MarkMeasurePartError(mv.group, sourceSegmentIDStr, sourceShardID, partID, errorMsg)
 			return fmt.Errorf("failed to stream measure part to target segment: %w", err)
 		}
 
-		// Mark part as completed for this specific target segment
-		mv.progress.MarkMeasurePartCompleted(mv.group, segmentIDStr, sourceShardID, partID)
+		// Mark part as completed (source-segment keyed).
+		mv.progress.MarkMeasurePartCompleted(mv.group, sourceSegmentIDStr, sourceShardID, partID)
 
 		mv.logger.Info().
 			Uint64("part_id", partID).
@@ -297,6 +356,74 @@ func (mv *measureMigrationVisitor) VisitPart(_ *timestamp.TimeRange, sourceShard
 	}
 
 	mv.progress.MarkSourceMeasurePartCompleted(mv.group, partPath, sourceShardID, partID)
+	return nil
+}
+
+// visitPartRowReplay handles the multi-target-segment case by re-publishing
+// each row of the source part through the real write API. The receiver picks
+// the destination segment per row, so the per-target loop is unnecessary
+// here. Progress is marked once for the whole part (matching chunk-sync
+// granularity).
+func (mv *measureMigrationVisitor) visitPartRowReplay(ctx context.Context, segmentTR *timestamp.TimeRange, sourceShardID common.ShardID, partID uint64,
+	partPath string, targetSegments []time.Time,
+) error {
+	// Resume guard: if a prior run already row-replayed this part, skip the
+	// re-replay (it would republish every row again, wasting work). Keyed by the
+	// SOURCE segment (segmentTR), not the target segments: part IDs reset per
+	// source segment, so a target-keyed check could collide with a different
+	// source segment's part of the same ID. Mirrors trace's VisitShard guard.
+	sourceSegmentIDStr := segmentTR.String()
+	if mv.progress.IsMeasurePartCompleted(mv.group, sourceSegmentIDStr, sourceShardID, partID) {
+		mv.progress.MarkSourceMeasurePartCompleted(mv.group, partPath, sourceShardID, partID)
+		mv.logger.Debug().
+			Uint64("part_id", partID).
+			Uint32("source_shard", uint32(sourceShardID)).
+			Str("group", mv.group).
+			Msg("measure part already row-replayed; skipping on resume")
+		return nil
+	}
+	replayer, err := mv.ensureReplayer(ctx)
+	if err != nil {
+		return err
+	}
+	mv.logger.Info().
+		Uint64("part_id", partID).
+		Uint32("source_shard", uint32(sourceShardID)).
+		Int("target_segments_count", len(targetSegments)).
+		Str("group", mv.group).
+		Msg("measure part spans multiple target segments; switching to row-replay")
+	rowCount, err := replayer.replayPart(ctx, partPath)
+	if err != nil {
+		// Row-replay is all-or-nothing per part; mark the source part errored so
+		// resume retries the whole part (same source key the guard checks above).
+		mv.progress.MarkMeasurePartError(mv.group, sourceSegmentIDStr, sourceShardID, partID, err.Error())
+		return fmt.Errorf("row-replay measure part %s: %w", partPath, err)
+	}
+	// Confirm this part's rows reached every node before marking it completed.
+	// replayPart only enqueues; the batch publisher is client-streaming so
+	// per-node errors surface only when its stream closes, so flushAndConfirm
+	// closes the publisher to collect that result (then opens a fresh one for the
+	// next part). Marking before this confirmation could report success for rows
+	// a flush failure never delivered, and the resume guard would then skip the
+	// part, losing data.
+	cee, flushErr := replayer.flushAndConfirm(ctx)
+	if flushErr != nil || len(cee) > 0 {
+		mv.progress.RecordRowReplayNodeErrors(mv.group, cee)
+		confirmErr := flushErr
+		if confirmErr == nil {
+			confirmErr = fmt.Errorf("%d node error(s)", len(cee))
+		}
+		mv.progress.MarkMeasurePartError(mv.group, sourceSegmentIDStr, sourceShardID, partID, confirmErr.Error())
+		return fmt.Errorf("confirm row-replay measure part %s: %w", partPath, confirmErr)
+	}
+	mv.progress.MarkMeasurePartCompleted(mv.group, sourceSegmentIDStr, sourceShardID, partID)
+	mv.progress.MarkSourceMeasurePartCompleted(mv.group, partPath, sourceShardID, partID)
+	mv.progress.AddMeasureRowReplay(mv.group, rowCount)
+	mv.logger.Info().
+		Uint64("part_id", partID).
+		Int("rows_published", rowCount).
+		Str("group", mv.group).
+		Msg("measure row-replay completed")
 	return nil
 }
 
@@ -368,14 +495,30 @@ func (mv *measureMigrationVisitor) streamPartToNode(nodeID string, targetShardID
 	return nil
 }
 
-// Close cleans up all chunked sync clients.
+// Close cleans up all chunked sync clients and the row-replayer.
 func (mv *measureMigrationVisitor) Close() error {
+	if mv.replayer != nil {
+		cee, replayCloseErr := mv.replayer.Close()
+		mv.progress.RecordRowReplayNodeErrors(mv.group, cee)
+		if replayCloseErr != nil {
+			mv.logger.Warn().Err(replayCloseErr).Interface("node_errors", cee).Msg("failed to close measure row replayer")
+		} else if len(cee) > 0 {
+			mv.logger.Warn().Interface("node_errors", cee).Msg("measure row replayer reported per-node errors")
+		}
+		mv.replayer = nil
+	}
 	for nodeID, client := range mv.chunkedClients {
 		if err := client.Close(); err != nil {
 			mv.logger.Warn().Err(err).Str("node", nodeID).Msg("failed to close chunked sync client")
 		}
 	}
 	mv.chunkedClients = make(map[string]queue.ChunkedSyncClient)
+	chunkSync, rowReplay := mv.CounterSnapshot()
+	mv.logger.Info().
+		Uint64("parts_chunk_sync", chunkSync).
+		Uint64("parts_row_replay", rowReplay).
+		Str("group", mv.group).
+		Msg("measure migration visitor closed")
 	return nil
 }
 

--- a/banyand/backup/lifecycle/migration_integration.go
+++ b/banyand/backup/lifecycle/migration_integration.go
@@ -23,6 +23,7 @@ import (
 	"github.com/apache/skywalking-banyandb/api/common"
 	"github.com/apache/skywalking-banyandb/banyand/internal/storage"
 	"github.com/apache/skywalking-banyandb/banyand/measure"
+	"github.com/apache/skywalking-banyandb/banyand/metadata"
 	"github.com/apache/skywalking-banyandb/banyand/stream"
 	"github.com/apache/skywalking-banyandb/banyand/trace"
 	"github.com/apache/skywalking-banyandb/pkg/fs"
@@ -32,7 +33,7 @@ import (
 
 // migrateStreamWithFileBasedAndProgress performs file-based stream migration with progress tracking.
 func migrateStreamWithFileBasedAndProgress(tsdbRootPath string, timeRange timestamp.TimeRange, group *GroupConfig,
-	logger *logger.Logger, progress *Progress, chunkSize int,
+	logger *logger.Logger, progress *Progress, chunkSize int, md metadata.Repo,
 ) ([]string, error) {
 	// Convert segment Interval to IntervalRule using storage.MustToIntervalRule
 	segmentIntervalRule := storage.MustToIntervalRule(group.SegmentInterval)
@@ -55,7 +56,7 @@ func migrateStreamWithFileBasedAndProgress(tsdbRootPath string, timeRange timest
 	// Create file-based migration visitor with progress tracking and target stage interval
 	visitor := newStreamMigrationVisitor(
 		group.Group, group.TargetShardNum, group.TargetReplicas, group.NodeSelector, group.QueueClient,
-		logger, progress, chunkSize, targetStageInterval,
+		logger, progress, chunkSize, targetStageInterval, md,
 	)
 	defer visitor.Close()
 
@@ -121,7 +122,7 @@ func (pcv *partCountVisitor) VisitElementIndex(_ *timestamp.TimeRange, _ common.
 
 // migrateMeasureWithFileBasedAndProgress performs file-based measure migration with progress tracking.
 func migrateMeasureWithFileBasedAndProgress(tsdbRootPath string, timeRange timestamp.TimeRange, group *GroupConfig,
-	logger *logger.Logger, progress *Progress, chunkSize int,
+	logger *logger.Logger, progress *Progress, chunkSize int, md metadata.Repo,
 ) ([]string, error) {
 	// Convert segment interval to IntervalRule using storage.MustToIntervalRule
 	segmentIntervalRule := storage.MustToIntervalRule(group.SegmentInterval)
@@ -143,7 +144,7 @@ func migrateMeasureWithFileBasedAndProgress(tsdbRootPath string, timeRange times
 	// Create file-based migration visitor with progress tracking and target stage interval
 	visitor := newMeasureMigrationVisitor(
 		group.Group, group.TargetShardNum, group.TargetReplicas, group.NodeSelector, group.QueueClient,
-		logger, progress, chunkSize, targetStageInterval,
+		logger, progress, chunkSize, targetStageInterval, md,
 	)
 	defer visitor.Close()
 
@@ -201,7 +202,7 @@ func (pcv *measurePartCountVisitor) VisitPart(_ *timestamp.TimeRange, _ common.S
 
 // migrateTraceWithFileBasedAndProgress performs file-based trace migration with progress tracking.
 func migrateTraceWithFileBasedAndProgress(tsdbRootPath string, timeRange timestamp.TimeRange, group *GroupConfig,
-	logger *logger.Logger, progress *Progress, chunkSize int,
+	logger *logger.Logger, progress *Progress, chunkSize int, md metadata.Repo,
 ) ([]string, error) {
 	// Convert segment interval to IntervalRule using storage.MustToIntervalRule
 	segmentIntervalRule := storage.MustToIntervalRule(group.SegmentInterval)
@@ -223,7 +224,7 @@ func migrateTraceWithFileBasedAndProgress(tsdbRootPath string, timeRange timesta
 	// Create file-based migration visitor with progress tracking and target stage interval
 	visitor := newTraceMigrationVisitor(
 		group.Group, group.TargetShardNum, group.TargetReplicas, group.NodeSelector, group.QueueClient,
-		logger, progress, chunkSize, targetStageInterval,
+		logger, progress, chunkSize, targetStageInterval, md,
 	)
 	defer visitor.Close()
 

--- a/banyand/backup/lifecycle/progress.go
+++ b/banyand/backup/lifecycle/progress.go
@@ -74,6 +74,25 @@ type Progress struct {
 	SourceCompletedTraceShards        map[string]map[string]map[common.ShardID]bool            `json:"source_completed_trace_shards"`
 	SourceCompletedTraceSeries        map[string]map[string]map[common.ShardID]bool            `json:"source_completed_trace_series"`
 
+	// Sync-mode breakdown per group: how many parts (measure/stream) or shards
+	// (trace) were migrated via chunk-sync vs row-replay, plus the real number
+	// of rows replayed. Accumulated across resume cycles, fed into the report's
+	// summary.<catalog>.sync_breakdown.
+	StreamChunkSyncParts  map[string]uint64 `json:"stream_chunk_sync_parts"`
+	StreamRowReplayParts  map[string]uint64 `json:"stream_row_replay_parts"`
+	StreamRowReplayRows   map[string]uint64 `json:"stream_row_replay_rows"`
+	MeasureChunkSyncParts map[string]uint64 `json:"measure_chunk_sync_parts"`
+	MeasureRowReplayParts map[string]uint64 `json:"measure_row_replay_parts"`
+	MeasureRowReplayRows  map[string]uint64 `json:"measure_row_replay_rows"`
+	TraceChunkSyncShards  map[string]uint64 `json:"trace_chunk_sync_shards"`
+	TraceRowReplayParts   map[string]uint64 `json:"trace_row_replay_parts"`
+	TraceRowReplayRows    map[string]uint64 `json:"trace_row_replay_rows"`
+
+	// Per-node errors reported by row replayers during flush/close, keyed by
+	// group then node id. A group is single-catalog, so group names do not
+	// collide across catalogs.
+	RowReplayNodeErrors map[string]map[string]string `json:"row_replay_node_errors"`
+
 	progressFilePath   string     `json:"-"`
 	SnapshotStreamDir  string     `json:"snapshot_stream_dir"`
 	SnapshotMeasureDir string     `json:"snapshot_measure_dir"`
@@ -148,6 +167,17 @@ func NewProgress(path string, l *logger.Logger) *Progress {
 		SourceCompletedMeasureSeries:      make(map[string]map[string]map[common.ShardID]bool),
 		SourceCompletedTraceShards:        make(map[string]map[string]map[common.ShardID]bool),
 		SourceCompletedTraceSeries:        make(map[string]map[string]map[common.ShardID]bool),
+
+		StreamChunkSyncParts:  make(map[string]uint64),
+		StreamRowReplayParts:  make(map[string]uint64),
+		StreamRowReplayRows:   make(map[string]uint64),
+		MeasureChunkSyncParts: make(map[string]uint64),
+		MeasureRowReplayParts: make(map[string]uint64),
+		MeasureRowReplayRows:  make(map[string]uint64),
+		TraceChunkSyncShards:  make(map[string]uint64),
+		TraceRowReplayParts:   make(map[string]uint64),
+		TraceRowReplayRows:    make(map[string]uint64),
+		RowReplayNodeErrors:   make(map[string]map[string]string),
 
 		progressFilePath: path,
 		logger:           l,
@@ -652,6 +682,132 @@ func (p *Progress) ClearErrors() {
 	p.MeasureSeriesErrors = make(map[string]map[string]map[common.ShardID]string)
 	p.TraceShardErrors = make(map[string]map[string]map[common.ShardID]string)
 	p.TraceSeriesErrors = make(map[string]map[string]map[common.ShardID]string)
+}
+
+// AddMeasureChunkSyncPart records one measure part migrated via chunk-sync.
+func (p *Progress) AddMeasureChunkSyncPart(group string) {
+	defer p.saveProgress()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.MeasureChunkSyncParts == nil {
+		p.MeasureChunkSyncParts = make(map[string]uint64)
+	}
+
+	p.MeasureChunkSyncParts[group]++
+}
+
+// AddMeasureRowReplay records one measure part migrated via row-replay and the
+// number of rows it republished.
+func (p *Progress) AddMeasureRowReplay(group string, rows int) {
+	defer p.saveProgress()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.MeasureRowReplayParts == nil {
+		p.MeasureRowReplayParts = make(map[string]uint64)
+	}
+	if p.MeasureRowReplayRows == nil {
+		p.MeasureRowReplayRows = make(map[string]uint64)
+	}
+
+	p.MeasureRowReplayParts[group]++
+	if rows > 0 {
+		p.MeasureRowReplayRows[group] += uint64(rows)
+	}
+}
+
+// AddStreamChunkSyncPart records one stream part migrated via chunk-sync.
+func (p *Progress) AddStreamChunkSyncPart(group string) {
+	defer p.saveProgress()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.StreamChunkSyncParts == nil {
+		p.StreamChunkSyncParts = make(map[string]uint64)
+	}
+
+	p.StreamChunkSyncParts[group]++
+}
+
+// AddStreamRowReplay records one stream part migrated via row-replay and the
+// number of rows it republished.
+func (p *Progress) AddStreamRowReplay(group string, rows int) {
+	defer p.saveProgress()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.StreamRowReplayParts == nil {
+		p.StreamRowReplayParts = make(map[string]uint64)
+	}
+	if p.StreamRowReplayRows == nil {
+		p.StreamRowReplayRows = make(map[string]uint64)
+	}
+
+	p.StreamRowReplayParts[group]++
+	if rows > 0 {
+		p.StreamRowReplayRows[group] += uint64(rows)
+	}
+}
+
+// AddTraceChunkSyncShard records one trace shard migrated via chunk-sync.
+func (p *Progress) AddTraceChunkSyncShard(group string) {
+	defer p.saveProgress()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.TraceChunkSyncShards == nil {
+		p.TraceChunkSyncShards = make(map[string]uint64)
+	}
+
+	p.TraceChunkSyncShards[group]++
+}
+
+// AddTraceRowReplay records the parts and rows of a trace shard migrated via
+// row-replay (one shard may contain several parts).
+func (p *Progress) AddTraceRowReplay(group string, parts, rows int) {
+	defer p.saveProgress()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.TraceRowReplayParts == nil {
+		p.TraceRowReplayParts = make(map[string]uint64)
+	}
+	if p.TraceRowReplayRows == nil {
+		p.TraceRowReplayRows = make(map[string]uint64)
+	}
+
+	if parts > 0 {
+		p.TraceRowReplayParts[group] += uint64(parts)
+	}
+	if rows > 0 {
+		p.TraceRowReplayRows[group] += uint64(rows)
+	}
+}
+
+// RecordRowReplayNodeErrors persists the per-node errors a row replayer
+// reported while flushing/closing its publisher. Keyed by group then node id.
+func (p *Progress) RecordRowReplayNodeErrors(group string, cee map[string]*common.Error) {
+	if len(cee) == 0 {
+		return
+	}
+	defer p.saveProgress()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.RowReplayNodeErrors == nil {
+		p.RowReplayNodeErrors = make(map[string]map[string]string)
+	}
+	if p.RowReplayNodeErrors[group] == nil {
+		p.RowReplayNodeErrors[group] = make(map[string]string)
+	}
+
+	for nodeID, ce := range cee {
+		if ce == nil {
+			continue
+		}
+		p.RowReplayNodeErrors[group][nodeID] = ce.Error()
+	}
 }
 
 // MarkMeasureSeriesCompleted marks a specific series segment of a measure as completed.

--- a/banyand/backup/lifecycle/progress_mark_test.go
+++ b/banyand/backup/lifecycle/progress_mark_test.go
@@ -18,10 +18,13 @@
 package lifecycle
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/apache/skywalking-banyandb/api/common"
 	"github.com/apache/skywalking-banyandb/pkg/logger"
 )
 
@@ -189,4 +192,78 @@ func TestPerTargetAndPerSourceAreIndependent(t *testing.T) {
 	// Per-target map untouched by source mark.
 	assert.False(t, p.IsStreamPartCompleted("g", "src-1", 0, 1))
 	assert.Equal(t, 1, p.StreamPartProgress["g"])
+}
+
+// TestPartCompletionKeyedBySourceSegment pins that measure/stream part
+// completion dedup is keyed by the SOURCE segment, not the target segment.
+// Part IDs reset per source segment, so when several source segments collapse
+// into one larger target segment (warm interval > hot interval), two source
+// segments can each carry part_id=1 on the same shard. If completion were keyed
+// by the target segment, marking source-A's part done would make source-B's
+// part look done and the visitor (VisitPart) would skip it, dropping source-B's
+// data. Keying by the source segment — what measure/stream VisitPart now pass,
+// matching trace's source-keyed VisitShard — keeps the two parts independent.
+func TestPartCompletionKeyedBySourceSegment(t *testing.T) {
+	p := NewProgress("", logger.GetLogger("test"))
+	const (
+		group   = "g"
+		srcSegA = "[2026-05-19 00:00:00, 2026-05-20 00:00:00)"
+		srcSegB = "[2026-05-20 00:00:00, 2026-05-21 00:00:00)"
+	)
+	var shard common.ShardID // 0 on both source segments
+	const partID uint64 = 1  // resets per source segment, so it collides
+
+	// Source segment A's part 1 migrated into the shared target segment.
+	p.MarkMeasurePartCompleted(group, srcSegA, shard, partID)
+	p.MarkStreamPartCompleted(group, srcSegA, shard, partID)
+
+	// Source segment B's part 1 (same shard + part ID, different source segment)
+	// must NOT be seen as already done — otherwise VisitPart skips it and loses
+	// B's data.
+	assert.False(t, p.IsMeasurePartCompleted(group, srcSegB, shard, partID),
+		"measure: source segment B part must be independent of source segment A")
+	assert.False(t, p.IsStreamPartCompleted(group, srcSegB, shard, partID),
+		"stream: source segment B part must be independent of source segment A")
+
+	// Source segment A stays marked.
+	assert.True(t, p.IsMeasurePartCompleted(group, srcSegA, shard, partID))
+	assert.True(t, p.IsStreamPartCompleted(group, srcSegA, shard, partID))
+}
+
+// TestSyncBreakdownCountersPersistAndAccumulate pins that the chunk-sync /
+// row-replay counters and the per-node replay errors are written to the
+// progress file and reloaded on resume, and that a subsequent Add accumulates
+// onto the reloaded value rather than resetting it.
+func TestSyncBreakdownCountersPersistAndAccumulate(t *testing.T) {
+	pf := filepath.Join(t.TempDir(), "progress.json")
+	l := logger.GetLogger("test")
+
+	p := NewProgress(pf, l)
+	p.AddMeasureChunkSyncPart("g")  // measure: 1 chunk-sync part
+	p.AddMeasureChunkSyncPart("g")  // measure: 2 chunk-sync parts
+	p.AddMeasureRowReplay("g", 5)   // measure: 1 row-replay part, 5 rows
+	p.AddStreamChunkSyncPart("g2")  // stream: 1 chunk-sync part
+	p.AddStreamRowReplay("g2", 3)   // stream: 1 row-replay part, 3 rows
+	p.AddTraceChunkSyncShard("g3")  // trace: 1 chunk-sync shard
+	p.AddTraceRowReplay("g3", 2, 6) // trace: 2 row-replay parts, 6 rows
+	p.RecordRowReplayNodeErrors("g2", map[string]*common.Error{"node-1": common.NewError("boom")})
+
+	// Reload from disk (resume).
+	reloaded := LoadProgress(pf, l)
+	assert.Equal(t, uint64(2), reloaded.MeasureChunkSyncParts["g"])
+	assert.Equal(t, uint64(1), reloaded.MeasureRowReplayParts["g"])
+	assert.Equal(t, uint64(5), reloaded.MeasureRowReplayRows["g"])
+	assert.Equal(t, uint64(1), reloaded.StreamChunkSyncParts["g2"])
+	assert.Equal(t, uint64(1), reloaded.StreamRowReplayParts["g2"])
+	assert.Equal(t, uint64(3), reloaded.StreamRowReplayRows["g2"])
+	assert.Equal(t, uint64(1), reloaded.TraceChunkSyncShards["g3"])
+	assert.Equal(t, uint64(2), reloaded.TraceRowReplayParts["g3"])
+	assert.Equal(t, uint64(6), reloaded.TraceRowReplayRows["g3"])
+	require.Contains(t, reloaded.RowReplayNodeErrors, "g2")
+	assert.Contains(t, reloaded.RowReplayNodeErrors["g2"]["node-1"], "boom")
+
+	// Resume accumulation: a further Add builds on the reloaded value.
+	reloaded.AddMeasureRowReplay("g", 10)
+	assert.Equal(t, uint64(2), reloaded.MeasureRowReplayParts["g"])
+	assert.Equal(t, uint64(15), reloaded.MeasureRowReplayRows["g"])
 }

--- a/banyand/backup/lifecycle/report_partial_failure_test.go
+++ b/banyand/backup/lifecycle/report_partial_failure_test.go
@@ -93,7 +93,7 @@ func TestBuildMigrationReport_PartialFailure(t *testing.T) {
 	svc := &lifecycleService{l: logger.GetLogger("test")}
 	report := svc.buildMigrationReport(p)
 
-	require.Equal(t, "2.0", report["report_version"])
+	require.Equal(t, "2.1", report["report_version"])
 	summary, ok := report["summary"].(map[string]interface{})
 	require.True(t, ok)
 	errs, ok := report["errors"].(map[string]interface{})
@@ -187,6 +187,64 @@ func TestBuildMigrationReport_EmptyCycleHonestTotalGroups(t *testing.T) {
 	assert.Equal(t, 0, ms["total_groups"])
 	assert.Equal(t, 0, ms["completed_groups"])
 	assert.InDelta(t, 0.0, ms["completion_rate"], 1e-9)
+}
+
+// TestBuildMigrationReport_SyncBreakdown pins the sync_breakdown blocks and the
+// row_replay_node_errors block introduced in report_version 2.1. It seeds both
+// chunk-sync and row-replay activity across measure/stream/trace groups and
+// asserts the per-group and _total accounting plus the per-node replay error.
+func TestBuildMigrationReport_SyncBreakdown(t *testing.T) {
+	p := NewProgress("", logger.GetLogger("test"))
+
+	// measure: 2 chunk-sync parts; 1 row-replay part carrying 5 rows.
+	p.AddMeasureChunkSyncPart("sw_metrics")
+	p.AddMeasureChunkSyncPart("sw_metrics")
+	p.AddMeasureRowReplay("sw_metrics", 5)
+	// stream: 1 chunk-sync part; 2 row-replay parts carrying 3 + 4 rows.
+	p.AddStreamChunkSyncPart("sw_stream")
+	p.AddStreamRowReplay("sw_stream", 3)
+	p.AddStreamRowReplay("sw_stream", 4)
+	// trace: 1 chunk-sync shard; 1 row-replay shard with 2 parts / 6 rows.
+	p.AddTraceChunkSyncShard("sw_trace")
+	p.AddTraceRowReplay("sw_trace", 2, 6)
+	// per-node replay error on the stream group.
+	p.RecordRowReplayNodeErrors("sw_stream", map[string]*common.Error{
+		"data-node-1": common.NewError("flush timeout"),
+	})
+
+	svc := &lifecycleService{l: logger.GetLogger("test")}
+	report := svc.buildMigrationReport(p)
+	summary := report["summary"].(map[string]interface{})
+
+	mb := summary["measure_migration"].(map[string]interface{})["sync_breakdown"].(map[string]interface{})
+	assertBreakdown(t, mb, "sw_metrics", "chunk_sync_parts", 2, 1, 5)
+	assertBreakdown(t, mb, "_total", "chunk_sync_parts", 2, 1, 5)
+
+	sb := summary["stream_migration"].(map[string]interface{})["sync_breakdown"].(map[string]interface{})
+	assertBreakdown(t, sb, "sw_stream", "chunk_sync_parts", 1, 2, 7)
+	assertBreakdown(t, sb, "_total", "chunk_sync_parts", 1, 2, 7)
+
+	tb := summary["trace_migration"].(map[string]interface{})["sync_breakdown"].(map[string]interface{})
+	assertBreakdown(t, tb, "sw_trace", "chunk_sync_shards", 1, 2, 6)
+	assertBreakdown(t, tb, "_total", "chunk_sync_shards", 1, 2, 6)
+
+	errs := report["errors"].(map[string]interface{})
+	nodeErrs, ok := errs["row_replay_node_errors"].(map[string]interface{})
+	require.True(t, ok, "errors.row_replay_node_errors must be a map")
+	groupErrs, ok := nodeErrs["sw_stream"].(map[string]interface{})
+	require.True(t, ok, "row_replay_node_errors must contain sw_stream")
+	assert.Contains(t, groupErrs["data-node-1"], "flush timeout")
+}
+
+// assertBreakdown checks one sync_breakdown entry's chunk count (keyed by
+// chunkKey), row-replay part count and row-replay row count.
+func assertBreakdown(t *testing.T, breakdown map[string]interface{}, key, chunkKey string, chunk, replayParts, replayRows uint64) {
+	t.Helper()
+	entry, ok := breakdown[key].(map[string]interface{})
+	require.Truef(t, ok, "sync_breakdown[%s] must be a map", key)
+	assert.Equalf(t, chunk, entry[chunkKey], "sync_breakdown[%s].%s", key, chunkKey)
+	assert.Equalf(t, replayParts, entry["row_replay_parts"], "sync_breakdown[%s].row_replay_parts", key)
+	assert.Equalf(t, replayRows, entry["row_replay_rows"], "sync_breakdown[%s].row_replay_rows", key)
 }
 
 // assertResource pins down a single resource sub-block under a catalog

--- a/banyand/backup/lifecycle/row_replay.go
+++ b/banyand/backup/lifecycle/row_replay.go
@@ -1,0 +1,312 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package lifecycle implements row-level replay paths used by migration visitors
+// when a source segment maps to more than one target segment. The receiving
+// data node owns segment creation per-row, which makes the per-target sender
+// loop unnecessary.
+package lifecycle
+
+import (
+	"fmt"
+
+	commonv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/common/v1"
+	databasev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
+	modelv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/model/v1"
+	"github.com/apache/skywalking-banyandb/banyand/internal/dump"
+	dumpmeasure "github.com/apache/skywalking-banyandb/banyand/internal/dump/measure"
+	dumpstream "github.com/apache/skywalking-banyandb/banyand/internal/dump/stream"
+	dumptrace "github.com/apache/skywalking-banyandb/banyand/internal/dump/trace"
+	pbv1 "github.com/apache/skywalking-banyandb/pkg/pb/v1"
+)
+
+// decodeSeriesEntityValues recovers (subject, entityTagValues) from the raw
+// EntityValues byte sequence stored in part-level smeta.bin or recovered via
+// PartSeriesMap.
+func decodeSeriesEntityValues(rawBytes []byte) (string, pbv1.EntityValues, error) {
+	if len(rawBytes) == 0 {
+		return "", nil, fmt.Errorf("empty entity values bytes")
+	}
+	var s pbv1.Series
+	if err := s.Unmarshal(rawBytes); err != nil {
+		return "", nil, fmt.Errorf("unmarshal series: %w", err)
+	}
+	if s.Subject == "" {
+		return "", nil, fmt.Errorf("decoded subject is empty")
+	}
+	return s.Subject, s.EntityValues, nil
+}
+
+// deriveMergedRuleToTag builds an IndexRuleID -> IndexedTagSpec map covering the
+// group's measures. A rule's tag is resolved within the measure it is bound to
+// (via IndexRuleBinding), not against a group-wide tag set: tag names may
+// collide across measures with a different family/type, so a global merge would
+// decode an indexed value with the wrong type. Rules whose tag is not
+// column-defined in the bound measure are skipped because the resolver cannot
+// decode their value without a known type.
+func deriveMergedRuleToTag(measures []*databasev1.Measure, rules []*databasev1.IndexRule,
+	bindings []*databasev1.IndexRuleBinding,
+) map[uint32]dump.IndexedTagSpec {
+	if len(measures) == 0 || len(rules) == 0 || len(bindings) == 0 {
+		return nil
+	}
+	type tagInfo struct {
+		spec   *databasev1.TagSpec
+		family string
+	}
+	// Per-measure tag index: tag name -> family/spec, scoped to each measure so
+	// colliding names resolve to the right type.
+	measureTags := make(map[string]map[string]tagInfo, len(measures))
+	for _, m := range measures {
+		tags := make(map[string]tagInfo)
+		for _, fam := range m.TagFamilies {
+			for _, ts := range fam.Tags {
+				tags[ts.Name] = tagInfo{family: fam.Name, spec: ts}
+			}
+		}
+		measureTags[m.GetMetadata().GetName()] = tags
+	}
+	ruleByName := make(map[string]*databasev1.IndexRule, len(rules))
+	for _, rule := range rules {
+		if rule.GetMetadata() != nil {
+			ruleByName[rule.GetMetadata().GetName()] = rule
+		}
+	}
+	out := make(map[uint32]dump.IndexedTagSpec)
+	for _, binding := range bindings {
+		subject := binding.GetSubject()
+		if subject == nil || subject.GetCatalog() != commonv1.Catalog_CATALOG_MEASURE {
+			continue
+		}
+		tags, ok := measureTags[subject.GetName()]
+		if !ok {
+			continue
+		}
+		for _, ruleName := range binding.GetRules() {
+			rule, exists := ruleByName[ruleName]
+			if !exists || rule.GetMetadata() == nil {
+				continue
+			}
+			// The index stores a rule's value under a field keyed solely by its
+			// IndexRuleID (FieldKey.Marshal), so the resolver recovers exactly
+			// one value per rule. A multi-tag rule indexes a composite term that
+			// cannot be split back into individual tag values, so only single-tag
+			// rules are decodable; skip the rest rather than mis-decode tags[0].
+			ruleTags := rule.GetTags()
+			if len(ruleTags) != 1 {
+				continue
+			}
+			info, found := tags[ruleTags[0]]
+			if !found || info.spec == nil {
+				continue
+			}
+			out[rule.GetMetadata().GetId()] = dump.IndexedTagSpec{
+				Family: info.family,
+				Name:   ruleTags[0],
+				Type:   tagTypeToValueType(info.spec.Type),
+			}
+		}
+	}
+	return out
+}
+
+// tagTypeToValueType maps the schema TagType enum to the storage ValueType
+// used by dump.DecodeTagValue. It mirrors the production write path's mapping.
+func tagTypeToValueType(t databasev1.TagType) pbv1.ValueType {
+	switch t {
+	case databasev1.TagType_TAG_TYPE_STRING:
+		return pbv1.ValueTypeStr
+	case databasev1.TagType_TAG_TYPE_INT:
+		return pbv1.ValueTypeInt64
+	case databasev1.TagType_TAG_TYPE_DATA_BINARY:
+		return pbv1.ValueTypeBinaryData
+	case databasev1.TagType_TAG_TYPE_STRING_ARRAY:
+		return pbv1.ValueTypeStrArr
+	case databasev1.TagType_TAG_TYPE_INT_ARRAY:
+		return pbv1.ValueTypeInt64Arr
+	case databasev1.TagType_TAG_TYPE_TIMESTAMP:
+		return pbv1.ValueTypeTimestamp
+	default:
+		return pbv1.ValueTypeUnknown
+	}
+}
+
+// fieldTypeToValueType maps the schema FieldType enum to the storage ValueType
+// used by dumpmeasure.DecodeFieldValue.
+func fieldTypeToValueType(t databasev1.FieldType) pbv1.ValueType {
+	switch t {
+	case databasev1.FieldType_FIELD_TYPE_STRING:
+		return pbv1.ValueTypeStr
+	case databasev1.FieldType_FIELD_TYPE_INT:
+		return pbv1.ValueTypeInt64
+	case databasev1.FieldType_FIELD_TYPE_FLOAT:
+		return pbv1.ValueTypeFloat64
+	case databasev1.FieldType_FIELD_TYPE_DATA_BINARY:
+		return pbv1.ValueTypeBinaryData
+	default:
+		return pbv1.ValueTypeUnknown
+	}
+}
+
+// buildEntityTagIndex maps Entity.TagNames positionally onto the decoded
+// EntityValues so the per-tag builders can backfill entity tags that live
+// neither in the column store nor in the IndexResolver output.
+func buildEntityTagIndex(entity *databasev1.Entity, evList pbv1.EntityValues) map[string]*modelv1.TagValue {
+	if entity == nil || len(entity.TagNames) == 0 {
+		return nil
+	}
+	out := make(map[string]*modelv1.TagValue, len(entity.TagNames))
+	for i, name := range entity.TagNames {
+		if i >= len(evList) {
+			break
+		}
+		out[name] = evList[i]
+	}
+	return out
+}
+
+// buildMeasureTagFamilies rebuilds the TagFamilyForWrite list in schema order.
+// Resolution priority: column store > IndexResolver > EntityValues > null.
+func buildMeasureTagFamilies(
+	families []*databasev1.TagFamilySpec,
+	entity *databasev1.Entity,
+	row dumpmeasure.Row,
+	evList pbv1.EntityValues,
+	indexedTyped map[string]*modelv1.TagValue,
+) []*modelv1.TagFamilyForWrite {
+	entityIdx := buildEntityTagIndex(entity, evList)
+	out := make([]*modelv1.TagFamilyForWrite, 0, len(families))
+	for _, fam := range families {
+		tf := &modelv1.TagFamilyForWrite{Tags: make([]*modelv1.TagValue, 0, len(fam.Tags))}
+		for _, t := range fam.Tags {
+			tf.Tags = append(tf.Tags, resolveMeasureTagValue(fam.Name, t, row, entityIdx, indexedTyped))
+		}
+		out = append(out, tf)
+	}
+	return out
+}
+
+func resolveMeasureTagValue(
+	familyName string,
+	t *databasev1.TagSpec,
+	row dumpmeasure.Row,
+	entityIdx map[string]*modelv1.TagValue,
+	indexedTyped map[string]*modelv1.TagValue,
+) *modelv1.TagValue {
+	fullName := familyName + "." + t.Name
+	if raw, ok := row.Tags[fullName]; ok {
+		vt, hasType := row.TagTypes[fullName]
+		if !hasType {
+			vt = tagTypeToValueType(t.Type)
+		}
+		return dump.DecodeTagValue(vt, raw, nil)
+	}
+	if tv, ok := indexedTyped[fullName]; ok && tv != nil {
+		return tv
+	}
+	if tv, ok := entityIdx[t.Name]; ok && tv != nil {
+		return tv
+	}
+	return pbv1.NullTagValue
+}
+
+// buildMeasureFields rebuilds the Fields list in schema order using the
+// row.Fields raw bytes + row.FieldTypes. Missing fields produce a null
+// FieldValue.
+func buildMeasureFields(specs []*databasev1.FieldSpec, row dumpmeasure.Row) []*modelv1.FieldValue {
+	if len(specs) == 0 {
+		return nil
+	}
+	out := make([]*modelv1.FieldValue, 0, len(specs))
+	for _, spec := range specs {
+		raw, ok := row.Fields[spec.Name]
+		if !ok {
+			out = append(out, pbv1.NullFieldValue)
+			continue
+		}
+		vt, hasType := row.FieldTypes[spec.Name]
+		if !hasType {
+			vt = fieldTypeToValueType(spec.FieldType)
+		}
+		out = append(out, dumpmeasure.DecodeFieldValue(vt, raw))
+	}
+	return out
+}
+
+// buildStreamTagFamilies rebuilds a stream row's TagFamilyForWrite list in
+// schema order. Resolution priority: column store > EntityValues > null.
+func buildStreamTagFamilies(
+	families []*databasev1.TagFamilySpec,
+	entity *databasev1.Entity,
+	row dumpstream.Row,
+	evList pbv1.EntityValues,
+) []*modelv1.TagFamilyForWrite {
+	entityIdx := buildEntityTagIndex(entity, evList)
+	out := make([]*modelv1.TagFamilyForWrite, 0, len(families))
+	for _, fam := range families {
+		tf := &modelv1.TagFamilyForWrite{Tags: make([]*modelv1.TagValue, 0, len(fam.Tags))}
+		for _, t := range fam.Tags {
+			fullName := fam.Name + "." + t.Name
+			if raw, ok := row.Tags[fullName]; ok {
+				vt, hasType := row.TagTypes[fullName]
+				if !hasType {
+					vt = tagTypeToValueType(t.Type)
+				}
+				tf.Tags = append(tf.Tags, dump.DecodeTagValue(vt, raw, nil))
+				continue
+			}
+			if tv, ok := entityIdx[t.Name]; ok && tv != nil {
+				tf.Tags = append(tf.Tags, tv)
+				continue
+			}
+			tf.Tags = append(tf.Tags, pbv1.NullTagValue)
+		}
+		out = append(out, tf)
+	}
+	return out
+}
+
+// buildTraceTags rebuilds a trace row's flat tags list in schema order.
+// trace_id and span_id are promoted to top-level Row fields by the dump
+// library, so we match them by schema-declared name rather than Tags lookup.
+func buildTraceTags(specs []*databasev1.TraceTagSpec, row dumptrace.Row, traceIDName, spanIDName string) []*modelv1.TagValue {
+	if len(specs) == 0 {
+		return nil
+	}
+	out := make([]*modelv1.TagValue, 0, len(specs))
+	for _, t := range specs {
+		switch t.Name {
+		case traceIDName:
+			out = append(out, &modelv1.TagValue{Value: &modelv1.TagValue_Str{Str: &modelv1.Str{Value: row.TraceID}}})
+			continue
+		case spanIDName:
+			out = append(out, &modelv1.TagValue{Value: &modelv1.TagValue_Str{Str: &modelv1.Str{Value: row.SpanID}}})
+			continue
+		}
+		raw, ok := row.Tags[t.Name]
+		if !ok {
+			out = append(out, pbv1.NullTagValue)
+			continue
+		}
+		vt, hasType := row.TagTypes[t.Name]
+		if !hasType {
+			vt = tagTypeToValueType(t.Type)
+		}
+		out = append(out, dump.DecodeTagValue(vt, raw, nil))
+	}
+	return out
+}

--- a/banyand/backup/lifecycle/row_replay_measure.go
+++ b/banyand/backup/lifecycle/row_replay_measure.go
@@ -1,0 +1,336 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package lifecycle
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/apache/skywalking-banyandb/api/common"
+	"github.com/apache/skywalking-banyandb/api/data"
+	commonv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/common/v1"
+	databasev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
+	measurev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/measure/v1"
+	"github.com/apache/skywalking-banyandb/banyand/internal/dump"
+	dumpmeasure "github.com/apache/skywalking-banyandb/banyand/internal/dump/measure"
+	"github.com/apache/skywalking-banyandb/banyand/metadata"
+	"github.com/apache/skywalking-banyandb/banyand/metadata/schema"
+	"github.com/apache/skywalking-banyandb/banyand/queue"
+	"github.com/apache/skywalking-banyandb/pkg/bus"
+	"github.com/apache/skywalking-banyandb/pkg/fs"
+	"github.com/apache/skywalking-banyandb/pkg/logger"
+	"github.com/apache/skywalking-banyandb/pkg/node"
+	"github.com/apache/skywalking-banyandb/pkg/partition"
+)
+
+const (
+	measureReplayBatchSize    = 2000
+	measureReplayBatchTimeout = 30 * time.Second
+)
+
+// cachedMeasureSchema bundles a measure's schema with its derived entity and
+// sharding-key routers so each row only requires one schema lookup per
+// measure. shardingKey is non-nil only when the measure declares a non-empty
+// ShardingKey; otherwise the entity-based shardID wins.
+type cachedMeasureSchema struct {
+	schema        *databasev1.Measure
+	shardingKey   partition.Router
+	entityLocator partition.Locator
+}
+
+// measureRowReplayer replays a group's measure parts row-by-row through the
+// real Write API, resolving each row's schema on demand via EntityValues.
+type measureRowReplayer struct {
+	selector        node.Selector
+	client          queue.Client
+	publisher       queue.BatchPublisher
+	fs              fs.FileSystem
+	logger          *logger.Logger
+	measureSchemas  map[string]*databasev1.Measure
+	schemaCache     map[string]*cachedMeasureSchema
+	irCache         map[string]*dump.IndexResolver
+	mergedRuleToTag map[uint32]dump.IndexedTagSpec
+	counter         *uint64
+	group           string
+	batch           []bus.Message
+	schemaCacheMu   sync.Mutex
+	irCacheMu       sync.Mutex
+	batchMu         sync.Mutex
+	targetShardNum  uint32
+}
+
+// newMeasureRowReplayer constructs a measure replayer, eagerly enumerating the
+// group's measures and index rules for IndexResolver decoding.
+func newMeasureRowReplayer(
+	ctx context.Context,
+	group string, targetShardNum uint32,
+	selector node.Selector, client queue.Client,
+	md metadata.Repo, fileSystem fs.FileSystem,
+	l *logger.Logger, counter *uint64,
+) (*measureRowReplayer, error) {
+	measures, err := md.MeasureRegistry().ListMeasure(ctx, schema.ListOpt{Group: group})
+	if err != nil {
+		return nil, fmt.Errorf("list measures of group %s: %w", group, err)
+	}
+	rules, err := md.IndexRuleRegistry().ListIndexRule(ctx, schema.ListOpt{Group: group})
+	if err != nil {
+		return nil, fmt.Errorf("list index rules of group %s: %w", group, err)
+	}
+	bindings, err := md.IndexRuleBindingRegistry().ListIndexRuleBinding(ctx, schema.ListOpt{Group: group})
+	if err != nil {
+		return nil, fmt.Errorf("list index rule bindings of group %s: %w", group, err)
+	}
+	// Index the already-listed measures by name so loadSchema resolves each
+	// subject from this snapshot instead of issuing a redundant GetMeasure
+	// per measure. Using one consistent snapshot also avoids mid-migration
+	// schema drift.
+	measureSchemas := make(map[string]*databasev1.Measure, len(measures))
+	for _, m := range measures {
+		measureSchemas[m.GetMetadata().GetName()] = m
+	}
+	return &measureRowReplayer{
+		group:           group,
+		targetShardNum:  targetShardNum,
+		selector:        selector,
+		client:          client,
+		publisher:       client.NewBatchPublisher(measureReplayBatchTimeout),
+		fs:              fileSystem,
+		logger:          l,
+		measureSchemas:  measureSchemas,
+		schemaCache:     make(map[string]*cachedMeasureSchema),
+		irCache:         make(map[string]*dump.IndexResolver),
+		mergedRuleToTag: deriveMergedRuleToTag(measures, rules, bindings),
+		counter:         counter,
+		batch:           make([]bus.Message, 0, measureReplayBatchSize),
+	}, nil
+}
+
+// Close flushes pending messages, closes the publisher and releases cached
+// IndexResolver handles.
+func (r *measureRowReplayer) Close() (map[string]*common.Error, error) {
+	flushCtx, cancel := context.WithTimeout(context.Background(), measureReplayBatchTimeout)
+	defer cancel()
+	flushErr := r.flushBatch(flushCtx)
+	r.irCacheMu.Lock()
+	for _, ir := range r.irCache {
+		_ = ir.Close()
+	}
+	r.irCache = nil
+	r.irCacheMu.Unlock()
+	cee, closeErr := r.publisher.Close()
+	if flushErr != nil {
+		return cee, flushErr
+	}
+	return cee, closeErr
+}
+
+// flushAndConfirm flushes the buffered batch, closes the publisher to obtain the
+// per-node delivery result for everything sent since the last call, then opens a
+// fresh publisher for subsequent parts. The batch publisher is client-streaming,
+// so per-node errors are only observable once its stream closes; this lets a
+// row-replayed part be confirmed durable before it is marked completed.
+func (r *measureRowReplayer) flushAndConfirm(ctx context.Context) (map[string]*common.Error, error) {
+	flushErr := r.flushBatch(ctx)
+	cee, closeErr := r.publisher.Close()
+	r.publisher = r.client.NewBatchPublisher(measureReplayBatchTimeout)
+	if flushErr != nil {
+		return cee, flushErr
+	}
+	return cee, closeErr
+}
+
+// loadSchema resolves a measure schema by name from the snapshot listed at
+// construction and lazily caches its derived routers.
+func (r *measureRowReplayer) loadSchema(measureName string) (*cachedMeasureSchema, error) {
+	r.schemaCacheMu.Lock()
+	defer r.schemaCacheMu.Unlock()
+	if c, ok := r.schemaCache[measureName]; ok {
+		return c, nil
+	}
+	m, ok := r.measureSchemas[measureName]
+	if !ok {
+		return nil, fmt.Errorf("measure schema %s/%s not found in group snapshot", r.group, measureName)
+	}
+	c := &cachedMeasureSchema{
+		schema:        m,
+		entityLocator: partition.NewEntityLocator(m.TagFamilies, m.Entity, m.GetMetadata().GetModRevision()),
+	}
+	if sk := m.GetShardingKey(); sk != nil && len(sk.GetTagNames()) > 0 {
+		c.shardingKey = partition.NewShardingKeyLocator(m.TagFamilies, sk)
+	}
+	r.schemaCache[measureName] = c
+	return c, nil
+}
+
+// loadIndexResolver lazily opens an IndexResolver per source segment.
+func (r *measureRowReplayer) loadIndexResolver(segmentPath string) (*dump.IndexResolver, error) {
+	r.irCacheMu.Lock()
+	defer r.irCacheMu.Unlock()
+	if ir, ok := r.irCache[segmentPath]; ok {
+		return ir, nil
+	}
+	ir, err := dump.NewIndexResolver(segmentPath, dump.DefaultIndexCacheSize, r.mergedRuleToTag)
+	if err != nil {
+		return nil, fmt.Errorf("open index resolver for %s: %w", segmentPath, err)
+	}
+	r.irCache[segmentPath] = ir
+	return ir, nil
+}
+
+// replayPart opens a source part and publishes each row through the queue.
+func (r *measureRowReplayer) replayPart(ctx context.Context, partPath string) (int, error) {
+	partID, parseErr := strconv.ParseUint(filepath.Base(partPath), 16, 64)
+	if parseErr != nil {
+		return 0, fmt.Errorf("invalid part path %s: %w", partPath, parseErr)
+	}
+	shardPath := filepath.Dir(partPath)
+	segmentPath := filepath.Dir(shardPath)
+
+	reader, err := dumpmeasure.OpenPart(partID, shardPath, r.fs)
+	if err != nil {
+		return 0, fmt.Errorf("open part %s: %w", partPath, err)
+	}
+	defer reader.Close()
+
+	ir, err := r.loadIndexResolver(segmentPath)
+	if err != nil {
+		return 0, fmt.Errorf("load index resolver for segment %s: %w", segmentPath, err)
+	}
+	reader.SetIndexResolver(ir)
+
+	it := reader.Iterator()
+	defer it.Close()
+
+	rowCount := 0
+	for it.Next() {
+		row := it.Row()
+		if rowErr := r.publishRow(ctx, ir, row); rowErr != nil {
+			pos := it.Position()
+			r.logger.Warn().Err(rowErr).
+				Str("group", r.group).
+				Str("part", partPath).
+				Int("block_idx", pos.BlockIdx).
+				Int("row_idx", pos.RowIdx).
+				Int("rows_published", rowCount).
+				Msg("measure row-replay aborted mid-part on publish error; will retry on resume")
+			return rowCount, rowErr
+		}
+		rowCount++
+	}
+	if iterErr := it.Err(); iterErr != nil {
+		pos := it.Position()
+		r.logger.Warn().Err(iterErr).
+			Str("group", r.group).
+			Str("part", partPath).
+			Int("block_idx", pos.BlockIdx).
+			Int("row_idx", pos.RowIdx).
+			Int("rows_published", rowCount).
+			Msg("measure row-replay aborted mid-part; will retry on resume")
+		return rowCount, iterErr
+	}
+	if r.counter != nil {
+		atomic.AddUint64(r.counter, 1)
+	}
+	return rowCount, nil
+}
+
+// buildWriteRequest reconstructs the WriteRequest + InternalWriteRequest pair
+// from a raw measure Row. Separated from publishRow for testability.
+func (r *measureRowReplayer) buildWriteRequest(
+	ir *dump.IndexResolver, row dumpmeasure.Row,
+) (*measurev1.WriteRequest, *measurev1.InternalWriteRequest, error) {
+	subject, evList, err := decodeSeriesEntityValues(row.EntityValues)
+	if err != nil {
+		return nil, nil, fmt.Errorf("decode entity values (seriesID=%d): %w", row.SeriesID, err)
+	}
+	cached, err := r.loadSchema(subject)
+	if err != nil {
+		return nil, nil, err
+	}
+	indexedTyped := ir.DecodeTagValues(row.IndexedTags)
+	tagFamilies := buildMeasureTagFamilies(cached.schema.TagFamilies, cached.schema.Entity, row, evList, indexedTyped)
+	fields := buildMeasureFields(cached.schema.Fields, row)
+
+	wr := &measurev1.WriteRequest{
+		Metadata: &commonv1.Metadata{Group: r.group, Name: subject},
+		DataPoint: &measurev1.DataPointValue{
+			Timestamp:   timestamppb.New(time.Unix(0, row.Timestamp)),
+			Version:     row.Version,
+			TagFamilies: tagFamilies,
+			Fields:      fields,
+		},
+		MessageId: uint64(time.Now().UnixNano()),
+	}
+	tagValues, shardID, err := partition.ApplyLocators(subject, tagFamilies,
+		cached.entityLocator, cached.shardingKey, r.targetShardNum)
+	if err != nil {
+		return nil, nil, fmt.Errorf("route %s: %w", subject, err)
+	}
+	iwr := &measurev1.InternalWriteRequest{
+		ShardId:      uint32(shardID),
+		EntityValues: tagValues[1:].Encode(),
+		Request:      wr,
+	}
+	return wr, iwr, nil
+}
+
+// publishRow rebuilds a WriteRequest from a measure Row and enqueues it.
+func (r *measureRowReplayer) publishRow(ctx context.Context, ir *dump.IndexResolver, row dumpmeasure.Row) error {
+	wr, iwr, err := r.buildWriteRequest(ir, row)
+	if err != nil {
+		return err
+	}
+	nodeID, err := r.selector.Pick(r.group, wr.Metadata.Name, iwr.ShardId, 0)
+	if err != nil {
+		return fmt.Errorf("pick target node for %s: %w", wr.Metadata.Name, err)
+	}
+	msg := bus.NewBatchMessageWithNode(bus.MessageID(time.Now().UnixNano()), nodeID, iwr)
+	return r.enqueue(ctx, msg)
+}
+
+// enqueue appends a message to the batch and flushes when full.
+func (r *measureRowReplayer) enqueue(ctx context.Context, msg bus.Message) error {
+	r.batchMu.Lock()
+	r.batch = append(r.batch, msg)
+	shouldFlush := len(r.batch) >= measureReplayBatchSize
+	r.batchMu.Unlock()
+	if shouldFlush {
+		return r.flushBatch(ctx)
+	}
+	return nil
+}
+
+func (r *measureRowReplayer) flushBatch(ctx context.Context) error {
+	r.batchMu.Lock()
+	if len(r.batch) == 0 {
+		r.batchMu.Unlock()
+		return nil
+	}
+	pending := r.batch
+	r.batch = make([]bus.Message, 0, measureReplayBatchSize)
+	r.batchMu.Unlock()
+	_, err := r.publisher.Publish(ctx, data.TopicMeasureWrite, pending...)
+	return err
+}

--- a/banyand/backup/lifecycle/row_replay_measure.go
+++ b/banyand/backup/lifecycle/row_replay_measure.go
@@ -70,13 +70,14 @@ type measureRowReplayer struct {
 	logger          *logger.Logger
 	measureSchemas  map[string]*databasev1.Measure
 	schemaCache     map[string]*cachedMeasureSchema
-	irCache         map[string]*dump.IndexResolver
+	irResolver      *dump.IndexResolver
 	mergedRuleToTag map[uint32]dump.IndexedTagSpec
 	counter         *uint64
 	group           string
+	irPath          string
 	batch           []bus.Message
 	schemaCacheMu   sync.Mutex
-	irCacheMu       sync.Mutex
+	irMu            sync.Mutex
 	batchMu         sync.Mutex
 	targetShardNum  uint32
 }
@@ -120,7 +121,6 @@ func newMeasureRowReplayer(
 		logger:          l,
 		measureSchemas:  measureSchemas,
 		schemaCache:     make(map[string]*cachedMeasureSchema),
-		irCache:         make(map[string]*dump.IndexResolver),
 		mergedRuleToTag: deriveMergedRuleToTag(measures, rules, bindings),
 		counter:         counter,
 		batch:           make([]bus.Message, 0, measureReplayBatchSize),
@@ -133,12 +133,13 @@ func (r *measureRowReplayer) Close() (map[string]*common.Error, error) {
 	flushCtx, cancel := context.WithTimeout(context.Background(), measureReplayBatchTimeout)
 	defer cancel()
 	flushErr := r.flushBatch(flushCtx)
-	r.irCacheMu.Lock()
-	for _, ir := range r.irCache {
-		_ = ir.Close()
+	r.irMu.Lock()
+	if r.irResolver != nil {
+		_ = r.irResolver.Close()
+		r.irResolver = nil
+		r.irPath = ""
 	}
-	r.irCache = nil
-	r.irCacheMu.Unlock()
+	r.irMu.Unlock()
 	cee, closeErr := r.publisher.Close()
 	if flushErr != nil {
 		return cee, flushErr
@@ -184,18 +185,29 @@ func (r *measureRowReplayer) loadSchema(measureName string) (*cachedMeasureSchem
 	return c, nil
 }
 
-// loadIndexResolver lazily opens an IndexResolver per source segment.
+// loadIndexResolver lazily opens an IndexResolver for the current source
+// segment. Only one resolver is kept resident: same segmentPath reuses it
+// (so all shards/parts under a segment share the bluge reader and avoid
+// reopening the same exclusive-locked dir), and a different segmentPath closes
+// the prior one before opening a new one. The replayer's Close releases the
+// last resolver.
 func (r *measureRowReplayer) loadIndexResolver(segmentPath string) (*dump.IndexResolver, error) {
-	r.irCacheMu.Lock()
-	defer r.irCacheMu.Unlock()
-	if ir, ok := r.irCache[segmentPath]; ok {
-		return ir, nil
+	r.irMu.Lock()
+	defer r.irMu.Unlock()
+	if r.irResolver != nil && r.irPath == segmentPath {
+		return r.irResolver, nil
+	}
+	if r.irResolver != nil {
+		_ = r.irResolver.Close()
+		r.irResolver = nil
+		r.irPath = ""
 	}
 	ir, err := dump.NewIndexResolver(segmentPath, dump.DefaultIndexCacheSize, r.mergedRuleToTag)
 	if err != nil {
 		return nil, fmt.Errorf("open index resolver for %s: %w", segmentPath, err)
 	}
-	r.irCache[segmentPath] = ir
+	r.irResolver = ir
+	r.irPath = segmentPath
 	return ir, nil
 }
 

--- a/banyand/backup/lifecycle/row_replay_stream.go
+++ b/banyand/backup/lifecycle/row_replay_stream.go
@@ -1,0 +1,294 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package lifecycle
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/apache/skywalking-banyandb/api/common"
+	"github.com/apache/skywalking-banyandb/api/data"
+	commonv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/common/v1"
+	databasev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
+	streamv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/stream/v1"
+	"github.com/apache/skywalking-banyandb/banyand/internal/dump"
+	dumpstream "github.com/apache/skywalking-banyandb/banyand/internal/dump/stream"
+	"github.com/apache/skywalking-banyandb/banyand/metadata"
+	"github.com/apache/skywalking-banyandb/banyand/queue"
+	"github.com/apache/skywalking-banyandb/pkg/bus"
+	"github.com/apache/skywalking-banyandb/pkg/convert"
+	"github.com/apache/skywalking-banyandb/pkg/fs"
+	"github.com/apache/skywalking-banyandb/pkg/logger"
+	"github.com/apache/skywalking-banyandb/pkg/node"
+	"github.com/apache/skywalking-banyandb/pkg/partition"
+)
+
+const (
+	streamReplayBatchSize    = 2000
+	streamReplayBatchTimeout = 30 * time.Second
+)
+
+type cachedStreamSchema struct {
+	schema        *databasev1.Stream
+	entityLocator partition.Locator
+}
+
+// streamRowReplayer replays a group's stream parts row-by-row.
+type streamRowReplayer struct {
+	selector       node.Selector
+	client         queue.Client
+	publisher      queue.BatchPublisher
+	metadata       metadata.Repo
+	fs             fs.FileSystem
+	logger         *logger.Logger
+	schemaCache    map[string]*cachedStreamSchema
+	irCache        map[string]*dump.IndexResolver
+	counter        *uint64
+	group          string
+	batch          []bus.Message
+	schemaCacheMu  sync.Mutex
+	irCacheMu      sync.Mutex
+	batchMu        sync.Mutex
+	targetShardNum uint32
+}
+
+func newStreamRowReplayer(
+	group string, targetShardNum uint32,
+	selector node.Selector, client queue.Client,
+	md metadata.Repo, fileSystem fs.FileSystem,
+	l *logger.Logger, counter *uint64,
+) *streamRowReplayer {
+	return &streamRowReplayer{
+		group:          group,
+		targetShardNum: targetShardNum,
+		selector:       selector,
+		client:         client,
+		publisher:      client.NewBatchPublisher(streamReplayBatchTimeout),
+		metadata:       md,
+		fs:             fileSystem,
+		logger:         l,
+		schemaCache:    make(map[string]*cachedStreamSchema),
+		irCache:        make(map[string]*dump.IndexResolver),
+		counter:        counter,
+		batch:          make([]bus.Message, 0, streamReplayBatchSize),
+	}
+}
+
+// Close flushes pending messages, closes the publisher and releases cached
+// IndexResolver handles.
+func (r *streamRowReplayer) Close() (map[string]*common.Error, error) {
+	flushCtx, cancel := context.WithTimeout(context.Background(), streamReplayBatchTimeout)
+	defer cancel()
+	flushErr := r.flushBatch(flushCtx)
+	r.irCacheMu.Lock()
+	for _, ir := range r.irCache {
+		_ = ir.Close()
+	}
+	r.irCache = nil
+	r.irCacheMu.Unlock()
+	cee, closeErr := r.publisher.Close()
+	if flushErr != nil {
+		return cee, flushErr
+	}
+	return cee, closeErr
+}
+
+// flushAndConfirm flushes the buffered batch, closes the publisher to obtain the
+// per-node delivery result for everything sent since the last call, then opens a
+// fresh publisher for subsequent parts. The batch publisher is client-streaming,
+// so per-node errors are only observable once its stream closes; this lets a
+// row-replayed part be confirmed durable before it is marked completed.
+func (r *streamRowReplayer) flushAndConfirm(ctx context.Context) (map[string]*common.Error, error) {
+	flushErr := r.flushBatch(ctx)
+	cee, closeErr := r.publisher.Close()
+	r.publisher = r.client.NewBatchPublisher(streamReplayBatchTimeout)
+	if flushErr != nil {
+		return cee, flushErr
+	}
+	return cee, closeErr
+}
+
+// loadIndexResolver lazily opens an IndexResolver per source segment.
+func (r *streamRowReplayer) loadIndexResolver(segmentPath string) (*dump.IndexResolver, error) {
+	r.irCacheMu.Lock()
+	defer r.irCacheMu.Unlock()
+	if ir, ok := r.irCache[segmentPath]; ok {
+		return ir, nil
+	}
+	ir, err := dump.NewIndexResolver(segmentPath, dump.DefaultIndexCacheSize, nil)
+	if err != nil {
+		return nil, fmt.Errorf("open stream index resolver for %s: %w", segmentPath, err)
+	}
+	r.irCache[segmentPath] = ir
+	return ir, nil
+}
+
+func (r *streamRowReplayer) loadSchema(ctx context.Context, streamName string) (*cachedStreamSchema, error) {
+	r.schemaCacheMu.Lock()
+	defer r.schemaCacheMu.Unlock()
+	if c, ok := r.schemaCache[streamName]; ok {
+		return c, nil
+	}
+	s, err := r.metadata.StreamRegistry().GetStream(ctx, &commonv1.Metadata{Group: r.group, Name: streamName})
+	if err != nil {
+		return nil, fmt.Errorf("load stream schema %s/%s: %w", r.group, streamName, err)
+	}
+	c := &cachedStreamSchema{
+		schema:        s,
+		entityLocator: partition.NewEntityLocator(s.TagFamilies, s.Entity, s.GetMetadata().GetModRevision()),
+	}
+	r.schemaCache[streamName] = c
+	return c, nil
+}
+
+func (r *streamRowReplayer) replayPart(ctx context.Context, partPath string) (int, error) {
+	partID, parseErr := strconv.ParseUint(filepath.Base(partPath), 16, 64)
+	if parseErr != nil {
+		return 0, fmt.Errorf("invalid part path %s: %w", partPath, parseErr)
+	}
+	shardPath := filepath.Dir(partPath)
+	segmentPath := filepath.Dir(shardPath)
+
+	reader, err := dumpstream.OpenPart(partID, shardPath, r.fs)
+	if err != nil {
+		return 0, fmt.Errorf("open stream part %s: %w", partPath, err)
+	}
+	defer reader.Close()
+
+	ir, irErr := r.loadIndexResolver(segmentPath)
+	if irErr != nil {
+		return 0, fmt.Errorf("load stream index resolver for segment %s: %w", segmentPath, irErr)
+	}
+	reader.SetIndexResolver(ir)
+
+	it := reader.Iterator()
+	defer it.Close()
+
+	rowCount := 0
+	for it.Next() {
+		row := it.Row()
+		if rowErr := r.publishRow(ctx, row); rowErr != nil {
+			pos := it.Position()
+			r.logger.Warn().Err(rowErr).
+				Str("group", r.group).
+				Str("part", partPath).
+				Int("block_idx", pos.BlockIdx).
+				Int("row_idx", pos.RowIdx).
+				Int("rows_published", rowCount).
+				Msg("stream row-replay aborted mid-part on publish error; will retry on resume")
+			return rowCount, rowErr
+		}
+		rowCount++
+	}
+	if iterErr := it.Err(); iterErr != nil {
+		pos := it.Position()
+		r.logger.Warn().Err(iterErr).
+			Str("group", r.group).
+			Str("part", partPath).
+			Int("block_idx", pos.BlockIdx).
+			Int("row_idx", pos.RowIdx).
+			Int("rows_published", rowCount).
+			Msg("stream row-replay aborted mid-part; will retry on resume")
+		return rowCount, iterErr
+	}
+	if r.counter != nil {
+		atomic.AddUint64(r.counter, 1)
+	}
+	return rowCount, nil
+}
+
+// buildWriteRequest reconstructs the WriteRequest + InternalWriteRequest pair
+// from a raw stream Row. Separated from publishRow for testability.
+func (r *streamRowReplayer) buildWriteRequest(ctx context.Context, row dumpstream.Row) (*streamv1.WriteRequest, *streamv1.InternalWriteRequest, error) {
+	subject, evList, err := decodeSeriesEntityValues(row.EntityValues)
+	if err != nil {
+		return nil, nil, fmt.Errorf("decode entity values (seriesID=%d): %w", row.SeriesID, err)
+	}
+	cached, err := r.loadSchema(ctx, subject)
+	if err != nil {
+		return nil, nil, err
+	}
+	tagFamilies := buildStreamTagFamilies(cached.schema.TagFamilies, cached.schema.Entity, row, evList)
+	wr := &streamv1.WriteRequest{
+		Metadata: &commonv1.Metadata{Group: r.group, Name: subject},
+		Element: &streamv1.ElementValue{
+			ElementId:   base64.StdEncoding.EncodeToString(convert.Uint64ToBytes(row.ElementID)),
+			Timestamp:   timestamppb.New(time.Unix(0, row.Timestamp)),
+			TagFamilies: tagFamilies,
+		},
+		MessageId: uint64(time.Now().UnixNano()),
+	}
+	tagValues, shardID, err := partition.ApplyLocators(subject, tagFamilies,
+		cached.entityLocator, nil, r.targetShardNum)
+	if err != nil {
+		return nil, nil, fmt.Errorf("route %s: %w", subject, err)
+	}
+	iwr := &streamv1.InternalWriteRequest{
+		ShardId:      uint32(shardID),
+		EntityValues: tagValues[1:].Encode(),
+		Request:      wr,
+		RawElementId: row.ElementID,
+	}
+	return wr, iwr, nil
+}
+
+func (r *streamRowReplayer) publishRow(ctx context.Context, row dumpstream.Row) error {
+	wr, iwr, err := r.buildWriteRequest(ctx, row)
+	if err != nil {
+		return err
+	}
+	nodeID, err := r.selector.Pick(r.group, wr.Metadata.Name, iwr.ShardId, 0)
+	if err != nil {
+		return fmt.Errorf("pick target node for %s: %w", wr.Metadata.Name, err)
+	}
+	msg := bus.NewBatchMessageWithNode(bus.MessageID(time.Now().UnixNano()), nodeID, iwr)
+	return r.enqueue(ctx, msg)
+}
+
+// enqueue appends a message to the batch and flushes when full.
+func (r *streamRowReplayer) enqueue(ctx context.Context, msg bus.Message) error {
+	r.batchMu.Lock()
+	r.batch = append(r.batch, msg)
+	shouldFlush := len(r.batch) >= streamReplayBatchSize
+	r.batchMu.Unlock()
+	if shouldFlush {
+		return r.flushBatch(ctx)
+	}
+	return nil
+}
+
+func (r *streamRowReplayer) flushBatch(ctx context.Context) error {
+	r.batchMu.Lock()
+	if len(r.batch) == 0 {
+		r.batchMu.Unlock()
+		return nil
+	}
+	pending := r.batch
+	r.batch = make([]bus.Message, 0, streamReplayBatchSize)
+	r.batchMu.Unlock()
+	_, err := r.publisher.Publish(ctx, data.TopicStreamWrite, pending...)
+	return err
+}

--- a/banyand/backup/lifecycle/row_replay_stream.go
+++ b/banyand/backup/lifecycle/row_replay_stream.go
@@ -65,12 +65,13 @@ type streamRowReplayer struct {
 	fs             fs.FileSystem
 	logger         *logger.Logger
 	schemaCache    map[string]*cachedStreamSchema
-	irCache        map[string]*dump.IndexResolver
+	irResolver     *dump.IndexResolver
 	counter        *uint64
 	group          string
+	irPath         string
 	batch          []bus.Message
 	schemaCacheMu  sync.Mutex
-	irCacheMu      sync.Mutex
+	irMu           sync.Mutex
 	batchMu        sync.Mutex
 	targetShardNum uint32
 }
@@ -91,7 +92,6 @@ func newStreamRowReplayer(
 		fs:             fileSystem,
 		logger:         l,
 		schemaCache:    make(map[string]*cachedStreamSchema),
-		irCache:        make(map[string]*dump.IndexResolver),
 		counter:        counter,
 		batch:          make([]bus.Message, 0, streamReplayBatchSize),
 	}
@@ -103,12 +103,13 @@ func (r *streamRowReplayer) Close() (map[string]*common.Error, error) {
 	flushCtx, cancel := context.WithTimeout(context.Background(), streamReplayBatchTimeout)
 	defer cancel()
 	flushErr := r.flushBatch(flushCtx)
-	r.irCacheMu.Lock()
-	for _, ir := range r.irCache {
-		_ = ir.Close()
+	r.irMu.Lock()
+	if r.irResolver != nil {
+		_ = r.irResolver.Close()
+		r.irResolver = nil
+		r.irPath = ""
 	}
-	r.irCache = nil
-	r.irCacheMu.Unlock()
+	r.irMu.Unlock()
 	cee, closeErr := r.publisher.Close()
 	if flushErr != nil {
 		return cee, flushErr
@@ -131,18 +132,29 @@ func (r *streamRowReplayer) flushAndConfirm(ctx context.Context) (map[string]*co
 	return cee, closeErr
 }
 
-// loadIndexResolver lazily opens an IndexResolver per source segment.
+// loadIndexResolver lazily opens an IndexResolver for the current source
+// segment. Only one resolver is kept resident: same segmentPath reuses it
+// (so all shards/parts under a segment share the bluge reader and avoid
+// reopening the same exclusive-locked dir), and a different segmentPath closes
+// the prior one before opening a new one. The replayer's Close releases the
+// last resolver.
 func (r *streamRowReplayer) loadIndexResolver(segmentPath string) (*dump.IndexResolver, error) {
-	r.irCacheMu.Lock()
-	defer r.irCacheMu.Unlock()
-	if ir, ok := r.irCache[segmentPath]; ok {
-		return ir, nil
+	r.irMu.Lock()
+	defer r.irMu.Unlock()
+	if r.irResolver != nil && r.irPath == segmentPath {
+		return r.irResolver, nil
+	}
+	if r.irResolver != nil {
+		_ = r.irResolver.Close()
+		r.irResolver = nil
+		r.irPath = ""
 	}
 	ir, err := dump.NewIndexResolver(segmentPath, dump.DefaultIndexCacheSize, nil)
 	if err != nil {
 		return nil, fmt.Errorf("open stream index resolver for %s: %w", segmentPath, err)
 	}
-	r.irCache[segmentPath] = ir
+	r.irResolver = ir
+	r.irPath = segmentPath
 	return ir, nil
 }
 

--- a/banyand/backup/lifecycle/row_replay_test.go
+++ b/banyand/backup/lifecycle/row_replay_test.go
@@ -1,0 +1,968 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package lifecycle
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	gofs "io/fs"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/apache/skywalking-banyandb/api/data"
+	commonv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/common/v1"
+	databasev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
+	measurev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/measure/v1"
+	modelv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/model/v1"
+	streamv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/stream/v1"
+	tracev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/trace/v1"
+	"github.com/apache/skywalking-banyandb/banyand/internal/dump"
+	dumpmeasure "github.com/apache/skywalking-banyandb/banyand/internal/dump/measure"
+	dumpstream "github.com/apache/skywalking-banyandb/banyand/internal/dump/stream"
+	dumptrace "github.com/apache/skywalking-banyandb/banyand/internal/dump/trace"
+	"github.com/apache/skywalking-banyandb/banyand/measure"
+	metadataservice "github.com/apache/skywalking-banyandb/banyand/metadata/service"
+	obsservice "github.com/apache/skywalking-banyandb/banyand/observability/services"
+	"github.com/apache/skywalking-banyandb/banyand/protector"
+	"github.com/apache/skywalking-banyandb/banyand/queue"
+	"github.com/apache/skywalking-banyandb/banyand/stream"
+	"github.com/apache/skywalking-banyandb/banyand/trace"
+	"github.com/apache/skywalking-banyandb/pkg/bus"
+	"github.com/apache/skywalking-banyandb/pkg/convert"
+	localfs "github.com/apache/skywalking-banyandb/pkg/fs"
+	"github.com/apache/skywalking-banyandb/pkg/logger"
+	pbv1 "github.com/apache/skywalking-banyandb/pkg/pb/v1"
+	"github.com/apache/skywalking-banyandb/pkg/test"
+)
+
+// TestDecodeSeriesEntityValues_RoundTrip verifies that a marshaled Series
+// round-trips through decodeSeriesEntityValues.
+func TestDecodeSeriesEntityValues_RoundTrip(t *testing.T) {
+	t.Run("subject_with_string_entity_tags", func(t *testing.T) {
+		original := &pbv1.Series{
+			Subject: "service_cpm_minute",
+			EntityValues: []*modelv1.TagValue{
+				{Value: &modelv1.TagValue_Str{Str: &modelv1.Str{Value: "checkout"}}},
+				{Value: &modelv1.TagValue_Str{Str: &modelv1.Str{Value: "us-east-1"}}},
+			},
+		}
+		require.NoError(t, original.Marshal())
+
+		subject, evList, err := decodeSeriesEntityValues(original.Buffer)
+		require.NoError(t, err)
+		assert.Equal(t, "service_cpm_minute", subject)
+		require.Len(t, evList, 2)
+		assert.Equal(t, "checkout", evList[0].GetStr().GetValue())
+		assert.Equal(t, "us-east-1", evList[1].GetStr().GetValue())
+	})
+
+	t.Run("empty_bytes_rejected", func(t *testing.T) {
+		_, _, err := decodeSeriesEntityValues(nil)
+		require.Error(t, err)
+	})
+
+	t.Run("empty_subject_rejected", func(t *testing.T) {
+		s := &pbv1.Series{Subject: "", EntityValues: nil}
+		require.NoError(t, s.Marshal())
+		_, _, err := decodeSeriesEntityValues(s.Buffer)
+		require.Error(t, err)
+	})
+}
+
+// TestTagTypeToValueType verifies every TagType maps to the expected ValueType.
+func TestTagTypeToValueType(t *testing.T) {
+	cases := []struct {
+		in   databasev1.TagType
+		want pbv1.ValueType
+	}{
+		{databasev1.TagType_TAG_TYPE_STRING, pbv1.ValueTypeStr},
+		{databasev1.TagType_TAG_TYPE_INT, pbv1.ValueTypeInt64},
+		{databasev1.TagType_TAG_TYPE_DATA_BINARY, pbv1.ValueTypeBinaryData},
+		{databasev1.TagType_TAG_TYPE_STRING_ARRAY, pbv1.ValueTypeStrArr},
+		{databasev1.TagType_TAG_TYPE_INT_ARRAY, pbv1.ValueTypeInt64Arr},
+		{databasev1.TagType_TAG_TYPE_TIMESTAMP, pbv1.ValueTypeTimestamp},
+		{databasev1.TagType_TAG_TYPE_UNSPECIFIED, pbv1.ValueTypeUnknown},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, tagTypeToValueType(c.in), "TagType=%v", c.in)
+	}
+}
+
+// TestFieldTypeToValueType verifies every FieldType maps to the expected ValueType.
+func TestFieldTypeToValueType(t *testing.T) {
+	cases := []struct {
+		in   databasev1.FieldType
+		want pbv1.ValueType
+	}{
+		{databasev1.FieldType_FIELD_TYPE_STRING, pbv1.ValueTypeStr},
+		{databasev1.FieldType_FIELD_TYPE_INT, pbv1.ValueTypeInt64},
+		{databasev1.FieldType_FIELD_TYPE_FLOAT, pbv1.ValueTypeFloat64},
+		{databasev1.FieldType_FIELD_TYPE_DATA_BINARY, pbv1.ValueTypeBinaryData},
+		{databasev1.FieldType_FIELD_TYPE_UNSPECIFIED, pbv1.ValueTypeUnknown},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, fieldTypeToValueType(c.in), "FieldType=%v", c.in)
+	}
+}
+
+// TestBuildEntityTagIndex verifies positional mapping of Entity.TagNames to EntityValues.
+func TestBuildEntityTagIndex(t *testing.T) {
+	entity := &databasev1.Entity{TagNames: []string{"service", "region"}}
+	evList := pbv1.EntityValues{
+		&modelv1.TagValue{Value: &modelv1.TagValue_Str{Str: &modelv1.Str{Value: "checkout"}}},
+		&modelv1.TagValue{Value: &modelv1.TagValue_Str{Str: &modelv1.Str{Value: "us-east-1"}}},
+	}
+	idx := buildEntityTagIndex(entity, evList)
+	require.Len(t, idx, 2)
+	assert.Equal(t, "checkout", idx["service"].GetStr().GetValue())
+	assert.Equal(t, "us-east-1", idx["region"].GetStr().GetValue())
+
+	// A nil entity yields no index.
+	assert.Nil(t, buildEntityTagIndex(nil, evList))
+
+	// Fewer values than names: trailing names are dropped, no panic.
+	short := buildEntityTagIndex(entity, evList[:1])
+	require.Len(t, short, 1)
+	assert.Equal(t, "checkout", short["service"].GetStr().GetValue())
+}
+
+// TestDeriveMergedRuleToTag verifies index-rule -> tag-spec resolution,
+// including skipping rules for undeclared tags.
+func TestDeriveMergedRuleToTag(t *testing.T) {
+	measures := []*databasev1.Measure{
+		{
+			Metadata: &commonv1.Metadata{Name: "m1"},
+			TagFamilies: []*databasev1.TagFamilySpec{
+				{
+					Name: "searchable",
+					Tags: []*databasev1.TagSpec{
+						{Name: "endpoint_id", Type: databasev1.TagType_TAG_TYPE_STRING},
+						{Name: "rpc_latency_buckets", Type: databasev1.TagType_TAG_TYPE_INT_ARRAY},
+					},
+				},
+			},
+		},
+	}
+	rules := []*databasev1.IndexRule{
+		{
+			Metadata: &commonv1.Metadata{Id: 101, Name: "idx_endpoint"},
+			Tags:     []string{"endpoint_id"},
+		},
+		{
+			Metadata: &commonv1.Metadata{Id: 102, Name: "idx_buckets"},
+			Tags:     []string{"rpc_latency_buckets"},
+		},
+		{
+			Metadata: &commonv1.Metadata{Id: 103, Name: "idx_unknown"},
+			Tags:     []string{"not_declared_anywhere"},
+		},
+		{
+			// Multi-tag (composite) rule: indexed under one ruleID field as a
+			// composite term, not decodable into individual tag values.
+			Metadata: &commonv1.Metadata{Id: 104, Name: "idx_multi"},
+			Tags:     []string{"endpoint_id", "rpc_latency_buckets"},
+		},
+	}
+	bindings := []*databasev1.IndexRuleBinding{
+		{
+			Subject: &databasev1.Subject{Catalog: commonv1.Catalog_CATALOG_MEASURE, Name: "m1"},
+			Rules:   []string{"idx_endpoint", "idx_buckets", "idx_unknown", "idx_multi"},
+		},
+	}
+	out := deriveMergedRuleToTag(measures, rules, bindings)
+	require.Len(t, out, 2)
+	assert.Equal(t, dump.IndexedTagSpec{Family: "searchable", Name: "endpoint_id", Type: pbv1.ValueTypeStr}, out[101])
+	assert.Equal(t, dump.IndexedTagSpec{Family: "searchable", Name: "rpc_latency_buckets", Type: pbv1.ValueTypeInt64Arr}, out[102])
+	_, hasUnknown := out[103]
+	assert.False(t, hasUnknown, "rule whose tag is undefined in the bound measure should be skipped")
+	_, hasMulti := out[104]
+	assert.False(t, hasMulti, "multi-tag (composite) rule must be skipped: its value is not a single decodable tag")
+}
+
+// TestDeriveMergedRuleToTag_PerMeasureScope pins the collision fix: two measures
+// declare a tag with the same name but a different family/type. Each rule must
+// resolve within the measure it is bound to, not a group-wide merge.
+func TestDeriveMergedRuleToTag_PerMeasureScope(t *testing.T) {
+	measures := []*databasev1.Measure{
+		{
+			Metadata: &commonv1.Metadata{Name: "m_str"},
+			TagFamilies: []*databasev1.TagFamilySpec{
+				{Name: "fa", Tags: []*databasev1.TagSpec{{Name: "x", Type: databasev1.TagType_TAG_TYPE_STRING}}},
+			},
+		},
+		{
+			Metadata: &commonv1.Metadata{Name: "m_int"},
+			TagFamilies: []*databasev1.TagFamilySpec{
+				{Name: "fb", Tags: []*databasev1.TagSpec{{Name: "x", Type: databasev1.TagType_TAG_TYPE_INT}}},
+			},
+		},
+	}
+	rules := []*databasev1.IndexRule{
+		{Metadata: &commonv1.Metadata{Id: 1, Name: "r_str"}, Tags: []string{"x"}},
+		{Metadata: &commonv1.Metadata{Id: 2, Name: "r_int"}, Tags: []string{"x"}},
+	}
+	bindings := []*databasev1.IndexRuleBinding{
+		{Subject: &databasev1.Subject{Catalog: commonv1.Catalog_CATALOG_MEASURE, Name: "m_str"}, Rules: []string{"r_str"}},
+		{Subject: &databasev1.Subject{Catalog: commonv1.Catalog_CATALOG_MEASURE, Name: "m_int"}, Rules: []string{"r_int"}},
+	}
+	out := deriveMergedRuleToTag(measures, rules, bindings)
+	require.Len(t, out, 2)
+	assert.Equal(t, dump.IndexedTagSpec{Family: "fa", Name: "x", Type: pbv1.ValueTypeStr}, out[1],
+		"rule bound to m_str must resolve tag x as STRING in family fa")
+	assert.Equal(t, dump.IndexedTagSpec{Family: "fb", Name: "x", Type: pbv1.ValueTypeInt64}, out[2],
+		"rule bound to m_int must resolve tag x as INT in family fb")
+}
+
+// TestDeriveMergedRuleToTag_EmptyInputs verifies nil/empty inputs return nil,
+// including the no-bindings case (no rule is applied to any measure).
+func TestDeriveMergedRuleToTag_EmptyInputs(t *testing.T) {
+	assert.Nil(t, deriveMergedRuleToTag(nil, nil, nil))
+	assert.Nil(t, deriveMergedRuleToTag(
+		[]*databasev1.Measure{{Metadata: &commonv1.Metadata{Name: "m"}}},
+		[]*databasev1.IndexRule{{Metadata: &commonv1.Metadata{Id: 1, Name: "r"}, Tags: []string{"x"}}},
+		nil,
+	), "no bindings must yield nil")
+	assert.Nil(t, deriveMergedRuleToTag([]*databasev1.Measure{{Metadata: &commonv1.Metadata{Name: "m"}}}, nil,
+		[]*databasev1.IndexRuleBinding{{Subject: &databasev1.Subject{Catalog: commonv1.Catalog_CATALOG_MEASURE, Name: "m"}}}))
+}
+
+func stringTagValue(v string) *modelv1.TagValue {
+	return &modelv1.TagValue{Value: &modelv1.TagValue_Str{Str: &modelv1.Str{Value: v}}}
+}
+
+func intTagValue(v int64) *modelv1.TagValue {
+	return &modelv1.TagValue{Value: &modelv1.TagValue_Int{Int: &modelv1.Int{Value: v}}}
+}
+
+func intFieldValue(v int64) *modelv1.FieldValue {
+	return &modelv1.FieldValue{Value: &modelv1.FieldValue_Int{Int: &modelv1.Int{Value: v}}}
+}
+
+func floatFieldValue(v float64) *modelv1.FieldValue {
+	return &modelv1.FieldValue{Value: &modelv1.FieldValue_Float{Float: &modelv1.Float{Value: v}}}
+}
+
+func mustMarshalTag(t *testing.T, tv *modelv1.TagValue) []byte {
+	t.Helper()
+	b, err := pbv1.MarshalTagValue(tv)
+	require.NoError(t, err)
+	return b
+}
+
+// TestBuildMeasureTagFamilies_PriorityOrder verifies tag resolution priority:
+// column store > IndexResolver > EntityValues > null.
+func TestBuildMeasureTagFamilies_PriorityOrder(t *testing.T) {
+	families := []*databasev1.TagFamilySpec{
+		{
+			Name: "primary",
+			Tags: []*databasev1.TagSpec{
+				{Name: "service", Type: databasev1.TagType_TAG_TYPE_STRING}, // entity tag
+				{Name: "method", Type: databasev1.TagType_TAG_TYPE_STRING},  // column tag
+			},
+		},
+		{
+			Name: "searchable",
+			Tags: []*databasev1.TagSpec{
+				{Name: "endpoint", Type: databasev1.TagType_TAG_TYPE_STRING}, // index-only tag
+				{Name: "absent", Type: databasev1.TagType_TAG_TYPE_STRING},   // truly missing
+			},
+		},
+	}
+	entity := &databasev1.Entity{TagNames: []string{"service"}}
+	evList := pbv1.EntityValues{stringTagValue("checkout")}
+
+	row := dumpmeasure.Row{
+		Tags: map[string][]byte{
+			"primary.method": mustMarshalTag(t, stringTagValue("POST")),
+		},
+		TagTypes: map[string]pbv1.ValueType{
+			"primary.method": pbv1.ValueTypeStr,
+		},
+	}
+	indexedTyped := map[string]*modelv1.TagValue{
+		"searchable.endpoint": stringTagValue("/checkout/v1"),
+	}
+
+	out := buildMeasureTagFamilies(families, entity, row, evList, indexedTyped)
+	require.Len(t, out, 2)
+	require.Len(t, out[0].Tags, 2)
+	require.Len(t, out[1].Tags, 2)
+
+	assert.Equal(t, "checkout", out[0].Tags[0].GetStr().GetValue())
+	assert.Equal(t, "POST", out[0].Tags[1].GetStr().GetValue())
+	assert.Equal(t, "/checkout/v1", out[1].Tags[0].GetStr().GetValue())
+	assert.True(t, proto.Equal(pbv1.NullTagValue, out[1].Tags[1]),
+		"absent tag must fall back to NullTagValue")
+}
+
+// TestBuildMeasureTagFamilies_ColumnOverridesIndexed verifies column store
+// wins over index resolver when both supply the same tag.
+func TestBuildMeasureTagFamilies_ColumnOverridesIndexed(t *testing.T) {
+	families := []*databasev1.TagFamilySpec{
+		{
+			Name: "primary",
+			Tags: []*databasev1.TagSpec{
+				{Name: "biz_id", Type: databasev1.TagType_TAG_TYPE_STRING},
+			},
+		},
+	}
+	row := dumpmeasure.Row{
+		Tags: map[string][]byte{
+			"primary.biz_id": mustMarshalTag(t, stringTagValue("from-column")),
+		},
+		TagTypes: map[string]pbv1.ValueType{
+			"primary.biz_id": pbv1.ValueTypeStr,
+		},
+	}
+	indexedTyped := map[string]*modelv1.TagValue{
+		"primary.biz_id": stringTagValue("from-index"),
+	}
+	out := buildMeasureTagFamilies(families, nil, row, nil, indexedTyped)
+	require.Len(t, out, 1)
+	require.Len(t, out[0].Tags, 1)
+	assert.Equal(t, "from-column", out[0].Tags[0].GetStr().GetValue(),
+		"column store must win over index resolver when both supply the same tag")
+}
+
+// TestBuildStreamTagFamilies_EntityAndColumn verifies stream tag resolution:
+// column store > EntityValues > null.
+func TestBuildStreamTagFamilies_EntityAndColumn(t *testing.T) {
+	families := []*databasev1.TagFamilySpec{
+		{
+			Name: "trace",
+			Tags: []*databasev1.TagSpec{
+				{Name: "service", Type: databasev1.TagType_TAG_TYPE_STRING}, // entity tag
+				{Name: "url", Type: databasev1.TagType_TAG_TYPE_STRING},     // column tag
+				{Name: "absent", Type: databasev1.TagType_TAG_TYPE_STRING},  // null
+			},
+		},
+	}
+	entity := &databasev1.Entity{TagNames: []string{"service"}}
+	evList := pbv1.EntityValues{stringTagValue("checkout")}
+	row := dumpstream.Row{
+		Tags: map[string][]byte{
+			"trace.url": mustMarshalTag(t, stringTagValue("/checkout/v1")),
+		},
+		TagTypes: map[string]pbv1.ValueType{
+			"trace.url": pbv1.ValueTypeStr,
+		},
+	}
+	out := buildStreamTagFamilies(families, entity, row, evList)
+	require.Len(t, out, 1)
+	require.Len(t, out[0].Tags, 3)
+	assert.Equal(t, "checkout", out[0].Tags[0].GetStr().GetValue())
+	assert.Equal(t, "/checkout/v1", out[0].Tags[1].GetStr().GetValue())
+	assert.True(t, proto.Equal(pbv1.NullTagValue, out[0].Tags[2]),
+		"absent tag must fall back to NullTagValue")
+}
+
+const (
+	roundtripMeasureGroup = "lc_rt_measure_group"
+	roundtripMeasureName  = "lc_rt_measure"
+	roundtripStreamGroup  = "lc_rt_stream_group"
+	roundtripStreamName   = "lc_rt_stream"
+	roundtripTraceGroup   = "lc_rt_trace_group"
+	roundtripTraceName    = "lc_rt_trace"
+)
+
+// TestRoundtrip_Measure writes a measure row, flushes to disk, then verifies
+// buildWriteRequest reconstructs a proto-equal WriteRequest.
+func TestRoundtrip_Measure(t *testing.T) {
+	req := require.New(t)
+	require.NoError(t, logger.Init(logger.Logging{Env: "dev", Level: "warn"}))
+	gomega.RegisterFailHandler(func(message string, _ ...int) { panic(message) })
+
+	pipeline := queue.Local()
+	metaSvc, err := metadataservice.NewService()
+	req.NoError(err)
+	metricSvc := obsservice.NewMetricService(metaSvc, pipeline, "test", nil)
+	pm := protector.NewMemory(metricSvc)
+	measureSvc, err := measure.NewStandalone(metaSvc, pipeline, nil, metricSvc, pm)
+	req.NoError(err)
+
+	metaPath, metaDefer, err := test.NewSpace()
+	req.NoError(err)
+	defer metaDefer()
+	ports, err := test.AllocateFreePorts(1)
+	req.NoError(err)
+	rootPath, rootDefer, err := test.NewSpace()
+	req.NoError(err)
+	defer rootDefer()
+
+	flags := []string{
+		"--schema-server-root-path=" + metaPath,
+		fmt.Sprintf("--schema-server-grpc-port=%d", ports[0]),
+		"--schema-server-grpc-host=127.0.0.1",
+		"--measure-root-path=" + rootPath,
+		"--measure-flush-timeout=200ms",
+	}
+	moduleDefer := test.SetupModules(flags, pipeline, metaSvc, measureSvc)
+	moduleStopped := false
+	defer func() {
+		if !moduleStopped {
+			moduleDefer()
+		}
+	}()
+
+	registerRoundtripMeasureSchema(t, metaSvc)
+	require.Eventually(t, func() bool {
+		_, ok := measureSvc.LoadGroup(roundtripMeasureGroup)
+		return ok
+	}, 30*time.Second, 200*time.Millisecond, "measure group not loaded")
+	time.Sleep(time.Second)
+
+	tsA := time.Now().Truncate(time.Millisecond)
+	tsB := tsA.Add(time.Hour)
+	// Two rows with fully distinct entity/tags/fields/version/timestamp, routed
+	// to different shards under shardNum=2 (series=ent-1 -> shard 0,
+	// ent-4 -> shard 1), so a parser that swaps or conflates rows fails.
+	type measureExpect struct {
+		wr        *measurev1.WriteRequest
+		series    string
+		wantShard uint32
+	}
+	entries := []measureExpect{
+		{buildMeasureWR(tsA, "ent-1", "alpha", 7, 111, 1.5, 42), "ent-1", 0},
+		{buildMeasureWR(tsB, "ent-4", "bravo", 8888, 222222, 2.71828, 99), "ent-4", 1},
+	}
+	expect := make(map[string]measureExpect, len(entries))
+
+	bp := pipeline.NewBatchPublisher(5 * time.Second)
+	for i, e := range entries {
+		expect[e.series] = e
+		_, errPub := bp.Publish(context.TODO(), data.TopicMeasureWrite, bus.NewMessage(bus.MessageID(i+1), &measurev1.InternalWriteRequest{
+			ShardId:      e.wantShard,
+			EntityValues: []*modelv1.TagValue{stringTagValue(e.series)},
+			Request:      e.wr,
+		}))
+		req.NoError(errPub)
+	}
+	closeNodeErrs, closeErr := bp.Close()
+	req.NoError(closeErr)
+	req.Empty(closeNodeErrs)
+
+	var partDirs []string
+	require.Eventually(t, func() bool {
+		partDirs = findRoundtripPartDirs(rootPath)
+		return len(partDirs) >= 2
+	}, 30*time.Second, 200*time.Millisecond, "measure parts for both shards not flushed")
+
+	// Construct the replayer while the metadata service is still running so it
+	// can enumerate measures + index rules; the IndexResolver below needs
+	// exclusive access to the bluge index dir, so the service must be stopped
+	// before any reader opens the segment.
+	replayer, err := newMeasureRowReplayer(context.TODO(), roundtripMeasureGroup, 2, nil, pipeline,
+		metaSvc, localfs.NewLocalFileSystem(), logger.GetLogger("test-replayer"), nil)
+	req.NoError(err)
+	defer replayer.Close()
+	// Warm the schema cache so buildWriteRequest does not need the metadata
+	// service after we stop it below.
+	_, err = replayer.loadSchema(roundtripMeasureName)
+	req.NoError(err)
+
+	moduleDefer()
+	moduleStopped = true
+
+	fileSystem := localfs.NewLocalFileSystem()
+	seen := make(map[string]bool)
+	for _, partDir := range partDirs {
+		partID, parseErr := strconv.ParseUint(filepath.Base(partDir), 16, 64)
+		req.NoError(parseErr)
+		shardPath := filepath.Dir(partDir)
+		segPath := filepath.Dir(shardPath)
+		reader, openErr := dumpmeasure.OpenPart(partID, shardPath, fileSystem)
+		req.NoError(openErr)
+		ir, irErr := replayer.loadIndexResolver(segPath)
+		req.NoError(irErr)
+		reader.SetIndexResolver(ir)
+		it := reader.Iterator()
+		for it.Next() {
+			row := it.Row()
+			wr, iwr, buildErr := replayer.buildWriteRequest(ir, row)
+			req.NoError(buildErr)
+			series := wr.GetDataPoint().GetTagFamilies()[0].GetTags()[0].GetStr().GetValue()
+			e, ok := expect[series]
+			require.Truef(t, ok, "replay produced an unexpected series %q", series)
+			assertMeasureWriteRequestEqual(t, e.wr, wr)
+			require.NotNil(t, iwr.Request, "iwr must wrap a WriteRequest")
+			require.Equal(t, wr, iwr.Request, "iwr.Request must point at the same WriteRequest")
+			require.Equalf(t, e.wantShard, iwr.ShardId, "series %q must route to shard %d under shardNum=2", series, e.wantShard)
+			require.Equal(t, pbv1.EntityValues{stringTagValue(series)}.Encode(), iwr.EntityValues,
+				"iwr.EntityValues must encode the entity tag (series)")
+			require.Falsef(t, seen[series], "series %q reconstructed twice", series)
+			seen[series] = true
+		}
+		require.NoError(t, it.Err())
+		it.Close()
+		reader.Close()
+	}
+	require.Len(t, seen, len(entries), "both rows (shard 0 and shard 1) must roundtrip exactly once")
+}
+
+// TestRoundtrip_Stream writes a stream element, flushes to disk, then verifies
+// buildWriteRequest reconstructs a proto-equal WriteRequest.
+func TestRoundtrip_Stream(t *testing.T) {
+	req := require.New(t)
+	require.NoError(t, logger.Init(logger.Logging{Env: "dev", Level: "warn"}))
+	gomega.RegisterFailHandler(func(message string, _ ...int) { panic(message) })
+
+	pipeline := queue.Local()
+	metaSvc, err := metadataservice.NewService()
+	req.NoError(err)
+	metricSvc := obsservice.NewMetricService(metaSvc, pipeline, "test", nil)
+	pm := protector.NewMemory(metricSvc)
+	streamSvc, err := stream.NewService(metaSvc, pipeline, metricSvc, pm, nil)
+	req.NoError(err)
+
+	metaPath, metaDefer, err := test.NewSpace()
+	req.NoError(err)
+	defer metaDefer()
+	ports, err := test.AllocateFreePorts(1)
+	req.NoError(err)
+	rootPath, rootDefer, err := test.NewSpace()
+	req.NoError(err)
+	defer rootDefer()
+
+	flags := []string{
+		"--schema-server-root-path=" + metaPath,
+		fmt.Sprintf("--schema-server-grpc-port=%d", ports[0]),
+		"--schema-server-grpc-host=127.0.0.1",
+		"--stream-root-path=" + rootPath,
+		"--stream-flush-timeout=200ms",
+	}
+	moduleDefer := test.SetupModules(flags, pipeline, metaSvc, streamSvc)
+	moduleStopped := false
+	defer func() {
+		if !moduleStopped {
+			moduleDefer()
+		}
+	}()
+
+	registerRoundtripStreamSchema(t, metaSvc)
+	require.Eventually(t, func() bool {
+		_, ok := streamSvc.LoadGroup(roundtripStreamGroup)
+		return ok
+	}, 30*time.Second, 200*time.Millisecond, "stream group not loaded")
+	time.Sleep(time.Second)
+
+	tsA := time.Now().Truncate(time.Millisecond)
+	tsB := tsA.Add(time.Hour)
+	// Two rows routed to different shards under shardNum=2 (series=ent-3 -> shard 0,
+	// ent-1 -> shard 1), with distinct tags, element ids and timestamps.
+	type streamExpect struct {
+		wr        *streamv1.WriteRequest
+		series    string
+		wantShard uint32
+	}
+	entries := []streamExpect{
+		{buildStreamWR(tsA, "ent-3", "alpha", 7, "elem-a"), "ent-3", 0},
+		{buildStreamWR(tsB, "ent-1", "bravo", 8888, "elem-b"), "ent-1", 1},
+	}
+	expect := make(map[string]streamExpect, len(entries))
+
+	bp := pipeline.NewBatchPublisher(5 * time.Second)
+	for i, e := range entries {
+		expect[e.series] = e
+		_, errPub := bp.Publish(context.TODO(), data.TopicStreamWrite, bus.NewMessage(bus.MessageID(i+1), &streamv1.InternalWriteRequest{
+			ShardId:      e.wantShard,
+			EntityValues: []*modelv1.TagValue{stringTagValue(e.series)},
+			Request:      e.wr,
+		}))
+		req.NoError(errPub)
+	}
+	closeNodeErrs, closeErr := bp.Close()
+	req.NoError(closeErr)
+	req.Empty(closeNodeErrs)
+
+	var partDirs []string
+	require.Eventually(t, func() bool {
+		partDirs = findRoundtripPartDirs(rootPath)
+		return len(partDirs) >= 2
+	}, 30*time.Second, 200*time.Millisecond, "stream parts for both shards not flushed")
+
+	replayer := newStreamRowReplayer(roundtripStreamGroup, 2, nil, pipeline,
+		metaSvc, localfs.NewLocalFileSystem(), logger.GetLogger("test-replayer"), nil)
+	defer replayer.Close()
+	// Warm the schema cache so buildWriteRequest does not need the metadata
+	// service after we stop it below.
+	_, err = replayer.loadSchema(context.TODO(), roundtripStreamName)
+	req.NoError(err)
+
+	moduleDefer()
+	moduleStopped = true
+
+	fileSystem := localfs.NewLocalFileSystem()
+	seen := make(map[string]bool)
+	for _, partDir := range partDirs {
+		partID, parseErr := strconv.ParseUint(filepath.Base(partDir), 16, 64)
+		req.NoError(parseErr)
+		shardPath := filepath.Dir(partDir)
+		segPath := filepath.Dir(shardPath)
+		reader, openErr := dumpstream.OpenPart(partID, shardPath, fileSystem)
+		req.NoError(openErr)
+		ir, irErr := replayer.loadIndexResolver(segPath)
+		req.NoError(irErr)
+		reader.SetIndexResolver(ir)
+		it := reader.Iterator()
+		for it.Next() {
+			row := it.Row()
+			wr, iwr, buildErr := replayer.buildWriteRequest(context.TODO(), row)
+			req.NoError(buildErr)
+			series := wr.GetElement().GetTagFamilies()[0].GetTags()[0].GetStr().GetValue()
+			e, ok := expect[series]
+			require.Truef(t, ok, "replay produced an unexpected series %q", series)
+			assertStreamWriteRequestEqual(t, e.wr, wr)
+			require.NotNil(t, iwr.Request, "iwr must wrap a WriteRequest")
+			require.Equal(t, wr, iwr.Request, "iwr.Request must point at the same WriteRequest")
+			require.Equalf(t, e.wantShard, iwr.ShardId, "series %q must route to shard %d under shardNum=2", series, e.wantShard)
+			require.Equal(t, pbv1.EntityValues{stringTagValue(series)}.Encode(), iwr.EntityValues,
+				"iwr.EntityValues must encode the entity tag (series)")
+			require.Equal(t, row.ElementID, iwr.RawElementId, "raw_element_id must equal source row.ElementID")
+			decodedID, decErr := base64.StdEncoding.DecodeString(wr.Element.ElementId)
+			require.NoError(t, decErr, "wr.Element.ElementId must be valid base64")
+			require.Equal(t, row.ElementID, convert.BytesToUint64(decodedID),
+				"wr.Element.ElementId must encode the same eID carried by raw_element_id")
+			require.Falsef(t, seen[series], "series %q reconstructed twice", series)
+			seen[series] = true
+		}
+		require.NoError(t, it.Err())
+		it.Close()
+		reader.Close()
+	}
+	require.Len(t, seen, len(entries), "both rows (shard 0 and shard 1) must roundtrip exactly once")
+}
+
+// TestRoundtrip_Trace writes a trace span, flushes to disk, then verifies
+// buildWriteRequest reconstructs a proto-equal WriteRequest.
+func TestRoundtrip_Trace(t *testing.T) {
+	req := require.New(t)
+	require.NoError(t, logger.Init(logger.Logging{Env: "dev", Level: "warn"}))
+	gomega.RegisterFailHandler(func(message string, _ ...int) { panic(message) })
+
+	pipeline := queue.Local()
+	metaSvc, err := metadataservice.NewService()
+	req.NoError(err)
+	metricSvc := obsservice.NewMetricService(metaSvc, pipeline, "test", nil)
+	pm := protector.NewMemory(metricSvc)
+	traceSvc, err := trace.NewService(metaSvc, pipeline, metricSvc, pm)
+	req.NoError(err)
+
+	metaPath, metaDefer, err := test.NewSpace()
+	req.NoError(err)
+	defer metaDefer()
+	ports, err := test.AllocateFreePorts(1)
+	req.NoError(err)
+	rootPath, rootDefer, err := test.NewSpace()
+	req.NoError(err)
+	defer rootDefer()
+
+	flags := []string{
+		"--schema-server-root-path=" + metaPath,
+		fmt.Sprintf("--schema-server-grpc-port=%d", ports[0]),
+		"--schema-server-grpc-host=127.0.0.1",
+		"--trace-root-path=" + rootPath,
+		"--trace-flush-timeout=200ms",
+	}
+	moduleDefer := test.SetupModules(flags, pipeline, metaSvc, traceSvc)
+	moduleStopped := false
+	defer func() {
+		if !moduleStopped {
+			moduleDefer()
+		}
+	}()
+
+	registerRoundtripTraceSchema(t, metaSvc)
+	require.Eventually(t, func() bool {
+		_, ok := traceSvc.LoadGroup(roundtripTraceGroup)
+		return ok
+	}, 30*time.Second, 200*time.Millisecond, "trace group not loaded")
+	time.Sleep(time.Second)
+
+	tsA := time.Now().Truncate(time.Millisecond)
+	tsB := tsA.Add(time.Hour)
+	// Two spans routed to different shards under shardNum=2 (trace_id=trace-0 ->
+	// shard 0, trace-abc -> shard 1), with distinct span ids, span payloads and
+	// timestamps.
+	type traceExpect struct {
+		wr        *tracev1.WriteRequest
+		traceID   string
+		wantShard uint32
+	}
+	entries := []traceExpect{
+		{buildTraceWR(tsA, "trace-0", "span-a", []byte("payload-a")), "trace-0", 0},
+		{buildTraceWR(tsB, "trace-abc", "span-b", []byte("payload-b-longer")), "trace-abc", 1},
+	}
+	expect := make(map[string]traceExpect, len(entries))
+
+	bp := pipeline.NewBatchPublisher(5 * time.Second)
+	for i, e := range entries {
+		expect[e.traceID] = e
+		_, errPub := bp.Publish(context.TODO(), data.TopicTraceWrite, bus.NewMessage(bus.MessageID(i+1), &tracev1.InternalWriteRequest{
+			ShardId: e.wantShard,
+			Request: e.wr,
+		}))
+		req.NoError(errPub)
+	}
+	closeNodeErrs, closeErr := bp.Close()
+	req.NoError(closeErr)
+	req.Empty(closeNodeErrs)
+
+	var partDirs []string
+	require.Eventually(t, func() bool {
+		partDirs = findRoundtripPartDirs(rootPath)
+		return len(partDirs) >= 2
+	}, 30*time.Second, 200*time.Millisecond, "trace parts for both shards not flushed")
+
+	replayer, err := newTraceRowReplayer(context.TODO(), roundtripTraceGroup, 2, nil, pipeline,
+		metaSvc, localfs.NewLocalFileSystem(), logger.GetLogger("test-replayer"), nil)
+	req.NoError(err)
+	defer replayer.Close()
+
+	moduleDefer()
+	moduleStopped = true
+
+	fileSystem := localfs.NewLocalFileSystem()
+	seen := make(map[string]bool)
+	for _, partDir := range partDirs {
+		partID, parseErr := strconv.ParseUint(filepath.Base(partDir), 16, 64)
+		req.NoError(parseErr)
+		shardPath := filepath.Dir(partDir)
+		reader, openErr := dumptrace.OpenPart(partID, shardPath, fileSystem)
+		req.NoError(openErr)
+		it := reader.Iterator()
+		for it.Next() {
+			row := it.Row()
+			wr, iwr := replayer.buildWriteRequest(row)
+			traceID := wr.GetTags()[0].GetStr().GetValue()
+			e, ok := expect[traceID]
+			require.Truef(t, ok, "replay produced an unexpected trace_id %q", traceID)
+			assertTraceWriteRequestEqual(t, e.wr, wr)
+			require.NotNil(t, iwr.Request, "iwr must wrap a WriteRequest")
+			require.Equal(t, wr, iwr.Request, "iwr.Request must point at the same WriteRequest")
+			require.Equalf(t, e.wantShard, iwr.ShardId, "trace_id %q must route to shard %d under shardNum=2", traceID, e.wantShard)
+			require.Falsef(t, seen[traceID], "trace_id %q reconstructed twice", traceID)
+			seen[traceID] = true
+		}
+		require.NoError(t, it.Err())
+		it.Close()
+		reader.Close()
+	}
+	require.Len(t, seen, len(entries), "both spans (shard 0 and shard 1) must roundtrip exactly once")
+}
+
+// buildMeasureWR builds a measure WriteRequest whose entity (series), other
+// tags, fields, version and timestamp are all caller-controlled so two rows can
+// be made fully distinct.
+func buildMeasureWR(ts time.Time, series, strTag string, intTag, intField int64, floatField float64, version int64) *measurev1.WriteRequest {
+	return &measurev1.WriteRequest{
+		Metadata: &commonv1.Metadata{Group: roundtripMeasureGroup, Name: roundtripMeasureName},
+		DataPoint: &measurev1.DataPointValue{
+			Timestamp:   timestamppb.New(ts),
+			Version:     version,
+			TagFamilies: []*modelv1.TagFamilyForWrite{{Tags: []*modelv1.TagValue{stringTagValue(series), stringTagValue(strTag), intTagValue(intTag)}}},
+			Fields:      []*modelv1.FieldValue{intFieldValue(intField), floatFieldValue(floatField)},
+		},
+	}
+}
+
+func buildStreamWR(ts time.Time, series, strTag string, intTag int64, elementID string) *streamv1.WriteRequest {
+	return &streamv1.WriteRequest{
+		Metadata: &commonv1.Metadata{Group: roundtripStreamGroup, Name: roundtripStreamName},
+		Element: &streamv1.ElementValue{
+			ElementId:   elementID,
+			Timestamp:   timestamppb.New(ts),
+			TagFamilies: []*modelv1.TagFamilyForWrite{{Tags: []*modelv1.TagValue{stringTagValue(series), stringTagValue(strTag), intTagValue(intTag)}}},
+		},
+	}
+}
+
+func buildTraceWR(ts time.Time, traceID, spanID string, span []byte) *tracev1.WriteRequest {
+	return &tracev1.WriteRequest{
+		Metadata: &commonv1.Metadata{Group: roundtripTraceGroup, Name: roundtripTraceName},
+		Tags: []*modelv1.TagValue{
+			stringTagValue(traceID),
+			stringTagValue(spanID),
+			{Value: &modelv1.TagValue_Timestamp{Timestamp: timestamppb.New(ts)}},
+		},
+		Span:    span,
+		Version: 1,
+	}
+}
+
+// assertMeasureWriteRequestEqual asserts proto.Equal ignoring MessageId.
+func assertMeasureWriteRequestEqual(t *testing.T, want, got *measurev1.WriteRequest) {
+	t.Helper()
+	wantC := proto.Clone(want).(*measurev1.WriteRequest)
+	gotC := proto.Clone(got).(*measurev1.WriteRequest)
+	wantC.MessageId = 0
+	gotC.MessageId = 0
+	require.Truef(t, proto.Equal(wantC, gotC), "measure WriteRequest mismatch:\nwant: %v\ngot:  %v", wantC, gotC)
+}
+
+// assertStreamWriteRequestEqual asserts proto.Equal ignoring MessageId and
+// ElementId (the replayer base64-encodes the storage uint64; receiver uses
+// raw_element_id instead).
+func assertStreamWriteRequestEqual(t *testing.T, want, got *streamv1.WriteRequest) {
+	t.Helper()
+	wantC := proto.Clone(want).(*streamv1.WriteRequest)
+	gotC := proto.Clone(got).(*streamv1.WriteRequest)
+	wantC.MessageId = 0
+	gotC.MessageId = 0
+	if wantC.Element != nil {
+		wantC.Element.ElementId = ""
+	}
+	if gotC.Element != nil {
+		gotC.Element.ElementId = ""
+	}
+	require.Truef(t, proto.Equal(wantC, gotC), "stream WriteRequest mismatch:\nwant: %v\ngot:  %v", wantC, gotC)
+}
+
+// assertTraceWriteRequestEqual asserts proto.Equal ignoring Version.
+func assertTraceWriteRequestEqual(t *testing.T, want, got *tracev1.WriteRequest) {
+	t.Helper()
+	wantC := proto.Clone(want).(*tracev1.WriteRequest)
+	gotC := proto.Clone(got).(*tracev1.WriteRequest)
+	wantC.Version = 0
+	gotC.Version = 0
+	require.Truef(t, proto.Equal(wantC, gotC), "trace WriteRequest mismatch:\nwant: %v\ngot:  %v", wantC, gotC)
+}
+
+func registerRoundtripMeasureSchema(t *testing.T, metaSvc metadataservice.Service) {
+	t.Helper()
+	reg := metaSvc.SchemaRegistry()
+	ctx := context.TODO()
+	_, err := reg.CreateGroup(ctx, &commonv1.Group{
+		Metadata: &commonv1.Metadata{Name: roundtripMeasureGroup},
+		Catalog:  commonv1.Catalog_CATALOG_MEASURE,
+		ResourceOpts: &commonv1.ResourceOpts{
+			ShardNum:        2,
+			SegmentInterval: &commonv1.IntervalRule{Unit: commonv1.IntervalRule_UNIT_DAY, Num: 1},
+			Ttl:             &commonv1.IntervalRule{Unit: commonv1.IntervalRule_UNIT_DAY, Num: 7},
+		},
+	})
+	require.NoError(t, err)
+	_, err = reg.CreateMeasure(ctx, &databasev1.Measure{
+		Metadata: &commonv1.Metadata{Name: roundtripMeasureName, Group: roundtripMeasureGroup},
+		TagFamilies: []*databasev1.TagFamilySpec{{
+			Name: "default",
+			Tags: []*databasev1.TagSpec{
+				{Name: "series", Type: databasev1.TagType_TAG_TYPE_STRING},
+				{Name: "strTag", Type: databasev1.TagType_TAG_TYPE_STRING},
+				{Name: "intTag", Type: databasev1.TagType_TAG_TYPE_INT},
+			},
+		}},
+		Fields: []*databasev1.FieldSpec{
+			{
+				Name:              "intField",
+				FieldType:         databasev1.FieldType_FIELD_TYPE_INT,
+				EncodingMethod:    databasev1.EncodingMethod_ENCODING_METHOD_GORILLA,
+				CompressionMethod: databasev1.CompressionMethod_COMPRESSION_METHOD_ZSTD,
+			},
+			{
+				Name:              "floatField",
+				FieldType:         databasev1.FieldType_FIELD_TYPE_FLOAT,
+				EncodingMethod:    databasev1.EncodingMethod_ENCODING_METHOD_GORILLA,
+				CompressionMethod: databasev1.CompressionMethod_COMPRESSION_METHOD_ZSTD,
+			},
+		},
+		Entity: &databasev1.Entity{TagNames: []string{"series"}},
+	})
+	require.NoError(t, err)
+}
+
+func registerRoundtripStreamSchema(t *testing.T, metaSvc metadataservice.Service) {
+	t.Helper()
+	reg := metaSvc.SchemaRegistry()
+	ctx := context.TODO()
+	_, err := reg.CreateGroup(ctx, &commonv1.Group{
+		Metadata: &commonv1.Metadata{Name: roundtripStreamGroup},
+		Catalog:  commonv1.Catalog_CATALOG_STREAM,
+		ResourceOpts: &commonv1.ResourceOpts{
+			ShardNum:        2,
+			SegmentInterval: &commonv1.IntervalRule{Unit: commonv1.IntervalRule_UNIT_DAY, Num: 1},
+			Ttl:             &commonv1.IntervalRule{Unit: commonv1.IntervalRule_UNIT_DAY, Num: 7},
+		},
+	})
+	require.NoError(t, err)
+	_, err = reg.CreateStream(ctx, &databasev1.Stream{
+		Metadata: &commonv1.Metadata{Name: roundtripStreamName, Group: roundtripStreamGroup},
+		TagFamilies: []*databasev1.TagFamilySpec{{
+			Name: "default",
+			Tags: []*databasev1.TagSpec{
+				{Name: "series", Type: databasev1.TagType_TAG_TYPE_STRING},
+				{Name: "strTag", Type: databasev1.TagType_TAG_TYPE_STRING},
+				{Name: "intTag", Type: databasev1.TagType_TAG_TYPE_INT},
+			},
+		}},
+		Entity: &databasev1.Entity{TagNames: []string{"series"}},
+	})
+	require.NoError(t, err)
+}
+
+func registerRoundtripTraceSchema(t *testing.T, metaSvc metadataservice.Service) {
+	t.Helper()
+	reg := metaSvc.SchemaRegistry()
+	ctx := context.TODO()
+	_, err := reg.CreateGroup(ctx, &commonv1.Group{
+		Metadata: &commonv1.Metadata{Name: roundtripTraceGroup},
+		Catalog:  commonv1.Catalog_CATALOG_TRACE,
+		ResourceOpts: &commonv1.ResourceOpts{
+			ShardNum:        2,
+			SegmentInterval: &commonv1.IntervalRule{Unit: commonv1.IntervalRule_UNIT_DAY, Num: 1},
+			Ttl:             &commonv1.IntervalRule{Unit: commonv1.IntervalRule_UNIT_DAY, Num: 7},
+		},
+	})
+	require.NoError(t, err)
+	_, err = reg.CreateTrace(ctx, &databasev1.Trace{
+		Metadata: &commonv1.Metadata{Name: roundtripTraceName, Group: roundtripTraceGroup},
+		Tags: []*databasev1.TraceTagSpec{
+			{Name: "trace_id", Type: databasev1.TagType_TAG_TYPE_STRING},
+			{Name: "span_id", Type: databasev1.TagType_TAG_TYPE_STRING},
+			{Name: "timestamp", Type: databasev1.TagType_TAG_TYPE_TIMESTAMP},
+		},
+		TraceIdTagName:   "trace_id",
+		SpanIdTagName:    "span_id",
+		TimestampTagName: "timestamp",
+	})
+	require.NoError(t, err)
+}
+
+func findRoundtripPartDirs(root string) []string {
+	var dirs []string
+	_ = filepath.WalkDir(root, func(path string, d gofs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		if d.Name() == "metadata.json" {
+			if _, parseErr := strconv.ParseUint(filepath.Base(filepath.Dir(path)), 16, 64); parseErr == nil {
+				dirs = append(dirs, filepath.Dir(path))
+			}
+		}
+		return nil
+	})
+	return dirs
+}

--- a/banyand/backup/lifecycle/row_replay_trace.go
+++ b/banyand/backup/lifecycle/row_replay_trace.go
@@ -1,0 +1,233 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package lifecycle
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/apache/skywalking-banyandb/api/common"
+	"github.com/apache/skywalking-banyandb/api/data"
+	commonv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/common/v1"
+	databasev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
+	tracev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/trace/v1"
+	dumptrace "github.com/apache/skywalking-banyandb/banyand/internal/dump/trace"
+	"github.com/apache/skywalking-banyandb/banyand/metadata"
+	"github.com/apache/skywalking-banyandb/banyand/metadata/schema"
+	"github.com/apache/skywalking-banyandb/banyand/queue"
+	"github.com/apache/skywalking-banyandb/pkg/bus"
+	"github.com/apache/skywalking-banyandb/pkg/fs"
+	"github.com/apache/skywalking-banyandb/pkg/logger"
+	"github.com/apache/skywalking-banyandb/pkg/node"
+	"github.com/apache/skywalking-banyandb/pkg/partition"
+)
+
+const (
+	traceReplayBatchSize    = 2000
+	traceReplayBatchTimeout = 30 * time.Second
+	traceReplayVersion      = 1 // trace Row has no version; receiver requires version > 0.
+)
+
+// traceRowReplayer replays a group's trace parts. Trace schemas are
+// one-per-group; constructing the replayer for a group with multiple traces
+// returns an error.
+type traceRowReplayer struct {
+	selector       node.Selector
+	client         queue.Client
+	publisher      queue.BatchPublisher
+	fs             fs.FileSystem
+	logger         *logger.Logger
+	schema         *databasev1.Trace
+	traceName      string
+	counter        *uint64
+	group          string
+	batch          []bus.Message
+	batchMu        sync.Mutex
+	targetShardNum uint32
+}
+
+func newTraceRowReplayer(
+	ctx context.Context,
+	group string, targetShardNum uint32,
+	selector node.Selector, client queue.Client,
+	md metadata.Repo, fileSystem fs.FileSystem,
+	l *logger.Logger, counter *uint64,
+) (*traceRowReplayer, error) {
+	traces, err := md.TraceRegistry().ListTrace(ctx, schema.ListOpt{Group: group})
+	if err != nil {
+		return nil, fmt.Errorf("list traces of group %s: %w", group, err)
+	}
+	if len(traces) == 0 {
+		return nil, fmt.Errorf("no traces in group %s", group)
+	}
+	if len(traces) > 1 {
+		return nil, fmt.Errorf("group %s has %d traces; row-replay assumes a single trace per group", group, len(traces))
+	}
+	t := traces[0]
+	return &traceRowReplayer{
+		group:          group,
+		targetShardNum: targetShardNum,
+		selector:       selector,
+		client:         client,
+		publisher:      client.NewBatchPublisher(traceReplayBatchTimeout),
+		fs:             fileSystem,
+		logger:         l,
+		schema:         t,
+		traceName:      t.Metadata.Name,
+		counter:        counter,
+		batch:          make([]bus.Message, 0, traceReplayBatchSize),
+	}, nil
+}
+
+// Close flushes pending messages and closes the publisher.
+func (r *traceRowReplayer) Close() (map[string]*common.Error, error) {
+	flushCtx, cancel := context.WithTimeout(context.Background(), traceReplayBatchTimeout)
+	defer cancel()
+	flushErr := r.flushBatch(flushCtx)
+	cee, closeErr := r.publisher.Close()
+	if flushErr != nil {
+		return cee, flushErr
+	}
+	return cee, closeErr
+}
+
+// flushAndConfirm flushes the buffered batch, closes the publisher to obtain the
+// per-node delivery result for everything sent since the last call, then opens a
+// fresh publisher for subsequent shards. The batch publisher is client-streaming,
+// so per-node errors are only observable once its stream closes; this lets a
+// row-replayed shard be confirmed durable before it is marked completed.
+func (r *traceRowReplayer) flushAndConfirm(ctx context.Context) (map[string]*common.Error, error) {
+	flushErr := r.flushBatch(ctx)
+	cee, closeErr := r.publisher.Close()
+	r.publisher = r.client.NewBatchPublisher(traceReplayBatchTimeout)
+	if flushErr != nil {
+		return cee, flushErr
+	}
+	return cee, closeErr
+}
+
+func (r *traceRowReplayer) replayPart(ctx context.Context, partPath string) (int, error) {
+	partID, parseErr := strconv.ParseUint(filepath.Base(partPath), 16, 64)
+	if parseErr != nil {
+		return 0, fmt.Errorf("invalid part path %s: %w", partPath, parseErr)
+	}
+	shardPath := filepath.Dir(partPath)
+
+	reader, err := dumptrace.OpenPart(partID, shardPath, r.fs)
+	if err != nil {
+		return 0, fmt.Errorf("open trace part %s: %w", partPath, err)
+	}
+	defer reader.Close()
+
+	it := reader.Iterator()
+	defer it.Close()
+
+	rowCount := 0
+	for it.Next() {
+		row := it.Row()
+		if rowErr := r.publishRow(ctx, row); rowErr != nil {
+			pos := it.Position()
+			r.logger.Warn().Err(rowErr).
+				Str("group", r.group).
+				Str("trace", r.traceName).
+				Str("part", partPath).
+				Int("block_idx", pos.BlockIdx).
+				Int("row_idx", pos.RowIdx).
+				Int("rows_published", rowCount).
+				Msg("trace row-replay aborted mid-part on publish error; will retry on resume")
+			return rowCount, rowErr
+		}
+		rowCount++
+	}
+	if iterErr := it.Err(); iterErr != nil {
+		pos := it.Position()
+		r.logger.Warn().Err(iterErr).
+			Str("group", r.group).
+			Str("trace", r.traceName).
+			Str("part", partPath).
+			Int("block_idx", pos.BlockIdx).
+			Int("row_idx", pos.RowIdx).
+			Int("rows_published", rowCount).
+			Msg("trace row-replay aborted mid-part; will retry on resume")
+		return rowCount, iterErr
+	}
+	if r.counter != nil {
+		atomic.AddUint64(r.counter, 1)
+	}
+	return rowCount, nil
+}
+
+// buildWriteRequest reconstructs the WriteRequest + InternalWriteRequest pair
+// from a raw trace Row. Separated from publishRow for testability.
+func (r *traceRowReplayer) buildWriteRequest(row dumptrace.Row) (*tracev1.WriteRequest, *tracev1.InternalWriteRequest) {
+	tags := buildTraceTags(r.schema.Tags, row, r.schema.TraceIdTagName, r.schema.SpanIdTagName)
+	// Copy span bytes; the iterator buffer is reused across advances.
+	spanCopy := append([]byte(nil), row.Span...)
+	wr := &tracev1.WriteRequest{
+		Metadata: &commonv1.Metadata{Group: r.group, Name: r.traceName},
+		Tags:     tags,
+		Span:     spanCopy,
+		Version:  traceReplayVersion,
+	}
+	shardID := partition.TraceShardID(row.TraceID, r.targetShardNum)
+	iwr := &tracev1.InternalWriteRequest{
+		ShardId: uint32(shardID),
+		Request: wr,
+	}
+	return wr, iwr
+}
+
+func (r *traceRowReplayer) publishRow(ctx context.Context, row dumptrace.Row) error {
+	_, iwr := r.buildWriteRequest(row)
+	nodeID, err := r.selector.Pick(r.group, r.traceName, iwr.ShardId, 0)
+	if err != nil {
+		return fmt.Errorf("pick target node for trace %s: %w", r.traceName, err)
+	}
+	msg := bus.NewBatchMessageWithNode(bus.MessageID(time.Now().UnixNano()), nodeID, iwr)
+	return r.enqueue(ctx, msg)
+}
+
+// enqueue appends a message to the batch and flushes when full.
+func (r *traceRowReplayer) enqueue(ctx context.Context, msg bus.Message) error {
+	r.batchMu.Lock()
+	r.batch = append(r.batch, msg)
+	shouldFlush := len(r.batch) >= traceReplayBatchSize
+	r.batchMu.Unlock()
+	if shouldFlush {
+		return r.flushBatch(ctx)
+	}
+	return nil
+}
+
+func (r *traceRowReplayer) flushBatch(ctx context.Context) error {
+	r.batchMu.Lock()
+	if len(r.batch) == 0 {
+		r.batchMu.Unlock()
+		return nil
+	}
+	pending := r.batch
+	r.batch = make([]bus.Message, 0, traceReplayBatchSize)
+	r.batchMu.Unlock()
+	_, err := r.publisher.Publish(ctx, data.TopicTraceWrite, pending...)
+	return err
+}

--- a/banyand/backup/lifecycle/segment_boundary_utils.go
+++ b/banyand/backup/lifecycle/segment_boundary_utils.go
@@ -24,17 +24,16 @@ import (
 	"github.com/apache/skywalking-banyandb/pkg/timestamp"
 )
 
-func calculateTargetSegments(partMinTS, partMaxTS int64, targetInterval storage.IntervalRule) []time.Time {
-	// Use time.Local so sender's bucket math stays on the same per-timezone
-	// grid as the receiver, which sees ctx.MinTimestamp as time.Local too.
-	minTime := time.Unix(0, partMinTS)
-	maxTime := time.Unix(0, partMaxTS)
-
+// calculateTargetSegments returns every target bucket overlapping the half-open
+// source range [start, end). Every migration caller passes the source segment's
+// own boundaries (segment/shard time range), where end is exclusive, so the
+// strict current.Before(end) guard naturally excludes the empty next bucket
+// when the source ends exactly on a target boundary. Using time.Local keeps the
+// sender's bucket math on the same per-timezone grid as the receiver, which
+// sees ctx.MinTimestamp as time.Local too.
+func calculateTargetSegments(start, end time.Time, targetInterval storage.IntervalRule) []time.Time {
 	var targetSegments []time.Time
-	// current starts at the bucket containing minTime, so segmentEnd is
-	// always > minTime and the loop guard already excludes anything past
-	// maxTime - every iteration produces a real overlap.
-	for current := targetInterval.Standard(minTime); !current.After(maxTime); current = targetInterval.NextTime(current) {
+	for current := targetInterval.Standard(start); current.Before(end); current = targetInterval.NextTime(current) {
 		targetSegments = append(targetSegments, current)
 	}
 	return targetSegments

--- a/banyand/backup/lifecycle/segment_boundary_utils.go
+++ b/banyand/backup/lifecycle/segment_boundary_utils.go
@@ -25,13 +25,13 @@ import (
 )
 
 // calculateTargetSegments returns every target bucket overlapping the half-open
-// source range [start, end). Every migration caller passes the source segment's
-// own boundaries (segment/shard time range), where end is exclusive, so the
-// strict current.Before(end) guard naturally excludes the empty next bucket
-// when the source ends exactly on a target boundary. Using time.Local keeps the
-// sender's bucket math on the same per-timezone grid as the receiver, which
-// sees ctx.MinTimestamp as time.Local too.
+// source range [start, end); the Before(end) guard drops the empty trailing
+// bucket when the source ends on a boundary. start/end are normalized to
+// time.Local so the bucket math stays on the receiver's grid regardless of the
+// caller's time zone.
 func calculateTargetSegments(start, end time.Time, targetInterval storage.IntervalRule) []time.Time {
+	start = start.In(time.Local)
+	end = end.In(time.Local)
 	var targetSegments []time.Time
 	for current := targetInterval.Standard(start); current.Before(end); current = targetInterval.NextTime(current) {
 		targetSegments = append(targetSegments, current)

--- a/banyand/backup/lifecycle/segment_boundary_utils_test.go
+++ b/banyand/backup/lifecycle/segment_boundary_utils_test.go
@@ -89,11 +89,25 @@ func TestCalculateTargetSegments(t *testing.T) {
 				time.Date(2024, 1, 1, 18, 0, 0, 0, time.Local), // Hour 18-24
 			},
 		},
+		{
+			// Exclusive-end regression: a source whose end lands exactly on the
+			// next target boundary must map to ONE bucket, not the empty next one.
+			name:      "source end exactly on a 1-day target boundary stays single",
+			partMinTS: time.Date(2026, 5, 18, 0, 0, 0, 0, time.Local).UnixNano(),
+			partMaxTS: time.Date(2026, 5, 19, 0, 0, 0, 0, time.Local).UnixNano(),
+			targetInterval: storage.IntervalRule{
+				Unit: storage.DAY,
+				Num:  1,
+			},
+			expected: []time.Time{
+				time.Date(2026, 5, 18, 0, 0, 0, 0, time.Local),
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := calculateTargetSegments(tt.partMinTS, tt.partMaxTS, tt.targetInterval)
+			result := calculateTargetSegments(time.Unix(0, tt.partMinTS), time.Unix(0, tt.partMaxTS), tt.targetInterval)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/banyand/backup/lifecycle/service.go
+++ b/banyand/backup/lifecycle/service.go
@@ -536,7 +536,7 @@ func (l *lifecycleService) buildMigrationReport(p *Progress) map[string]interfac
 	now := time.Now()
 	report := map[string]interface{}{
 		"generated_at":   now,
-		"report_version": "2.0",
+		"report_version": "2.1",
 		"summary":        l.buildSummaryStats(p),
 		"errors":         l.buildErrorSummary(p),
 		"snapshot_info": map[string]interface{}{
@@ -609,6 +609,7 @@ func (l *lifecycleService) buildSummaryStats(p *Progress) map[string]interface{}
 				"errors":          streamElementIndexErrors,
 				"completion_rate": l.calculatePercentage(completedStreamElementIndex, totalStreamElementIndex),
 			},
+			"sync_breakdown": l.buildSyncBreakdown(p.StreamChunkSyncParts, p.StreamRowReplayParts, p.StreamRowReplayRows, "chunk_sync_parts"),
 		},
 		"measure_migration": map[string]interface{}{
 			"parts": map[string]interface{}{
@@ -623,6 +624,7 @@ func (l *lifecycleService) buildSummaryStats(p *Progress) map[string]interface{}
 				"errors":          measureSeriesErrors,
 				"completion_rate": l.calculatePercentage(completedMeasureSeries, totalMeasureSeries),
 			},
+			"sync_breakdown": l.buildSyncBreakdown(p.MeasureChunkSyncParts, p.MeasureRowReplayParts, p.MeasureRowReplayRows, "chunk_sync_parts"),
 		},
 		// Field names parts/series mirror stream_migration / measure_migration.
 		// "parts" is fed by the per-shard TraceShard counters because trace
@@ -640,21 +642,75 @@ func (l *lifecycleService) buildSummaryStats(p *Progress) map[string]interface{}
 				"errors":          traceSeriesErrors,
 				"completion_rate": l.calculatePercentage(completedTraceSeries, totalTraceSeries),
 			},
+			// Trace chunk-sync is shard-batched, so the breakdown reports
+			// chunk_sync_shards (not parts) alongside the row-replay part/row counts.
+			"sync_breakdown": l.buildSyncBreakdown(p.TraceChunkSyncShards, p.TraceRowReplayParts, p.TraceRowReplayRows, "chunk_sync_shards"),
 		},
 	}
+}
+
+// buildSyncBreakdown reports, per group, how many parts/shards were migrated via
+// chunk-sync vs row-replay and how many rows the row-replay path republished.
+// The chunkKey is "chunk_sync_parts" for measure/stream and "chunk_sync_shards"
+// for trace. A "_total" entry aggregates across groups.
+func (l *lifecycleService) buildSyncBreakdown(chunk, replayParts, replayRows map[string]uint64, chunkKey string) map[string]interface{} {
+	groups := make(map[string]struct{})
+	for g := range chunk {
+		groups[g] = struct{}{}
+	}
+	for g := range replayParts {
+		groups[g] = struct{}{}
+	}
+	for g := range replayRows {
+		groups[g] = struct{}{}
+	}
+	out := make(map[string]interface{}, len(groups)+1)
+	var totalChunk, totalReplayParts, totalReplayRows uint64
+	for g := range groups {
+		c, rp, rr := chunk[g], replayParts[g], replayRows[g]
+		out[g] = map[string]interface{}{
+			chunkKey:           c,
+			"row_replay_parts": rp,
+			"row_replay_rows":  rr,
+		}
+		totalChunk += c
+		totalReplayParts += rp
+		totalReplayRows += rr
+	}
+	out["_total"] = map[string]interface{}{
+		chunkKey:           totalChunk,
+		"row_replay_parts": totalReplayParts,
+		"row_replay_rows":  totalReplayRows,
+	}
+	return out
 }
 
 // buildErrorSummary creates detailed error information.
 func (l *lifecycleService) buildErrorSummary(p *Progress) map[string]interface{} {
 	return map[string]interface{}{
-		"stream_parts":         l.buildErrorDetails(p.StreamPartErrors),
-		"stream_series":        l.buildErrorDetails(p.StreamSeriesErrors),
-		"stream_element_index": l.buildErrorDetails(p.StreamElementIndexErrors),
-		"measure_parts":        l.buildErrorDetails(p.MeasurePartErrors),
-		"measure_series":       l.buildErrorDetails(p.MeasureSeriesErrors),
-		"trace_parts":          l.buildErrorDetails(p.TraceShardErrors),
-		"trace_series":         l.buildErrorDetails(p.TraceSeriesErrors),
+		"stream_parts":           l.buildErrorDetails(p.StreamPartErrors),
+		"stream_series":          l.buildErrorDetails(p.StreamSeriesErrors),
+		"stream_element_index":   l.buildErrorDetails(p.StreamElementIndexErrors),
+		"measure_parts":          l.buildErrorDetails(p.MeasurePartErrors),
+		"measure_series":         l.buildErrorDetails(p.MeasureSeriesErrors),
+		"trace_parts":            l.buildErrorDetails(p.TraceShardErrors),
+		"trace_series":           l.buildErrorDetails(p.TraceSeriesErrors),
+		"row_replay_node_errors": l.buildNodeErrorDetails(p.RowReplayNodeErrors),
 	}
+}
+
+// buildNodeErrorDetails copies the group→node→message error map for the report,
+// returning an empty map (never nil) so the JSON shape is stable.
+func (l *lifecycleService) buildNodeErrorDetails(nodeErrors map[string]map[string]string) map[string]interface{} {
+	result := make(map[string]interface{}, len(nodeErrors))
+	for group, nodes := range nodeErrors {
+		groupErrors := make(map[string]interface{}, len(nodes))
+		for nodeID, msg := range nodes {
+			groupErrors[nodeID] = msg
+		}
+		result[group] = groupErrors
+	}
+	return result
 }
 
 // Helper functions.
@@ -905,7 +961,8 @@ func (l *lifecycleService) processStreamGroupFileBased(_ context.Context, g *Gro
 	}
 
 	// Use the file-based migration with existing visitor pattern
-	segmentSuffixes, err := migrateStreamWithFileBasedAndProgress(rootDir, *tr, g, l.l, progress, int(l.chunkSize))
+	//nolint:contextcheck // migration drives its own context lifecycle for batch publish.
+	segmentSuffixes, err := migrateStreamWithFileBasedAndProgress(rootDir, *tr, g, l.l, progress, int(l.chunkSize), l.metadata)
 	if err != nil {
 		return nil, fmt.Errorf("file-based stream migration failed: %w", err)
 	}
@@ -1028,7 +1085,8 @@ func (l *lifecycleService) processMeasureGroupFileBased(_ context.Context, g *Gr
 	}
 
 	// Use the file-based migration with existing visitor pattern
-	segmentSuffixes, err := migrateMeasureWithFileBasedAndProgress(rootDir, *tr, g, l.l, progress, int(l.chunkSize))
+	//nolint:contextcheck // migration drives its own context lifecycle for batch publish.
+	segmentSuffixes, err := migrateMeasureWithFileBasedAndProgress(rootDir, *tr, g, l.l, progress, int(l.chunkSize), l.metadata)
 	if err != nil {
 		return nil, fmt.Errorf("file-based measure migration failed: %w", err)
 	}
@@ -1133,7 +1191,8 @@ func (l *lifecycleService) processTraceGroupFileBased(_ context.Context, g *Grou
 	}
 
 	// Use the file-based migration with existing visitor pattern
-	segmentSuffixes, err := migrateTraceWithFileBasedAndProgress(rootDir, *tr, g, l.l, progress, int(l.chunkSize))
+	//nolint:contextcheck // migration drives its own context lifecycle for batch publish.
+	segmentSuffixes, err := migrateTraceWithFileBasedAndProgress(rootDir, *tr, g, l.l, progress, int(l.chunkSize), l.metadata)
 	if err != nil {
 		return nil, fmt.Errorf("file-based trace migration failed: %w", err)
 	}

--- a/banyand/backup/lifecycle/steps.go
+++ b/banyand/backup/lifecycle/steps.go
@@ -191,10 +191,15 @@ func parseGroup(
 		return nil, fmt.Errorf("failed to initialize node selector for group %s", g.Metadata.Name)
 	}
 	client := pub.NewWithoutMetadata() //nolint:contextcheck // health check goroutine uses context.Background()
-	if g.Catalog == commonv1.Catalog_CATALOG_STREAM {
+	switch g.Catalog {
+	case commonv1.Catalog_CATALOG_STREAM:
 		_ = grpc.NewClusterNodeRegistry(data.TopicStreamWrite, client, nodeSel)
-	} else {
+	case commonv1.Catalog_CATALOG_TRACE:
+		_ = grpc.NewClusterNodeRegistry(data.TopicTraceWrite, client, nodeSel)
+	case commonv1.Catalog_CATALOG_MEASURE:
 		_ = grpc.NewClusterNodeRegistry(data.TopicMeasureWrite, client, nodeSel)
+	default:
+		return nil, fmt.Errorf("unsupported catalog %s for lifecycle migration of group %s", g.Catalog, g.Metadata.Name)
 	}
 
 	var existed bool

--- a/banyand/backup/lifecycle/stream_migration_visitor.go
+++ b/banyand/backup/lifecycle/stream_migration_visitor.go
@@ -23,12 +23,14 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/apache/skywalking-banyandb/api/common"
 	"github.com/apache/skywalking-banyandb/api/data"
 	commonv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/common/v1"
 	"github.com/apache/skywalking-banyandb/banyand/internal/storage"
+	"github.com/apache/skywalking-banyandb/banyand/metadata"
 	"github.com/apache/skywalking-banyandb/banyand/queue"
 	"github.com/apache/skywalking-banyandb/banyand/stream"
 	"github.com/apache/skywalking-banyandb/pkg/fs"
@@ -39,22 +41,26 @@ import (
 
 // streamMigrationVisitor implements the stream.Visitor interface for file-based migration.
 type streamMigrationVisitor struct {
-	selector            node.Selector                      // From parseGroup - node selector
-	client              queue.Client                       // From parseGroup - queue client
-	chunkedClients      map[string]queue.ChunkedSyncClient // Per-node chunked sync clients cache
-	logger              *logger.Logger
-	progress            *Progress // Progress tracker for migration states
-	lfs                 fs.FileSystem
-	group               string
-	targetShardNum      uint32               // From parseGroup - target shard count
-	replicas            uint32               // From parseGroup - replica count
-	chunkSize           int                  // Chunk size for streaming data
-	targetStageInterval storage.IntervalRule // NEW: target stage's segment interval
+	client                  queue.Client
+	lfs                     fs.FileSystem
+	metadata                metadata.Repo
+	selector                node.Selector
+	chunkedClients          map[string]queue.ChunkedSyncClient
+	logger                  *logger.Logger
+	progress                *Progress
+	replayer                *streamRowReplayer
+	group                   string
+	targetStageInterval     storage.IntervalRule
+	chunkSize               int
+	partsCopiedSingleTarget uint64
+	partsReplayedRowLevel   uint64
+	targetShardNum          uint32
+	replicas                uint32
 }
 
 // newStreamMigrationVisitor creates a new file-based migration visitor.
 func newStreamMigrationVisitor(group *commonv1.Group, shardNum, replicas uint32, selector node.Selector, client queue.Client,
-	l *logger.Logger, progress *Progress, chunkSize int, targetStageInterval storage.IntervalRule,
+	l *logger.Logger, progress *Progress, chunkSize int, targetStageInterval storage.IntervalRule, md metadata.Repo,
 ) *streamMigrationVisitor {
 	return &streamMigrationVisitor{
 		group:               group.Metadata.Name,
@@ -67,8 +73,25 @@ func newStreamMigrationVisitor(group *commonv1.Group, shardNum, replicas uint32,
 		progress:            progress,
 		chunkSize:           chunkSize,
 		targetStageInterval: targetStageInterval,
+		metadata:            md,
 		lfs:                 fs.NewLocalFileSystem(),
 	}
+}
+
+// CounterSnapshot returns the current (chunk-sync, row-replay) part counts.
+func (mv *streamMigrationVisitor) CounterSnapshot() (chunkSync, rowReplay uint64) {
+	return atomic.LoadUint64(&mv.partsCopiedSingleTarget), atomic.LoadUint64(&mv.partsReplayedRowLevel)
+}
+
+// ensureReplayer lazily constructs the row replayer on first use. Unlike
+// measure / trace, stream construction is infallible (no eager schema or
+// index-rule enumeration is needed) so the signature omits ctx and error.
+func (mv *streamMigrationVisitor) ensureReplayer() *streamRowReplayer {
+	if mv.replayer == nil {
+		mv.replayer = newStreamRowReplayer(mv.group, mv.targetShardNum, mv.selector, mv.client, mv.metadata,
+			mv.lfs, mv.logger, &mv.partsReplayedRowLevel)
+	}
+	return mv.replayer
 }
 
 // VisitSeries implements stream.Visitor.
@@ -102,10 +125,11 @@ func (mv *streamMigrationVisitor) VisitSeries(segmentTR *timestamp.TimeRange, se
 		Str("path", seriesIndexPath).
 		Msg("found segment files for migration")
 
-	// Calculate ALL target segments this series index should go to
+	// Calculate ALL target segments this series index should go to from the
+	// source segment's own [start, end) boundaries.
 	targetSegments := calculateTargetSegments(
-		segmentTR.Start.UnixNano(),
-		segmentTR.End.UnixNano(),
+		segmentTR.Start,
+		segmentTR.End,
 		mv.targetStageInterval,
 	)
 
@@ -114,7 +138,27 @@ func (mv *streamMigrationVisitor) VisitSeries(segmentTR *timestamp.TimeRange, se
 		Int64("series_min_ts", segmentTR.Start.UnixNano()).
 		Int64("series_max_ts", segmentTR.End.UnixNano()).
 		Str("group", mv.group).
-		Msg("migrating series index to multiple target segments")
+		Msg("migrating stream series index")
+
+	// Multi-target case: rely on row-replay's write path to rebuild the series
+	// index at the receiver; skip the file-based sync to avoid landing every
+	// .seg copy in the same target segment.
+	if len(targetSegments) > 1 {
+		mv.logger.Info().
+			Str("path", seriesIndexPath).
+			Int("target_segments_count", len(targetSegments)).
+			Str("group", mv.group).
+			Msg("source stream series index spans multiple target segments; skipping file-based sync (rebuilt by writeCallback)")
+		for _, segmentFileName := range segmentFiles {
+			fileSegmentIDStr := strings.TrimSuffix(segmentFileName, ".seg")
+			segmentID, parseErr := strconv.ParseUint(fileSegmentIDStr, 16, 64)
+			if parseErr != nil {
+				continue
+			}
+			mv.progress.MarkSourceStreamSeriesCompleted(mv.group, seriesIndexPath, common.ShardID(segmentID))
+		}
+		return nil
+	}
 
 	// Send series index to EACH target segment that overlaps with its time range
 	for i, targetSegmentTime := range targetSegments {
@@ -170,13 +214,7 @@ func (mv *streamMigrationVisitor) VisitSeries(segmentTR *timestamp.TimeRange, se
 					Msg("failed to open segment file")
 				return fmt.Errorf("failed to open segment file %s: %w", segmentFilePath, err)
 			}
-
-			// Close the file reader
-			defer func() {
-				if i == len(targetSegments)-1 { // Only close on last iteration
-					segmentFile.Close()
-				}
-			}()
+			defer segmentFile.Close()
 
 			files = append(files, fileInfo{
 				name: segmentFileName,
@@ -230,7 +268,7 @@ func (mv *streamMigrationVisitor) VisitSeries(segmentTR *timestamp.TimeRange, se
 }
 
 // VisitPart implements stream.Visitor - core migration logic.
-func (mv *streamMigrationVisitor) VisitPart(_ *timestamp.TimeRange, sourceShardID common.ShardID, partPath string) error {
+func (mv *streamMigrationVisitor) VisitPart(segmentTR *timestamp.TimeRange, sourceShardID common.ShardID, partPath string) error {
 	partData, err := stream.ParsePartMetadata(mv.lfs, partPath)
 	if err != nil {
 		return fmt.Errorf("failed to parse part metadata: %w", err)
@@ -239,10 +277,12 @@ func (mv *streamMigrationVisitor) VisitPart(_ *timestamp.TimeRange, sourceShardI
 	if err != nil {
 		return fmt.Errorf("failed to parse part ID from path: %w", err)
 	}
-	// Calculate ALL target segments this part should go to
+	// Decide the routing from the source segment's own [start, end) boundaries,
+	// matching VisitSeries so the chunk-sync/row-replay decision stays
+	// consistent with whether the series index is file-synced.
 	targetSegments := calculateTargetSegments(
-		partData.MinTimestamp,
-		partData.MaxTimestamp,
+		segmentTR.Start,
+		segmentTR.End,
 		mv.targetStageInterval,
 	)
 
@@ -253,15 +293,26 @@ func (mv *streamMigrationVisitor) VisitPart(_ *timestamp.TimeRange, sourceShardI
 		Int64("part_min_ts", partData.MinTimestamp).
 		Int64("part_max_ts", partData.MaxTimestamp).
 		Str("group", mv.group).
-		Msg("migrating part to multiple target segments")
+		Msg("migrating stream part")
+
+	if len(targetSegments) > 1 {
+		return mv.visitPartRowReplay(context.Background(), segmentTR, sourceShardID, partID, partPath, targetSegments)
+	}
+	atomic.AddUint64(&mv.partsCopiedSingleTarget, 1)
+	mv.progress.AddStreamChunkSyncPart(mv.group)
+
+	// Part completion is keyed by the SOURCE segment (segmentTR), not the target:
+	// part IDs reset per source segment, so two source segments can each carry
+	// part_id=1 on the same shard; a target-keyed check would skip the second
+	// and drop its data. Mirrors trace's source-keyed VisitShard.
+	sourceSegmentIDStr := segmentTR.String()
 
 	// Send part to EACH target segment that overlaps with its time range
 	for i, targetSegmentTime := range targetSegments {
 		targetShardID := mv.calculateTargetShardID(uint32(sourceShardID))
 
-		// Check if this part has already been completed for this segment
-		segmentIDStr := getSegmentTimeRange(targetSegmentTime, mv.targetStageInterval).String()
-		if mv.progress.IsStreamPartCompleted(mv.group, segmentIDStr, sourceShardID, partID) {
+		// Check if this part has already been completed (keyed by source segment).
+		if mv.progress.IsStreamPartCompleted(mv.group, sourceSegmentIDStr, sourceShardID, partID) {
 			mv.logger.Debug().
 				Uint64("part_id", partID).
 				Uint32("source_shard", uint32(sourceShardID)).
@@ -273,11 +324,7 @@ func (mv *streamMigrationVisitor) VisitPart(_ *timestamp.TimeRange, sourceShardI
 
 		// Create file readers for this part
 		files, release := stream.CreatePartFileReaderFromPath(partPath, mv.lfs)
-		defer func() {
-			if i == len(targetSegments)-1 { // Only release on last iteration
-				release()
-			}
-		}()
+		defer release()
 
 		// Clone part data for this target segment
 		targetPartData := partData
@@ -289,12 +336,12 @@ func (mv *streamMigrationVisitor) VisitPart(_ *timestamp.TimeRange, sourceShardI
 		// Stream part to target segment
 		if err := mv.streamPartToTargetShard(targetPartData); err != nil {
 			errorMsg := fmt.Sprintf("failed to stream part to target segment %s: %v", targetSegmentTime.Format(time.RFC3339), err)
-			mv.progress.MarkStreamPartError(mv.group, segmentIDStr, sourceShardID, partID, errorMsg)
+			mv.progress.MarkStreamPartError(mv.group, sourceSegmentIDStr, sourceShardID, partID, errorMsg)
 			return fmt.Errorf("failed to stream part to target segment: %w", err)
 		}
 
-		// Mark part as completed for this specific target segment
-		mv.progress.MarkStreamPartCompleted(mv.group, segmentIDStr, sourceShardID, partID)
+		// Mark part as completed (source-segment keyed).
+		mv.progress.MarkStreamPartCompleted(mv.group, sourceSegmentIDStr, sourceShardID, partID)
 
 		mv.logger.Info().
 			Uint64("part_id", partID).
@@ -304,6 +351,69 @@ func (mv *streamMigrationVisitor) VisitPart(_ *timestamp.TimeRange, sourceShardI
 	}
 
 	mv.progress.MarkSourceStreamPartCompleted(mv.group, partPath, sourceShardID, partID)
+	return nil
+}
+
+// visitPartRowReplay republishes each row of a source part that spans multiple
+// target segments. The receiver's writeCallback handles per-row segment
+// routing, so a single replayPart pass covers all targets.
+func (mv *streamMigrationVisitor) visitPartRowReplay(ctx context.Context, segmentTR *timestamp.TimeRange, sourceShardID common.ShardID, partID uint64,
+	partPath string, targetSegments []time.Time,
+) error {
+	// Resume guard: if a prior run already row-replayed this part, skip the
+	// re-replay (it would republish every row again, wasting work). Keyed by the
+	// SOURCE segment (segmentTR), not the target segments: part IDs reset per
+	// source segment, so a target-keyed check could collide with a different
+	// source segment's part of the same ID. Mirrors trace's VisitShard guard.
+	sourceSegmentIDStr := segmentTR.String()
+	if mv.progress.IsStreamPartCompleted(mv.group, sourceSegmentIDStr, sourceShardID, partID) {
+		mv.progress.MarkSourceStreamPartCompleted(mv.group, partPath, sourceShardID, partID)
+		mv.logger.Debug().
+			Uint64("part_id", partID).
+			Uint32("source_shard", uint32(sourceShardID)).
+			Str("group", mv.group).
+			Msg("stream part already row-replayed; skipping on resume")
+		return nil
+	}
+	replayer := mv.ensureReplayer()
+	mv.logger.Info().
+		Uint64("part_id", partID).
+		Uint32("source_shard", uint32(sourceShardID)).
+		Int("target_segments_count", len(targetSegments)).
+		Str("group", mv.group).
+		Msg("stream part spans multiple target segments; switching to row-replay")
+	rowCount, err := replayer.replayPart(ctx, partPath)
+	if err != nil {
+		// Row-replay is all-or-nothing per part; mark the source part errored so
+		// resume retries the whole part (same source key the guard checks above).
+		mv.progress.MarkStreamPartError(mv.group, sourceSegmentIDStr, sourceShardID, partID, err.Error())
+		return fmt.Errorf("row-replay stream part %s: %w", partPath, err)
+	}
+	// Confirm this part's rows reached every node before marking it completed.
+	// replayPart only enqueues; the batch publisher is client-streaming so
+	// per-node errors surface only when its stream closes, so flushAndConfirm
+	// closes the publisher to collect that result (then opens a fresh one for the
+	// next part). Marking before this confirmation could report success for rows
+	// a flush failure never delivered, and the resume guard would then skip the
+	// part, losing data.
+	cee, flushErr := replayer.flushAndConfirm(ctx)
+	if flushErr != nil || len(cee) > 0 {
+		mv.progress.RecordRowReplayNodeErrors(mv.group, cee)
+		confirmErr := flushErr
+		if confirmErr == nil {
+			confirmErr = fmt.Errorf("%d node error(s)", len(cee))
+		}
+		mv.progress.MarkStreamPartError(mv.group, sourceSegmentIDStr, sourceShardID, partID, confirmErr.Error())
+		return fmt.Errorf("confirm row-replay stream part %s: %w", partPath, confirmErr)
+	}
+	mv.progress.MarkStreamPartCompleted(mv.group, sourceSegmentIDStr, sourceShardID, partID)
+	mv.progress.MarkSourceStreamPartCompleted(mv.group, partPath, sourceShardID, partID)
+	mv.progress.AddStreamRowReplay(mv.group, rowCount)
+	mv.logger.Info().
+		Uint64("part_id", partID).
+		Int("rows_published", rowCount).
+		Str("group", mv.group).
+		Msg("stream row-replay completed")
 	return nil
 }
 
@@ -328,6 +438,20 @@ func (mv *streamMigrationVisitor) VisitElementIndex(segmentTR *timestamp.TimeRan
 		Int64("max_timestamp", segmentTR.End.UnixNano()).
 		Str("group", mv.group).
 		Msg("migrating element index")
+
+	// Multi-target case: the row-replay path republishes rows through the real
+	// write API and the receiver rebuilds the element index per row, so the
+	// file-based sync would just stamp every copy into a single target segment.
+	if targets := calculateTargetSegments(segmentTR.Start, segmentTR.End, mv.targetStageInterval); len(targets) > 1 {
+		mv.logger.Info().
+			Str("path", indexPath).
+			Int("target_segments_count", len(targets)).
+			Str("group", mv.group).
+			Msg("source element index spans multiple target segments; skipping file-based sync (rebuilt by writeCallback)")
+		mv.progress.MarkStreamElementIndexCompleted(mv.group, segmentIDStr, sourceShardID)
+		mv.progress.MarkSourceStreamElementIndexCompleted(mv.group, indexPath, sourceShardID)
+		return nil
+	}
 
 	// Find all .seg files in the element index directory
 	entries := mv.lfs.ReadDir(indexPath)
@@ -490,14 +614,30 @@ func (mv *streamMigrationVisitor) streamPartToNode(nodeID string, targetShardID 
 	return nil
 }
 
-// Close cleans up all chunked sync clients.
+// Close cleans up all chunked sync clients and the row-replayer.
 func (mv *streamMigrationVisitor) Close() error {
+	if mv.replayer != nil {
+		cee, replayCloseErr := mv.replayer.Close()
+		mv.progress.RecordRowReplayNodeErrors(mv.group, cee)
+		if replayCloseErr != nil {
+			mv.logger.Warn().Err(replayCloseErr).Interface("node_errors", cee).Msg("failed to close stream row replayer")
+		} else if len(cee) > 0 {
+			mv.logger.Warn().Interface("node_errors", cee).Msg("stream row replayer reported per-node errors")
+		}
+		mv.replayer = nil
+	}
 	for nodeID, client := range mv.chunkedClients {
 		if err := client.Close(); err != nil {
 			mv.logger.Warn().Err(err).Str("node", nodeID).Msg("failed to close chunked sync client")
 		}
 	}
 	mv.chunkedClients = make(map[string]queue.ChunkedSyncClient)
+	chunkSync, rowReplay := mv.CounterSnapshot()
+	mv.logger.Info().
+		Uint64("parts_chunk_sync", chunkSync).
+		Uint64("parts_row_replay", rowReplay).
+		Str("group", mv.group).
+		Msg("stream migration visitor closed")
 	return nil
 }
 

--- a/banyand/backup/lifecycle/trace_migration_visitor.go
+++ b/banyand/backup/lifecycle/trace_migration_visitor.go
@@ -24,12 +24,15 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync/atomic"
+	"time"
 
 	"github.com/apache/skywalking-banyandb/api/common"
 	"github.com/apache/skywalking-banyandb/api/data"
 	commonv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/common/v1"
 	"github.com/apache/skywalking-banyandb/banyand/internal/sidx"
 	"github.com/apache/skywalking-banyandb/banyand/internal/storage"
+	"github.com/apache/skywalking-banyandb/banyand/metadata"
 	"github.com/apache/skywalking-banyandb/banyand/queue"
 	"github.com/apache/skywalking-banyandb/banyand/trace"
 	"github.com/apache/skywalking-banyandb/pkg/fs"
@@ -40,22 +43,26 @@ import (
 
 // traceMigrationVisitor implements the trace.Visitor interface for file-based migration.
 type traceMigrationVisitor struct {
-	selector            node.Selector                      // From parseGroup - node selector
-	client              queue.Client                       // From parseGroup - queue client
-	chunkedClients      map[string]queue.ChunkedSyncClient // Per-node chunked sync clients cache
-	logger              *logger.Logger
-	progress            *Progress // Progress tracker for migration states
-	lfs                 fs.FileSystem
-	group               string
-	targetShardNum      uint32               // From parseGroup - target shard count
-	replicas            uint32               // From parseGroup - replica count
-	chunkSize           int                  // Chunk size for streaming data
-	targetStageInterval storage.IntervalRule // NEW: target stage's segment interval
+	client                  queue.Client
+	lfs                     fs.FileSystem
+	metadata                metadata.Repo
+	selector                node.Selector
+	chunkedClients          map[string]queue.ChunkedSyncClient
+	logger                  *logger.Logger
+	progress                *Progress
+	replayer                *traceRowReplayer
+	group                   string
+	targetStageInterval     storage.IntervalRule
+	chunkSize               int
+	partsCopiedSingleTarget uint64
+	partsReplayedRowLevel   uint64
+	targetShardNum          uint32
+	replicas                uint32
 }
 
 // newTraceMigrationVisitor creates a new file-based migration visitor.
 func newTraceMigrationVisitor(group *commonv1.Group, shardNum, replicas uint32, selector node.Selector, client queue.Client,
-	l *logger.Logger, progress *Progress, chunkSize int, targetStageInterval storage.IntervalRule,
+	l *logger.Logger, progress *Progress, chunkSize int, targetStageInterval storage.IntervalRule, md metadata.Repo,
 ) *traceMigrationVisitor {
 	return &traceMigrationVisitor{
 		group:               group.Metadata.Name,
@@ -68,8 +75,30 @@ func newTraceMigrationVisitor(group *commonv1.Group, shardNum, replicas uint32, 
 		progress:            progress,
 		chunkSize:           chunkSize,
 		targetStageInterval: targetStageInterval,
+		metadata:            md,
 		lfs:                 fs.NewLocalFileSystem(),
 	}
+}
+
+// CounterSnapshot returns the current (chunk-sync shards, row-replay parts)
+// counts. Trace chunk-sync ships at shard granularity; row-replay iterates
+// individual parts under the shard.
+func (mv *traceMigrationVisitor) CounterSnapshot() (chunkSync, rowReplay uint64) {
+	return atomic.LoadUint64(&mv.partsCopiedSingleTarget), atomic.LoadUint64(&mv.partsReplayedRowLevel)
+}
+
+// ensureReplayer lazily constructs the trace row replayer on first use.
+func (mv *traceMigrationVisitor) ensureReplayer(ctx context.Context) (*traceRowReplayer, error) {
+	if mv.replayer != nil {
+		return mv.replayer, nil
+	}
+	r, err := newTraceRowReplayer(ctx, mv.group, mv.targetShardNum, mv.selector, mv.client, mv.metadata,
+		mv.lfs, mv.logger, &mv.partsReplayedRowLevel)
+	if err != nil {
+		return nil, fmt.Errorf("create trace row replayer: %w", err)
+	}
+	mv.replayer = r
+	return r, nil
 }
 
 // VisitSeries implements trace.Visitor.
@@ -103,10 +132,11 @@ func (mv *traceMigrationVisitor) VisitSeries(segmentTR *timestamp.TimeRange, ser
 		Str("path", seriesIndexPath).
 		Msg("found trace segment files for migration")
 
-	// Calculate ALL target segments this series index should go to
+	// Calculate ALL target segments this series index should go to from the
+	// source segment's own [start, end) boundaries.
 	targetSegments := calculateTargetSegments(
-		segmentTR.Start.UnixNano(),
-		segmentTR.End.UnixNano(),
+		segmentTR.Start,
+		segmentTR.End,
 		mv.targetStageInterval,
 	)
 
@@ -115,7 +145,26 @@ func (mv *traceMigrationVisitor) VisitSeries(segmentTR *timestamp.TimeRange, ser
 		Int64("series_min_ts", segmentTR.Start.UnixNano()).
 		Int64("series_max_ts", segmentTR.End.UnixNano()).
 		Str("group", mv.group).
-		Msg("migrating trace series index to multiple target segments")
+		Msg("migrating trace series index")
+
+	// Multi-target case: rely on row-replay's write path to rebuild the trace
+	// series index at the receiver; skip the file-based sync.
+	if len(targetSegments) > 1 {
+		mv.logger.Info().
+			Str("path", seriesIndexPath).
+			Int("target_segments_count", len(targetSegments)).
+			Str("group", mv.group).
+			Msg("source trace series index spans multiple target segments; skipping file-based sync (rebuilt by writeCallback)")
+		for _, segmentFileName := range segmentFiles {
+			fileSegmentIDStr := strings.TrimSuffix(segmentFileName, ".seg")
+			segmentID, parseErr := strconv.ParseUint(fileSegmentIDStr, 16, 64)
+			if parseErr != nil {
+				continue
+			}
+			mv.progress.MarkSourceTraceSeriesCompleted(mv.group, seriesIndexPath, common.ShardID(segmentID))
+		}
+		return nil
+	}
 
 	// Send series index to EACH target segment that overlaps with its time range
 	for i, targetSegmentTime := range targetSegments {
@@ -171,13 +220,7 @@ func (mv *traceMigrationVisitor) VisitSeries(segmentTR *timestamp.TimeRange, ser
 					Msg("failed to open trace segment file")
 				return fmt.Errorf("failed to open trace segment file %s: %w", segmentFilePath, err)
 			}
-
-			// Close the file reader
-			defer func() {
-				if i == len(targetSegments)-1 { // Only close on last iteration
-					segmentFile.Close()
-				}
-			}()
+			defer segmentFile.Close()
 
 			files = append(files, fileInfo{
 				name: segmentFileName,
@@ -247,6 +290,18 @@ func (mv *traceMigrationVisitor) VisitShard(timestampTR *timestamp.TimeRange, so
 		mv.progress.MarkSourceTraceShardCompleted(mv.group, segmentIDStr, sourceShardID)
 		return nil
 	}
+
+	// Cross-segment guard: when the source shard's time range spans more than
+	// one target segment, the chunk-sync path would ship every core/sidx part
+	// to a single target segment via Standard(MinTimestamp). Switch to
+	// row-replay so the receiver routes each row to the right target segment.
+	// Decide from the source shard's own [start, end) boundaries.
+	targetSegments := calculateTargetSegments(timestampTR.Start, timestampTR.End, mv.targetStageInterval)
+	if len(targetSegments) > 1 {
+		return mv.visitShardRowReplay(context.Background(), sourceShardID, shardPath, segmentIDStr, targetSegments)
+	}
+	atomic.AddUint64(&mv.partsCopiedSingleTarget, 1)
+	mv.progress.AddTraceChunkSyncShard(mv.group)
 	allParts := make([]queue.StreamingPartData, 0)
 
 	sidxPartData, sidxReleases, err := mv.generateAllSidxPartData(timestampTR, sourceShardID, filepath.Join(shardPath, "sidx"))
@@ -260,7 +315,7 @@ func (mv *traceMigrationVisitor) VisitShard(timestampTR *timestamp.TimeRange, so
 	}()
 	allParts = append(allParts, sidxPartData...)
 
-	partDatas, partDataReleases, err := mv.generateAllPartData(sourceShardID, shardPath)
+	partDatas, partDataReleases, err := mv.generateAllPartData(timestampTR, sourceShardID, shardPath)
 	if err != nil {
 		return fmt.Errorf("failed to generate core par data: %s: %w", shardPath, err)
 	}
@@ -294,6 +349,76 @@ func (mv *traceMigrationVisitor) VisitShard(timestampTR *timestamp.TimeRange, so
 		Str("group", mv.group).
 		Msgf("trace shard migration completed for target segment")
 
+	return nil
+}
+
+// visitShardRowReplay walks every core part directly under the shard and
+// republishes each row through the real write API. Sidx parts and the source
+// series-index are intentionally skipped: the receiver's writeCallback
+// rebuilds those indices as part of the normal write flow.
+func (mv *traceMigrationVisitor) visitShardRowReplay(ctx context.Context, sourceShardID common.ShardID,
+	shardPath, segmentIDStr string, targetSegments []time.Time,
+) error {
+	replayer, err := mv.ensureReplayer(ctx)
+	if err != nil {
+		return err
+	}
+	mv.logger.Info().
+		Str("shard_path", shardPath).
+		Uint32("source_shard", uint32(sourceShardID)).
+		Int("target_segments_count", len(targetSegments)).
+		Str("group", mv.group).
+		Msg("trace shard spans multiple target segments; switching to row-replay")
+
+	entries := mv.lfs.ReadDir(shardPath)
+	totalRows := 0
+	partsReplayed := 0
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if len(name) != 16 {
+			continue
+		}
+		if _, parseErr := strconv.ParseUint(name, 16, 64); parseErr != nil {
+			continue
+		}
+		partPath := filepath.Join(shardPath, name)
+		rowCount, replayErr := replayer.replayPart(ctx, partPath)
+		if replayErr != nil {
+			mv.progress.MarkTraceShardError(mv.group, segmentIDStr, sourceShardID, replayErr.Error())
+			return fmt.Errorf("row-replay trace part %s: %w", partPath, replayErr)
+		}
+		totalRows += rowCount
+		partsReplayed++
+	}
+
+	// Confirm this shard's rows reached every node before marking it completed.
+	// replayPart only enqueues; the batch publisher is client-streaming so
+	// per-node errors surface only when its stream closes, so flushAndConfirm
+	// closes the publisher to collect that result (then opens a fresh one for the
+	// next shard). Marking before this confirmation could report success for rows
+	// a flush failure never delivered, and the resume guard would then skip the
+	// whole shard, losing data.
+	cee, flushErr := replayer.flushAndConfirm(ctx)
+	if flushErr != nil || len(cee) > 0 {
+		mv.progress.RecordRowReplayNodeErrors(mv.group, cee)
+		confirmErr := flushErr
+		if confirmErr == nil {
+			confirmErr = fmt.Errorf("%d node error(s)", len(cee))
+		}
+		mv.progress.MarkTraceShardError(mv.group, segmentIDStr, sourceShardID, confirmErr.Error())
+		return fmt.Errorf("confirm row-replay trace shard %s: %w", shardPath, confirmErr)
+	}
+	mv.progress.MarkTraceShardCompleted(mv.group, segmentIDStr, sourceShardID)
+	mv.progress.MarkSourceTraceShardCompleted(mv.group, segmentIDStr, sourceShardID)
+	mv.progress.AddTraceRowReplay(mv.group, partsReplayed, totalRows)
+	mv.logger.Info().
+		Str("shard_path", shardPath).
+		Int("rows_published", totalRows).
+		Str("group", mv.group).
+		Msg("trace row-replay completed")
 	return nil
 }
 
@@ -404,11 +529,13 @@ func (mv *traceMigrationVisitor) generateAllSidxPartData(
 	return parts, releases, nil
 }
 
-func (mv *traceMigrationVisitor) generateAllPartData(sourceShardID common.ShardID, shardPath string) ([]queue.StreamingPartData, []func(), error) {
+func (mv *traceMigrationVisitor) generateAllPartData(
+	segmentTR *timestamp.TimeRange, sourceShardID common.ShardID, shardPath string,
+) ([]queue.StreamingPartData, []func(), error) {
 	entries := mv.lfs.ReadDir(shardPath)
 
-	allParts := make([]queue.StreamingPartData, 0)
-	allReleases := make([]func(), 0)
+	allParts := make([]queue.StreamingPartData, 0, len(entries))
+	allReleases := make([]func(), 0, len(entries))
 	for _, entry := range entries {
 		if !entry.IsDir() {
 			continue
@@ -426,7 +553,7 @@ func (mv *traceMigrationVisitor) generateAllPartData(sourceShardID common.ShardI
 		}
 
 		partPath := filepath.Join(shardPath, name)
-		parts, releases, err := mv.generatePartData(sourceShardID, partPath)
+		parts, releases, err := mv.generatePartData(segmentTR, sourceShardID, partPath)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to generate part data for path %s: %w", partPath, err)
 		}
@@ -437,7 +564,9 @@ func (mv *traceMigrationVisitor) generateAllPartData(sourceShardID common.ShardI
 	return allParts, allReleases, nil
 }
 
-func (mv *traceMigrationVisitor) generatePartData(sourceShardID common.ShardID, partPath string) ([]queue.StreamingPartData, []func(), error) {
+func (mv *traceMigrationVisitor) generatePartData(
+	segmentTR *timestamp.TimeRange, sourceShardID common.ShardID, partPath string,
+) ([]queue.StreamingPartData, []func(), error) {
 	partData, err := trace.ParsePartMetadata(mv.lfs, partPath)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to parse trace part metadata: %w", err)
@@ -446,10 +575,11 @@ func (mv *traceMigrationVisitor) generatePartData(sourceShardID common.ShardID, 
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to parse part ID from path: %w", err)
 	}
-	// Calculate ALL target segments this part should go to
+	// Target segments come from the source shard's own [start, end) boundaries,
+	// the same range VisitShard used to choose chunk-sync vs row-replay.
 	targetSegments := calculateTargetSegments(
-		partData.MinTimestamp,
-		partData.MaxTimestamp,
+		segmentTR.Start,
+		segmentTR.End,
 		mv.targetStageInterval,
 	)
 
@@ -460,10 +590,10 @@ func (mv *traceMigrationVisitor) generatePartData(sourceShardID common.ShardID, 
 		Int64("part_min_ts", partData.MinTimestamp).
 		Int64("part_max_ts", partData.MaxTimestamp).
 		Str("group", mv.group).
-		Msg("generate trace part files to multiple target segments")
+		Msg("generating trace part files for target segments")
 
-	parts := make([]queue.StreamingPartData, 0)
-	releases := make([]func(), 0)
+	parts := make([]queue.StreamingPartData, 0, len(targetSegments))
+	releases := make([]func(), 0, len(targetSegments))
 	// Send part to EACH target segment that overlaps with its time range
 	for i, targetSegmentTime := range targetSegments {
 		targetShardID := mv.calculateTargetShardID(uint32(sourceShardID))
@@ -557,14 +687,30 @@ func (mv *traceMigrationVisitor) streamPartToNode(nodeID string, targetShardID u
 	return nil
 }
 
-// Close cleans up all chunked sync clients.
+// Close cleans up all chunked sync clients and the trace row-replayer.
 func (mv *traceMigrationVisitor) Close() error {
+	if mv.replayer != nil {
+		cee, replayCloseErr := mv.replayer.Close()
+		mv.progress.RecordRowReplayNodeErrors(mv.group, cee)
+		if replayCloseErr != nil {
+			mv.logger.Warn().Err(replayCloseErr).Interface("node_errors", cee).Msg("failed to close trace row replayer")
+		} else if len(cee) > 0 {
+			mv.logger.Warn().Interface("node_errors", cee).Msg("trace row replayer reported per-node errors")
+		}
+		mv.replayer = nil
+	}
 	for nodeID, client := range mv.chunkedClients {
 		if err := client.Close(); err != nil {
 			mv.logger.Warn().Err(err).Str("node", nodeID).Msg("failed to close chunked sync client")
 		}
 	}
 	mv.chunkedClients = make(map[string]queue.ChunkedSyncClient)
+	chunkSync, rowReplay := mv.CounterSnapshot()
+	mv.logger.Info().
+		Uint64("shards_chunk_sync", chunkSync).
+		Uint64("parts_row_replay", rowReplay).
+		Str("group", mv.group).
+		Msg("trace migration visitor closed")
 	return nil
 }
 

--- a/banyand/internal/dump/stream/iterator.go
+++ b/banyand/internal/dump/stream/iterator.go
@@ -20,6 +20,7 @@ package stream
 import (
 	"fmt"
 
+	"github.com/apache/skywalking-banyandb/api/common"
 	"github.com/apache/skywalking-banyandb/banyand/internal/dump"
 	"github.com/apache/skywalking-banyandb/pkg/compress/zstd"
 	"github.com/apache/skywalking-banyandb/pkg/encoding"
@@ -45,6 +46,20 @@ func (p *PartReader) Iterator() *dump.Iterator[Row] {
 			return dump.NewErrIterator[Row](fmt.Errorf("cannot parse block metadata: %w", err))
 		}
 		blocks = append(blocks, bms...)
+	}
+	// When the part has no part-level series metadata (the standalone write path
+	// writes none), recover EntityValues for just this part's series by scanning
+	// the segment-level series index scoped to the part.
+	if p.seriesMap == nil && p.indexResolver != nil {
+		seriesIDs := make(map[common.SeriesID]struct{})
+		for _, bm := range blocks {
+			seriesIDs[bm.seriesID] = struct{}{}
+		}
+		seriesMap, err := p.indexResolver.PartSeriesMap(seriesIDs)
+		if err != nil {
+			return dump.NewErrIterator[Row](fmt.Errorf("cannot build part series map: %w", err))
+		}
+		p.seriesMap = seriesMap
 	}
 	var decoder encoding.BytesBlockDecoder
 	return dump.NewIterator(len(blocks), func(blockIdx int) ([]Row, error) {

--- a/banyand/internal/dump/stream/stream.go
+++ b/banyand/internal/dump/stream/stream.go
@@ -95,6 +95,7 @@ type PartReader struct {
 	tagFamilies          map[string]fs.Reader
 	tagFamilyFilter      map[string]fs.Reader
 	seriesMap            map[common.SeriesID][]byte // part-level smeta.bin, nil if absent
+	indexResolver        *dump.IndexResolver        // optional segment-level series-index fallback
 	path                 string
 	primaryBlockMetadata []primaryBlockMetadata
 	partMetadata         PartMetadata
@@ -231,6 +232,12 @@ func (p *PartReader) PartID() uint64 { return p.partMetadata.ID }
 // SeriesMap returns the part-level SeriesID -> EntityValues map parsed from
 // smeta.bin, or nil if smeta.bin is absent.
 func (p *PartReader) SeriesMap() map[common.SeriesID][]byte { return p.seriesMap }
+
+// SetIndexResolver attaches a segment-level series-index resolver. When the
+// part has no smeta.bin (the standalone write path skips it), the iterator
+// falls back to IndexResolver.PartSeriesMap to recover EntityValues scoped to
+// just this part's distinct seriesIDs.
+func (p *PartReader) SetIndexResolver(r *dump.IndexResolver) { p.indexResolver = r }
 
 // Close releases all file handles. Safe to call multiple times.
 func (p *PartReader) Close() error {

--- a/banyand/liaison/grpc/discovery.go
+++ b/banyand/liaison/grpc/discovery.go
@@ -95,39 +95,20 @@ func (ds *discoveryService) navigateByLocator(metadata *commonv1.Metadata, tagFa
 		return nil, common.ShardID(0), errors.Wrapf(errNotExist, "finding the shard num by: %v", metadata)
 	}
 	id := getID(metadata)
-	var entityValues pbv1.EntityValues
-	var shardID common.ShardID
-	var err error
+	var entityRouter, shardingKeyRouter partition.Router
 	if specEntityLocator != nil {
-		entityValues, shardID, err = specEntityLocator.Locate(metadata.Name, tagFamilies, shardNum)
-		if err != nil {
-			return nil, common.ShardID(0), err
-		}
+		entityRouter = specEntityLocator
+	} else if cached, ok := ds.entityRepo.getLocator(id); ok {
+		entityRouter = cached
 	} else {
-		entityLocator, existed := ds.entityRepo.getLocator(id)
-		if !existed {
-			return nil, common.ShardID(0), errors.Wrapf(errNotExist, "finding the entity locator by: %v", metadata)
-		}
-		entityValues, shardID, err = entityLocator.Locate(metadata.Name, tagFamilies, shardNum)
-		if err != nil {
-			return nil, common.ShardID(0), err
-		}
+		return nil, common.ShardID(0), errors.Wrapf(errNotExist, "finding the entity locator by: %v", metadata)
 	}
 	if specShardingKeyLocator != nil {
-		_, shardID, err = specShardingKeyLocator.Locate(metadata.Name, tagFamilies, shardNum)
-		if err != nil {
-			return nil, common.ShardID(0), err
-		}
-	} else {
-		shardingKeyLocator, existed := ds.shardingKeyRepo.getLocator(id)
-		if existed {
-			_, shardID, err = shardingKeyLocator.Locate(metadata.Name, tagFamilies, shardNum)
-			if err != nil {
-				return nil, common.ShardID(0), err
-			}
-		}
+		shardingKeyRouter = specShardingKeyLocator
+	} else if sk, ok := ds.shardingKeyRepo.getLocator(id); ok {
+		shardingKeyRouter = sk
 	}
-	return entityValues, shardID, nil
+	return partition.ApplyLocators(metadata.Name, tagFamilies, entityRouter, shardingKeyRouter, shardNum)
 }
 
 type identity struct {

--- a/banyand/liaison/grpc/trace.go
+++ b/banyand/liaison/grpc/trace.go
@@ -38,6 +38,7 @@ import (
 	"github.com/apache/skywalking-banyandb/pkg/bus"
 	"github.com/apache/skywalking-banyandb/pkg/convert"
 	"github.com/apache/skywalking-banyandb/pkg/logger"
+	"github.com/apache/skywalking-banyandb/pkg/partition"
 	"github.com/apache/skywalking-banyandb/pkg/query"
 	"github.com/apache/skywalking-banyandb/pkg/timestamp"
 )
@@ -216,8 +217,7 @@ func (s *traceService) navigate(metadata *commonv1.Metadata,
 }
 
 func (s *traceService) shardID(traceID string, shardCount uint32) common.ShardID {
-	hash := convert.Hash([]byte(traceID))
-	return common.ShardID(hash % uint64(shardCount))
+	return partition.TraceShardID(traceID, shardCount)
 }
 
 func (s *traceService) extractTraceID(tags []*modelv1.TagValue, traceIDIndex int) (string, error) {

--- a/banyand/metadata/schema/property/client_test.go
+++ b/banyand/metadata/schema/property/client_test.go
@@ -508,6 +508,40 @@ func TestMeasureCRUD(t *testing.T) {
 	require.Error(t, getErr)
 }
 
+// TestListMeasureReturnsAllBeyondDefaultLimit guards the lifecycle row-replay
+// path, which calls ListMeasure to snapshot every measure in a group and then
+// resolves each replayed row's schema from that snapshot. A group with more
+// than ten measures must not be silently truncated: the schema query is issued
+// with limit=0, which the inverted store treats as "no cap", so all measures
+// must come back. Picking a count well above ten makes a regression to any
+// page-size default fail loudly.
+func TestListMeasureReturnsAllBeyondDefaultLimit(t *testing.T) {
+	addr := startTestSchemaServer(t)
+	reg := newTestRegistry(t, addr)
+	ctx := context.Background()
+	createTestGroup(t, reg)
+
+	const total = 25
+	wantNames := make(map[string]struct{}, total)
+	for i := 0; i < total; i++ {
+		m := testMeasure("test-group")
+		m.Metadata.Name = fmt.Sprintf("measure-%02d", i)
+		_, createErr := reg.CreateMeasure(ctx, m)
+		require.NoError(t, createErr, "create measure %s", m.Metadata.Name)
+		wantNames[m.Metadata.Name] = struct{}{}
+	}
+
+	measures, listErr := reg.ListMeasure(ctx, schema.ListOpt{Group: "test-group"})
+	require.NoError(t, listErr)
+	assert.Len(t, measures, total, "ListMeasure must return all %d measures without limit truncation", total)
+
+	gotNames := make(map[string]struct{}, len(measures))
+	for _, m := range measures {
+		gotNames[m.GetMetadata().GetName()] = struct{}{}
+	}
+	assert.Equal(t, wantNames, gotNames, "ListMeasure must return exactly the created measures")
+}
+
 func TestTraceCRUD(t *testing.T) {
 	addr := startTestSchemaServer(t)
 	reg := newTestRegistry(t, addr)

--- a/banyand/stream/write_standalone.go
+++ b/banyand/stream/write_standalone.go
@@ -170,9 +170,16 @@ func processElements(schemaRepo *schemaRepo, elements *elements, writeEvent *str
 
 	elements.timestamps = append(elements.timestamps, ts)
 	var eID uint64
-	if req.Element.GetElementId() != "" {
+	switch {
+	case writeEvent.RawElementId != 0:
+		// Lifecycle row-replay forwards the original storage-internal eID (already
+		// hashed by the source-side liaison). Use it directly so a logical element
+		// migrated through chunk-sync and row-replay paths keeps a single eID and
+		// the query-layer dedup (seenElementIDs) stays consistent.
+		eID = writeEvent.RawElementId
+	case req.Element.GetElementId() != "":
 		eID = convert.HashStr(metadata.Group + "|" + metadata.Name + "|" + req.Element.GetElementId())
-	} else {
+	default:
 		eID = schemaRepo.idGen.NextID()
 	}
 	elements.elementIDs = append(elements.elementIDs, eID)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -6453,6 +6453,7 @@ WriteResponse is the response contract for write
 | shard_id | [uint32](#uint32) |  |  |
 | entity_values | [banyandb.model.v1.TagValue](#banyandb-model-v1-TagValue) | repeated |  |
 | request | [WriteRequest](#banyandb-stream-v1-WriteRequest) |  |  |
+| raw_element_id | [uint64](#uint64) |  | raw_element_id carries the original storage-internal eID (an already-hashed uint64) forwarded by lifecycle row-replay. When non-zero, the receiver uses it directly and skips the HashStr step on element.element_id, so a logical element migrated through both chunk-sync and row-replay paths keeps the same target-side eID and query-layer dedup stays consistent. SDK and topN write paths leave this unset (0). |
 
 
 

--- a/pkg/partition/route.go
+++ b/pkg/partition/route.go
@@ -20,7 +20,10 @@ package partition
 import (
 	"github.com/pkg/errors"
 
+	"github.com/apache/skywalking-banyandb/api/common"
+	modelv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/model/v1"
 	"github.com/apache/skywalking-banyandb/pkg/convert"
+	pbv1 "github.com/apache/skywalking-banyandb/pkg/pb/v1"
 )
 
 // ShardID calculates a shard id.
@@ -30,4 +33,37 @@ func ShardID(key []byte, shardNum uint32) (uint, error) {
 	}
 	encodeKey := convert.Hash(key)
 	return uint(encodeKey % uint64(shardNum)), nil
+}
+
+// TraceShardID returns the shard id derived from a trace id hash.
+// A zero shardNum returns shard 0 to avoid a divide-by-zero panic.
+func TraceShardID(traceID string, shardNum uint32) common.ShardID {
+	if shardNum == 0 {
+		return 0
+	}
+	return common.ShardID(convert.Hash([]byte(traceID)) % uint64(shardNum))
+}
+
+// Router is anything that can map a write to its target (entityValues, shardID).
+type Router interface {
+	Locate(subject string, tagFamilies []*modelv1.TagFamilyForWrite, shardNum uint32) (pbv1.EntityValues, common.ShardID, error)
+}
+
+// ApplyLocators routes a write by entity tags then, when a non-nil
+// shardingKey Router is supplied, overrides the shard id with the
+// sharding-key derived one. EntityValues always come from the entity router.
+func ApplyLocators(subject string, tagFamilies []*modelv1.TagFamilyForWrite,
+	entityRouter, shardingKeyRouter Router, shardNum uint32,
+) (pbv1.EntityValues, common.ShardID, error) {
+	entityValues, shardID, err := entityRouter.Locate(subject, tagFamilies, shardNum)
+	if err != nil {
+		return nil, 0, err
+	}
+	if shardingKeyRouter != nil {
+		_, shardID, err = shardingKeyRouter.Locate(subject, tagFamilies, shardNum)
+		if err != nil {
+			return nil, 0, err
+		}
+	}
+	return entityValues, shardID, nil
 }

--- a/pkg/partition/route_test.go
+++ b/pkg/partition/route_test.go
@@ -1,0 +1,155 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package partition_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/apache/skywalking-banyandb/api/common"
+	databasev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
+	modelv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/model/v1"
+	"github.com/apache/skywalking-banyandb/pkg/partition"
+	pbv1 "github.com/apache/skywalking-banyandb/pkg/pb/v1"
+)
+
+// TestTraceShardID verifies hash-based shard routing is deterministic and
+// guards against a zero shardNum (which would panic with integer
+// divide-by-zero in production write paths).
+func TestTraceShardID(t *testing.T) {
+	t.Run("deterministic", func(t *testing.T) {
+		s1 := partition.TraceShardID("trace-abc", 8)
+		s2 := partition.TraceShardID("trace-abc", 8)
+		assert.Equal(t, s1, s2)
+		assert.True(t, uint32(s1) < 8)
+	})
+	t.Run("spread across shards", func(t *testing.T) {
+		seen := make(map[common.ShardID]struct{})
+		for i := 0; i < 64; i++ {
+			seen[partition.TraceShardID("trace-"+string(rune('A'+i)), 4)] = struct{}{}
+		}
+		assert.GreaterOrEqual(t, len(seen), 2, "hash must spread across multiple shards")
+	})
+	t.Run("zero shardNum returns 0 (no panic)", func(t *testing.T) {
+		assert.Equal(t, common.ShardID(0), partition.TraceShardID("any-trace-id", 0))
+	})
+}
+
+// fixedRouter satisfies partition.Router and returns predetermined results,
+// letting the test assert that ApplyLocators wires the right router into
+// the right slot and that the shardingKey override fires only when supplied.
+type fixedRouter struct {
+	err          error
+	entityValues pbv1.EntityValues
+	calls        int
+	shardID      common.ShardID
+}
+
+func (f *fixedRouter) Locate(_ string, _ []*modelv1.TagFamilyForWrite, _ uint32) (pbv1.EntityValues, common.ShardID, error) {
+	f.calls++
+	return f.entityValues, f.shardID, f.err
+}
+
+// TestApplyLocators_EntityOnly checks the no-shardingKey path: entityRouter's
+// output is returned unchanged.
+func TestApplyLocators_EntityOnly(t *testing.T) {
+	entity := &fixedRouter{
+		entityValues: pbv1.EntityValues{{Value: &modelv1.TagValue_Str{Str: &modelv1.Str{Value: "subject"}}}},
+		shardID:      common.ShardID(3),
+	}
+	values, shardID, err := partition.ApplyLocators("svc", nil, entity, nil, 8)
+	require.NoError(t, err)
+	assert.Equal(t, common.ShardID(3), shardID)
+	require.Len(t, values, 1)
+	assert.Equal(t, 1, entity.calls)
+}
+
+// TestApplyLocators_ShardingKeyOverride checks that a non-nil shardingKey
+// router overrides the entity-based shardID while entityValues stay from the
+// entity router.
+func TestApplyLocators_ShardingKeyOverride(t *testing.T) {
+	entity := &fixedRouter{
+		entityValues: pbv1.EntityValues{{Value: &modelv1.TagValue_Str{Str: &modelv1.Str{Value: "subject"}}}},
+		shardID:      common.ShardID(3),
+	}
+	sk := &fixedRouter{shardID: common.ShardID(5)}
+	values, shardID, err := partition.ApplyLocators("svc", nil, entity, sk, 8)
+	require.NoError(t, err)
+	assert.Equal(t, common.ShardID(5), shardID, "shardingKey must override entity-based shardID")
+	require.Len(t, values, 1)
+	assert.Equal(t, 1, entity.calls)
+	assert.Equal(t, 1, sk.calls)
+}
+
+// TestApplyLocators_EntityError propagates errors from the entity router and
+// does not consult the shardingKey router.
+func TestApplyLocators_EntityError(t *testing.T) {
+	entity := &fixedRouter{err: errors.New("entity locate failed")}
+	sk := &fixedRouter{shardID: common.ShardID(5)}
+	_, _, err := partition.ApplyLocators("svc", nil, entity, sk, 8)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "entity locate failed")
+	assert.Equal(t, 0, sk.calls, "shardingKey router must not run after entity error")
+}
+
+// TestApplyLocators_ShardingKeyError propagates errors from the shardingKey
+// router even though the entity router succeeded.
+func TestApplyLocators_ShardingKeyError(t *testing.T) {
+	entity := &fixedRouter{
+		entityValues: pbv1.EntityValues{{Value: &modelv1.TagValue_Str{Str: &modelv1.Str{Value: "subject"}}}},
+		shardID:      common.ShardID(3),
+	}
+	sk := &fixedRouter{err: errors.New("sharding key locate failed")}
+	_, _, err := partition.ApplyLocators("svc", nil, entity, sk, 8)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sharding key locate failed")
+}
+
+// TestApplyLocators_LocatorIntegration verifies that partition.Locator (the
+// concrete value type used by both the cached entity locator and sharding-key
+// locator in production) satisfies the Router interface and produces the
+// same shardID as a direct .Locate call.
+func TestApplyLocators_LocatorIntegration(t *testing.T) {
+	families := []*databasev1.TagFamilySpec{{
+		Name: "primary",
+		Tags: []*databasev1.TagSpec{
+			{Name: "service", Type: databasev1.TagType_TAG_TYPE_STRING},
+			{Name: "region", Type: databasev1.TagType_TAG_TYPE_STRING},
+		},
+	}}
+	entity := &databasev1.Entity{TagNames: []string{"service", "region"}}
+	entityLocator := partition.NewEntityLocator(families, entity, 1)
+
+	tagFamilies := []*modelv1.TagFamilyForWrite{{
+		Tags: []*modelv1.TagValue{
+			{Value: &modelv1.TagValue_Str{Str: &modelv1.Str{Value: "checkout"}}},
+			{Value: &modelv1.TagValue_Str{Str: &modelv1.Str{Value: "us-east-1"}}},
+		},
+	}}
+
+	wantValues, wantShard, wantErr := entityLocator.Locate("svc", tagFamilies, 8)
+	require.NoError(t, wantErr)
+
+	gotValues, gotShard, err := partition.ApplyLocators("svc", tagFamilies, entityLocator, nil, 8)
+	require.NoError(t, err)
+	assert.Equal(t, wantShard, gotShard)
+	require.Equal(t, len(wantValues), len(gotValues))
+}

--- a/pkg/test/measure/testdata/group_stages/sw_cross_segment.json
+++ b/pkg/test/measure/testdata/group_stages/sw_cross_segment.json
@@ -1,0 +1,33 @@
+{
+  "metadata": {
+    "name": "sw_cross_segment"
+  },
+  "catalog": "CATALOG_MEASURE",
+  "resource_opts": {
+    "shard_num": 1,
+    "segment_interval": {
+      "unit": "UNIT_DAY",
+      "num": 2
+    },
+    "ttl": {
+      "unit": "UNIT_DAY",
+      "num": 5
+    },
+    "stages": [
+      {
+        "name": "warm",
+        "shard_num": 1,
+        "segment_interval": {
+          "unit": "UNIT_DAY",
+          "num": 3
+        },
+        "ttl": {
+          "unit": "UNIT_DAY",
+          "num": 10
+        },
+        "node_selector": "type=warm"
+      }
+    ]
+  },
+  "updated_at": "2026-05-27T00:00:00.00Z"
+}

--- a/pkg/test/measure/testdata/groups/sw_cross_segment.json
+++ b/pkg/test/measure/testdata/groups/sw_cross_segment.json
@@ -1,0 +1,18 @@
+{
+  "metadata": {
+    "name": "sw_cross_segment"
+  },
+  "catalog": "CATALOG_MEASURE",
+  "resource_opts": {
+    "shard_num": 1,
+    "segment_interval": {
+      "unit": "UNIT_DAY",
+      "num": 2
+    },
+    "ttl": {
+      "unit": "UNIT_DAY",
+      "num": 5
+    }
+  },
+  "updated_at": "2026-05-27T00:00:00.00Z"
+}

--- a/pkg/test/measure/testdata/measures/cross_segment_metric.json
+++ b/pkg/test/measure/testdata/measures/cross_segment_metric.json
@@ -1,0 +1,32 @@
+{
+  "metadata": {
+    "name": "cross_segment_metric",
+    "group": "sw_cross_segment"
+  },
+  "tag_families": [
+    {
+      "name": "default",
+      "tags": [
+        {
+          "name": "entity_id",
+          "type": "TAG_TYPE_STRING"
+        }
+      ]
+    }
+  ],
+  "fields": [
+    {
+      "name": "value",
+      "field_type": "FIELD_TYPE_INT",
+      "encoding_method": "ENCODING_METHOD_GORILLA",
+      "compression_method": "COMPRESSION_METHOD_ZSTD"
+    }
+  ],
+  "entity": {
+    "tag_names": [
+      "entity_id"
+    ]
+  },
+  "interval": "1m",
+  "updated_at": "2026-05-27T00:00:00.00Z"
+}

--- a/pkg/test/stream/testdata/group.json
+++ b/pkg/test/stream/testdata/group.json
@@ -73,5 +73,23 @@
       }
     },
     "updated_at": "2021-04-15T01:30:15.01Z"
+  },
+  {
+    "metadata": {
+      "name": "sw_cross_segment_stream"
+    },
+    "catalog": "CATALOG_STREAM",
+    "resource_opts": {
+      "shard_num": 1,
+      "segment_interval": {
+        "unit": "UNIT_DAY",
+        "num": 2
+      },
+      "ttl": {
+        "unit": "UNIT_DAY",
+        "num": 5
+      }
+    },
+    "updated_at": "2026-05-27T00:00:00.00Z"
   }
 ]

--- a/pkg/test/stream/testdata/group_with_stages.json
+++ b/pkg/test/stream/testdata/group_with_stages.json
@@ -130,5 +130,38 @@
       ]
     },
     "updated_at": "2021-04-15T01:30:15.01Z"
+  },
+  {
+    "metadata": {
+      "name": "sw_cross_segment_stream"
+    },
+    "catalog": "CATALOG_STREAM",
+    "resource_opts": {
+      "shard_num": 1,
+      "segment_interval": {
+        "unit": "UNIT_DAY",
+        "num": 2
+      },
+      "ttl": {
+        "unit": "UNIT_DAY",
+        "num": 5
+      },
+      "stages": [
+        {
+          "name": "warm",
+          "shard_num": 1,
+          "segment_interval": {
+            "unit": "UNIT_DAY",
+            "num": 3
+          },
+          "ttl": {
+            "unit": "UNIT_DAY",
+            "num": 10
+          },
+          "node_selector": "type=warm"
+        }
+      ]
+    },
+    "updated_at": "2026-05-27T00:00:00.00Z"
   }
 ]

--- a/pkg/test/stream/testdata/streams/cross_segment_log.json
+++ b/pkg/test/stream/testdata/streams/cross_segment_log.json
@@ -1,0 +1,27 @@
+{
+  "metadata": {
+    "name": "cross_segment_log",
+    "group": "sw_cross_segment_stream"
+  },
+  "tag_families": [
+    {
+      "name": "searchable",
+      "tags": [
+        {
+          "name": "business_id",
+          "type": "TAG_TYPE_STRING"
+        },
+        {
+          "name": "entity_id",
+          "type": "TAG_TYPE_STRING"
+        }
+      ]
+    }
+  ],
+  "entity": {
+    "tag_names": [
+      "entity_id"
+    ]
+  },
+  "updated_at": "2026-05-27T00:00:00.00Z"
+}

--- a/pkg/test/trace/testdata/groups/sw_cross_segment_trace.json
+++ b/pkg/test/trace/testdata/groups/sw_cross_segment_trace.json
@@ -1,0 +1,19 @@
+{
+    "metadata": {
+        "name": "sw_cross_segment_trace"
+    },
+    "catalog": "CATALOG_TRACE",
+    "resource_opts": {
+        "shard_num": 1,
+        "replicas": 0,
+        "segment_interval": {
+            "unit": "UNIT_DAY",
+            "num": 2
+        },
+        "ttl": {
+            "unit": "UNIT_DAY",
+            "num": 5
+        }
+    },
+    "updated_at": "2026-05-27T00:00:00.00Z"
+}

--- a/pkg/test/trace/testdata/groups_stages/sw_cross_segment_trace.json
+++ b/pkg/test/trace/testdata/groups_stages/sw_cross_segment_trace.json
@@ -1,0 +1,34 @@
+{
+    "metadata": {
+        "name": "sw_cross_segment_trace"
+    },
+    "catalog": "CATALOG_TRACE",
+    "resource_opts": {
+        "shard_num": 1,
+        "replicas": 0,
+        "segment_interval": {
+            "unit": "UNIT_DAY",
+            "num": 2
+        },
+        "ttl": {
+            "unit": "UNIT_DAY",
+            "num": 5
+        },
+        "stages": [
+            {
+                "name": "warm",
+                "shard_num": 1,
+                "segment_interval": {
+                    "unit": "UNIT_DAY",
+                    "num": 3
+                },
+                "ttl": {
+                    "unit": "UNIT_DAY",
+                    "num": 10
+                },
+                "node_selector": "type=warm"
+            }
+        ]
+    },
+    "updated_at": "2026-05-27T00:00:00.00Z"
+}

--- a/pkg/test/trace/testdata/index_rule_bindings/cross_segment_trace.json
+++ b/pkg/test/trace/testdata/index_rule_bindings/cross_segment_trace.json
@@ -1,0 +1,16 @@
+{
+    "metadata": {
+        "name": "cross-segment-trace-index-rule-binding",
+        "group": "sw_cross_segment_trace"
+    },
+    "rules": [
+        "cross_segment_timestamp"
+    ],
+    "subject": {
+        "catalog": "CATALOG_TRACE",
+        "name": "cross_segment_trace_item"
+    },
+    "begin_at": "2021-04-15T01:30:15.01Z",
+    "expire_at": "2121-04-15T01:30:15.01Z",
+    "updated_at": "2026-05-27T00:00:00.00Z"
+}

--- a/pkg/test/trace/testdata/index_rules/cross_segment_timestamp.json
+++ b/pkg/test/trace/testdata/index_rules/cross_segment_timestamp.json
@@ -1,0 +1,11 @@
+{
+    "metadata": {
+        "name": "cross_segment_timestamp",
+        "group": "sw_cross_segment_trace"
+    },
+    "tags": [
+        "timestamp"
+    ],
+    "type": "TYPE_TREE",
+    "updated_at": "2026-05-27T00:00:00.00Z"
+}

--- a/pkg/test/trace/testdata/traces/cross_segment_trace.json
+++ b/pkg/test/trace/testdata/traces/cross_segment_trace.json
@@ -1,0 +1,24 @@
+{
+    "metadata": {
+        "name": "cross_segment_trace_item",
+        "group": "sw_cross_segment_trace"
+    },
+    "tags": [
+        {
+            "name": "trace_id",
+            "type": "TAG_TYPE_STRING"
+        },
+        {
+            "name": "span_id",
+            "type": "TAG_TYPE_STRING"
+        },
+        {
+            "name": "timestamp",
+            "type": "TAG_TYPE_TIMESTAMP"
+        }
+    ],
+    "trace_id_tag_name": "trace_id",
+    "span_id_tag_name": "span_id",
+    "timestamp_tag_name": "timestamp",
+    "updated_at": "2026-05-27T00:00:00.00Z"
+}

--- a/test/cases/lifecycle/lifecycle.go
+++ b/test/cases/lifecycle/lifecycle.go
@@ -19,17 +19,27 @@
 package lifecycle_test
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
+	commonv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/common/v1"
+	measurev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/measure/v1"
+	modelv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/model/v1"
+	streamv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/stream/v1"
+	tracev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/trace/v1"
 	"github.com/apache/skywalking-banyandb/banyand/backup/lifecycle"
 	"github.com/apache/skywalking-banyandb/pkg/grpchelper"
 	"github.com/apache/skywalking-banyandb/pkg/test/flags"
@@ -302,7 +312,7 @@ func verifyMigrationReport(rf string) {
 		gomega.Expect(report).To(gomega.HaveKey("summary"), "report %s missing summary", path)
 		gomega.Expect(report).To(gomega.HaveKey("errors"), "report %s missing errors", path)
 		gomega.Expect(report).To(gomega.HaveKey("snapshot_info"), "report %s missing snapshot_info", path)
-		gomega.Expect(report["report_version"]).To(gomega.Equal("2.0"), "report %s has unexpected report_version", path)
+		gomega.Expect(report["report_version"]).To(gomega.Equal("2.1"), "report %s has unexpected report_version", path)
 
 		// snapshot_info: trace_dir must surface alongside stream/measure.
 		snap, ok := report["snapshot_info"].(map[string]interface{})
@@ -347,8 +357,87 @@ func verifyMigrationReport(rf string) {
 			gomega.Expect(isMap).To(gomega.BeTrue(), "errors.%s must be a map in %s", key, path)
 			gomega.Expect(errMap).To(gomega.BeEmpty(), "errors.%s must be empty for a clean cycle in %s", key, path)
 		}
+
+		// report_version 2.1: every catalog carries a sync_breakdown block, and
+		// for measure/stream (where chunk-sync and row-replay share the part
+		// unit) chunk_sync_parts + row_replay_parts must reconcile to the
+		// catalog's completed parts. Trace is shard-batched so the sum check
+		// is skipped.
+		verifySyncBreakdown(summary, "stream_migration", "chunk_sync_parts", true, path)
+		verifySyncBreakdown(summary, "measure_migration", "chunk_sync_parts", true, path)
+		verifySyncBreakdown(summary, "trace_migration", "chunk_sync_shards", false, path)
+
+		// row_replay_node_errors must surface and stay empty for a clean cycle.
+		nodeErrs, found := errs["row_replay_node_errors"]
+		gomega.Expect(found).To(gomega.BeTrue(), "errors.row_replay_node_errors must be present in %s", path)
+		nodeErrMap, isMap := nodeErrs.(map[string]interface{})
+		gomega.Expect(isMap).To(gomega.BeTrue(), "errors.row_replay_node_errors must be a map in %s", path)
+		gomega.Expect(nodeErrMap).To(gomega.BeEmpty(), "errors.row_replay_node_errors must be empty for a clean cycle in %s", path)
 	}
 	gomega.Expect(jsonReports).To(gomega.BeNumerically(">", 0), "no JSON report files found under %s", rf)
+}
+
+// verifySyncBreakdown asserts a catalog's sync_breakdown block has a _total
+// entry with the chunk key (chunk_sync_parts or chunk_sync_shards) plus
+// row_replay_parts / row_replay_rows. When sumInvariant is set the _total
+// chunk + row-replay parts must equal the catalog's completed parts.
+func verifySyncBreakdown(summary map[string]interface{}, catalog, chunkKey string, sumInvariant bool, path string) {
+	cat, ok := summary[catalog].(map[string]interface{})
+	gomega.Expect(ok).To(gomega.BeTrue(), "summary.%s must be a map in %s", catalog, path)
+	sb, ok := cat["sync_breakdown"].(map[string]interface{})
+	gomega.Expect(ok).To(gomega.BeTrue(), "summary.%s.sync_breakdown must be a map in %s", catalog, path)
+	total, ok := sb["_total"].(map[string]interface{})
+	gomega.Expect(ok).To(gomega.BeTrue(), "summary.%s.sync_breakdown._total must be a map in %s", catalog, path)
+	for _, key := range []string{chunkKey, "row_replay_parts", "row_replay_rows"} {
+		gomega.Expect(total).To(gomega.HaveKey(key), "summary.%s.sync_breakdown._total missing %s in %s", catalog, key, path)
+	}
+	if !sumInvariant {
+		return
+	}
+	parts, ok := cat["parts"].(map[string]interface{})
+	gomega.Expect(ok).To(gomega.BeTrue(), "summary.%s.parts must be a map in %s", catalog, path)
+	completed := asInt(parts["completed"])
+	chunk := asInt(total[chunkKey])
+	replay := asInt(total["row_replay_parts"])
+	gomega.Expect(chunk+replay).To(gomega.Equal(completed),
+		"summary.%s sync_breakdown chunk(%d)+row_replay(%d) must equal parts.completed(%d) in %s",
+		catalog, chunk, replay, completed, path)
+}
+
+// verifyCrossSegmentReport asserts the locked per-group sync_breakdown of a
+// cross-segment migration run. The seeded data is deterministic, so the
+// row-replay row count is an absolute value; part/shard counts are pinned too
+// because every group here uses shard_num=1 (or a single entity) and one flush.
+func verifyCrossSegmentReport(reportDir, catalog, group, chunkKey string, wantChunk, wantReplayParts, wantReplayRows int) {
+	entries, err := os.ReadDir(reportDir)
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "cross-segment report dir %s must exist", reportDir)
+	latest := ""
+	for _, e := range entries {
+		if !e.IsDir() && filepath.Ext(e.Name()) == ".json" && e.Name() > latest {
+			latest = e.Name()
+		}
+	}
+	gomega.Expect(latest).NotTo(gomega.BeEmpty(), "no JSON report under %s", reportDir)
+	raw, readErr := os.ReadFile(filepath.Join(reportDir, latest))
+	gomega.Expect(readErr).NotTo(gomega.HaveOccurred(), "report %s must be readable", latest)
+	var report map[string]interface{}
+	gomega.Expect(json.Unmarshal(raw, &report)).To(gomega.Succeed(), "report %s must be valid JSON", latest)
+
+	summary, ok := report["summary"].(map[string]interface{})
+	gomega.Expect(ok).To(gomega.BeTrue(), "summary must be a map in %s", latest)
+	cat, ok := summary[catalog].(map[string]interface{})
+	gomega.Expect(ok).To(gomega.BeTrue(), "summary.%s must be a map in %s", catalog, latest)
+	sb, ok := cat["sync_breakdown"].(map[string]interface{})
+	gomega.Expect(ok).To(gomega.BeTrue(), "summary.%s.sync_breakdown must be a map in %s", catalog, latest)
+	entry, ok := sb[group].(map[string]interface{})
+	gomega.Expect(ok).To(gomega.BeTrue(), "sync_breakdown[%s] must exist in %s", group, latest)
+
+	gomega.Expect(asInt(entry[chunkKey])).To(gomega.Equal(wantChunk),
+		"sync_breakdown[%s].%s must be %d in %s", group, chunkKey, wantChunk, latest)
+	gomega.Expect(asInt(entry["row_replay_parts"])).To(gomega.Equal(wantReplayParts),
+		"sync_breakdown[%s].row_replay_parts must be %d in %s", group, wantReplayParts, latest)
+	gomega.Expect(asInt(entry["row_replay_rows"])).To(gomega.Equal(wantReplayRows),
+		"sync_breakdown[%s].row_replay_rows must be %d in %s", group, wantReplayRows, latest)
 }
 
 // verifyAllRatesAt100 enforces the per-resource accounting invariant: when
@@ -398,3 +487,687 @@ func asInt(v interface{}) int {
 	}
 	return 0
 }
+
+// crossSegmentTimestamps returns three probe timestamps shared by the
+// cross-segment suites: single sits in a source segment fully inside one target
+// segment, while left/right sit in a source segment that straddles a target
+// boundary (left and right of the crossing). The picked source day N satisfies
+// N%6==2 (LCM of the 2-day source and 3-day target grids), shifted >=8 local
+// days back so it clears the 5-day source TTL.
+func crossSegmentTimestamps() (single, left, right time.Time) {
+	nowLocal := time.Now().Local().Truncate(24 * time.Hour)
+	nowDay := nowLocal.Unix() / (24 * 3600)
+	crossSrcDayStart := nowDay - 8
+	for crossSrcDayStart%6 != 2 {
+		crossSrcDayStart--
+	}
+	crossSrcStart := nowLocal.AddDate(0, 0, int(crossSrcDayStart-nowDay))
+	return crossSrcStart.Add(-12 * time.Hour), crossSrcStart.Add(12 * time.Hour), crossSrcStart.Add(36 * time.Hour)
+}
+
+// runLifecycleMigration runs a single hot->warm lifecycle migration, pointing
+// every root path at the shared source dir and writing its report to reportDir.
+func runLifecycleMigration(progressFile, reportDir string) {
+	lifecycleCmd := lifecycle.NewCommand()
+	args := []string{
+		"--grpc-addr", SharedContext.DataAddr,
+		"--stream-root-path", SharedContext.SrcDir,
+		"--measure-root-path", SharedContext.SrcDir,
+		"--trace-root-path", SharedContext.SrcDir,
+		"--progress-file", progressFile,
+		"--report-dir", reportDir,
+	}
+	args = append(args, SharedContext.MetadataFlags...)
+	lifecycleCmd.SetArgs(args)
+	gomega.Expect(lifecycleCmd.Execute()).To(gomega.Succeed())
+}
+
+// drainWriteAcks closes a client-streaming write and fails the spec if any
+// server-side ack reports a non-success status, surfacing per-row rejections
+// that a bare CloseSend would swallow.
+func drainWriteAcks[R interface{ GetStatus() string }](recv func() (R, error), closeSend func() error) {
+	ackErrs := make(chan error, 8)
+	go func() {
+		defer close(ackErrs)
+		for {
+			resp, recvErr := recv()
+			if recvErr != nil {
+				return
+			}
+			if status := resp.GetStatus(); status != "" && status != "STATUS_SUCCEED" {
+				ackErrs <- fmt.Errorf("write rejected: %s", status)
+			}
+		}
+	}()
+	gomega.Expect(closeSend()).To(gomega.Succeed())
+	for ackErr := range ackErrs {
+		gomega.Expect(ackErr).NotTo(gomega.HaveOccurred(), "write ack must succeed")
+	}
+}
+
+// assertCrossSegmentPartMetadata validates the physical target-segment layout
+// after a cross-segment migration. It reads every part's metadata.json under
+// destGroupRoot and asserts (retrying until consistent):
+//   - exactly wantSegCount target segment directories exist;
+//   - every part's [min,max] stays within its own segment's [start, start+3d);
+//   - the `single` and `left` probe timestamps land in ONE segment (segA) while
+//     `right` lands in a DIFFERENT segment (segB);
+//   - segA and segB are contiguous on the 3-day grid (segB.start == segA.end),
+//     pinning their start/end values; and the boundary segA.end falls strictly
+//     inside (left, right] — i.e. it separates the left and right probes.
+func assertCrossSegmentPartMetadata(destGroupRoot string, single, left, right time.Time, wantSegCount int) {
+	const warmSegDays = 3
+	within := func(t time.Time, minTS, maxTS int64) bool {
+		n := t.UnixNano()
+		return n >= minTS && n <= maxTS
+	}
+	type segBounds struct {
+		start, end time.Time
+	}
+	gomega.Eventually(func() error {
+		segs := map[string]segBounds{}
+		var segSingle, segLeft, segRight string
+		segDirs, e := os.ReadDir(destGroupRoot)
+		if e != nil {
+			return e
+		}
+		for _, sd := range segDirs {
+			if !sd.IsDir() || !strings.HasPrefix(sd.Name(), "seg-") {
+				continue
+			}
+			segStart, perr := time.ParseInLocation("20060102", strings.TrimPrefix(sd.Name(), "seg-"), time.Local)
+			if perr != nil {
+				return fmt.Errorf("parse seg date %s: %w", sd.Name(), perr)
+			}
+			segEnd := segStart.AddDate(0, 0, warmSegDays)
+			segs[sd.Name()] = segBounds{start: segStart, end: segEnd}
+			shardDirs, _ := os.ReadDir(filepath.Join(destGroupRoot, sd.Name()))
+			for _, shd := range shardDirs {
+				if !shd.IsDir() || !strings.HasPrefix(shd.Name(), "shard-") {
+					continue
+				}
+				shardPath := filepath.Join(destGroupRoot, sd.Name(), shd.Name())
+				partDirs, _ := os.ReadDir(shardPath)
+				for _, pd := range partDirs {
+					if !pd.IsDir() {
+						continue
+					}
+					raw, rerr := os.ReadFile(filepath.Join(shardPath, pd.Name(), "metadata.json"))
+					if rerr != nil {
+						continue
+					}
+					var pm struct {
+						MinTimestamp int64 `json:"minTimestamp"`
+						MaxTimestamp int64 `json:"maxTimestamp"`
+					}
+					if jerr := json.Unmarshal(raw, &pm); jerr != nil {
+						return fmt.Errorf("parse %s/%s metadata: %w", sd.Name(), pd.Name(), jerr)
+					}
+					if pm.MinTimestamp < segStart.UnixNano() || pm.MaxTimestamp >= segEnd.UnixNano() {
+						return fmt.Errorf("part %s/%s [%d,%d] escapes seg [%d,%d)",
+							sd.Name(), pd.Name(), pm.MinTimestamp, pm.MaxTimestamp, segStart.UnixNano(), segEnd.UnixNano())
+					}
+					if within(single, pm.MinTimestamp, pm.MaxTimestamp) {
+						segSingle = sd.Name()
+					}
+					if within(left, pm.MinTimestamp, pm.MaxTimestamp) {
+						segLeft = sd.Name()
+					}
+					if within(right, pm.MinTimestamp, pm.MaxTimestamp) {
+						segRight = sd.Name()
+					}
+				}
+			}
+		}
+		if segSingle == "" || segLeft == "" || segRight == "" {
+			return fmt.Errorf("probe rows not all present in part metadata yet: single=%q left=%q right=%q", segSingle, segLeft, segRight)
+		}
+		if len(segs) != wantSegCount {
+			return fmt.Errorf("want %d target segment dirs, got %d", wantSegCount, len(segs))
+		}
+		if segSingle != segLeft {
+			return fmt.Errorf("single (%s) and left (%s) must share one target segment", segSingle, segLeft)
+		}
+		if segRight == segSingle {
+			return fmt.Errorf("right (%s) must be in a different target segment from single/left (%s)", segRight, segSingle)
+		}
+		segA, segB := segs[segSingle], segs[segRight]
+		if !segB.start.Equal(segA.end) {
+			return fmt.Errorf("segments not contiguous on the 3-day grid: %s ends %s but %s starts %s",
+				segSingle, segA.end.Format(time.RFC3339), segRight, segB.start.Format(time.RFC3339))
+		}
+		if !segA.end.After(left) || !segA.end.Before(right) {
+			return fmt.Errorf("segment boundary %s must fall strictly inside (left=%s, right=%s)",
+				segA.end.Format(time.RFC3339), left.Format(time.RFC3339), right.Format(time.RFC3339))
+		}
+		return nil
+	}, flags.EventuallyTimeout).Should(gomega.Succeed(),
+		"migrated parts must form exactly the expected contiguous target segments with correct bounds")
+}
+
+// Measure cross-segment migration regression.
+//
+// The sw_cross_segment group is 2d source / 3d target — coprime grids aligned to
+// the local-time epoch, so the source segment [Day 6k+2, Day 6k+4) always
+// straddles the target boundary at Day 6k+3 (row-replay path) while other source
+// segments stay within a single target segment (chunk-sync). We write three data
+// points (entity-a):
+//
+//	T0: t=T_SINGLE, value=100 → source seg-A (chunk-sync)  → target seg-α
+//	T1: t=T_A,      value=200 → source seg-B (row-replay) → target seg-α
+//	T2: t=T_B,      value=300 → source seg-B (row-replay) → target seg-β
+//
+// After migration the straddling source segment must split into two target
+// segments (seg-α and seg-β); pre-fix code copied every row into one segment. We
+// verify the physical part layout, the report's sync breakdown, and that each
+// timestamp returns its correct field value across same- and cross-segment
+// warm-stage queries.
+var _ = ginkgo.Describe("Measure cross-segment migration", ginkgo.Ordered, func() {
+	const (
+		crossGroup   = "sw_cross_segment"
+		crossMeasure = "cross_segment_metric"
+	)
+
+	ginkgo.It("source segments that span multiple target segments are split via row-replay", func() {
+		// === 1. Pick timestamps that exercise both single- and multi-target source segments. ===
+		// T0 sits in a single-target source segment; T1/T2 share a source segment
+		// that straddles a target boundary (left/right of the crossing).
+		singleTargetTS, crossLeftTS, crossRightTS := crossSegmentTimestamps()
+
+		ginkgo.By(fmt.Sprintf("seeding sw_cross_segment with T0=%s T1=%s T2=%s",
+			singleTargetTS.Format(time.RFC3339),
+			crossLeftTS.Format(time.RFC3339),
+			crossRightTS.Format(time.RFC3339)))
+
+		// === 2. Open a Write stream to liaison and send three rows.
+		//        SharedContext.Connection points at the data node (dataAddr); writes
+		//        must go through the liaison so it shard-locates and forwards. ===
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		liaisonConn, dialErr := grpchelper.Conn(SharedContext.LiaisonAddr, 10*time.Second,
+			grpc.WithTransportCredentials(insecure.NewCredentials()))
+		gomega.Expect(dialErr).NotTo(gomega.HaveOccurred(), "dial liaison")
+		defer func() { _ = liaisonConn.Close() }()
+		measureClient := measurev1.NewMeasureServiceClient(liaisonConn)
+		writeStream, writeErr := measureClient.Write(ctx)
+		gomega.Expect(writeErr).NotTo(gomega.HaveOccurred(), "open Write stream")
+
+		md := &commonv1.Metadata{Group: crossGroup, Name: crossMeasure}
+		sendRow := func(ts time.Time, entityID string, value int64, first bool) {
+			req := &measurev1.WriteRequest{
+				DataPoint: &measurev1.DataPointValue{
+					Timestamp: timestamppb.New(ts),
+					Version:   ts.UnixNano(),
+					TagFamilies: []*modelv1.TagFamilyForWrite{
+						{Tags: []*modelv1.TagValue{
+							{Value: &modelv1.TagValue_Str{Str: &modelv1.Str{Value: entityID}}},
+						}},
+					},
+					Fields: []*modelv1.FieldValue{
+						{Value: &modelv1.FieldValue_Int{Int: &modelv1.Int{Value: value}}},
+					},
+				},
+				MessageId: uint64(time.Now().UnixNano()),
+			}
+			if first {
+				req.Metadata = md
+			}
+			gomega.Expect(writeStream.Send(req)).To(gomega.Succeed())
+		}
+		sendRow(singleTargetTS, "entity-a", 100, true)
+		sendRow(crossLeftTS, "entity-a", 200, false)
+		sendRow(crossRightTS, "entity-a", 300, false)
+		// Collect server-side acks before CloseSend so any per-row rejection surfaces.
+		drainWriteAcks(writeStream.Recv, writeStream.CloseSend)
+		time.Sleep(flags.ConsistentlyTimeout)
+		// Diagnostic: dump the source group root so a regression makes it obvious
+		// whether the data wrote at all or whether the migration is what's missing.
+		// Layout on disk: measure/data/<group>/seg-YYYYMMDD/shard-N/...
+		srcGroupRoot := filepath.Join(SharedContext.SrcDir, "measure", "data", crossGroup)
+		srcEntries, srcErr := os.ReadDir(srcGroupRoot)
+		ginkgo.By(fmt.Sprintf("source group root %s exists=%v entries=%d err=%v",
+			srcGroupRoot, srcErr == nil, len(srcEntries), srcErr))
+		if srcErr == nil {
+			for _, e := range srcEntries {
+				ginkgo.By(fmt.Sprintf("  src entry: %s isDir=%v", e.Name(), e.IsDir()))
+			}
+		}
+
+		// === 3. Run lifecycle migration. The shared destination already holds older
+		//        migrated data from previous Describe blocks; we re-run migration so
+		//        sw_cross_segment's freshly-written parts flow hot → warm. ===
+		ginkgo.By("running lifecycle migration")
+		dir, err := os.MkdirTemp("", "lifecycle-cross-segment")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer os.RemoveAll(dir)
+		rf := filepath.Join(dir, "report")
+		runLifecycleMigration(filepath.Join(dir, "progress.json"), rf)
+
+		// === 4. Verify the destination directory contains multiple seg-* folders for
+		//        sw_cross_segment. Pre-fix, the cross-segment part would copy entirely
+		//        into one target segment, so only one seg-* folder would exist. ===
+		ginkgo.By("verifying multiple target segments were created")
+		// Layout on disk: measure/data/<group>/seg-YYYYMMDD/shard-N/...
+		destGroupRoot := filepath.Join(SharedContext.DestDir, "measure", "data", crossGroup)
+		destEntries, destErr := os.ReadDir(destGroupRoot)
+		ginkgo.By(fmt.Sprintf("dest group root %s exists=%v entries=%d err=%v",
+			destGroupRoot, destErr == nil, len(destEntries), destErr))
+		if destErr == nil {
+			for _, e := range destEntries {
+				ginkgo.By(fmt.Sprintf("  dest entry: %s isDir=%v", e.Name(), e.IsDir()))
+			}
+		}
+		// Physical-layer validation: exactly two contiguous target segments — T0 &
+		// T1 in seg-α, T2 in seg-β — with every part inside its own segment and the
+		// boundary falling between T1 and T2 (the split the pre-fix bug missed).
+		assertCrossSegmentPartMetadata(destGroupRoot, singleTargetTS, crossLeftTS, crossRightTS, 2)
+
+		// Locked sync_breakdown for this group: T0 (single-target segment) → 1
+		// chunk-sync part; T1+T2 (straddling segment, same entity_id → same
+		// source shard/part) → 1 row-replay part carrying exactly 2 rows.
+		verifyCrossSegmentReport(rf, "measure_migration", crossGroup, "chunk_sync_parts", 1, 1, 2)
+
+		// === 5. Query the warm stage and validate both placement AND values:
+		//        same-segment single/multi-row queries, the cross-segment
+		//        aggregate, and that each timestamp carries its correct field
+		//        value (a count-only check would miss a row-replay that swaps or
+		//        corrupts a field/timestamp). ===
+		ginkgo.By("querying warm stage for each timestamp")
+		queryClient := measurev1.NewMeasureServiceClient(liaisonConn)
+		runQuery := func(start, end time.Time, wantCount int) []*measurev1.DataPoint {
+			req := &measurev1.QueryRequest{
+				Groups: []string{crossGroup},
+				Name:   crossMeasure,
+				TimeRange: &modelv1.TimeRange{
+					Begin: timestamppb.New(start),
+					End:   timestamppb.New(end),
+				},
+				TagProjection: &modelv1.TagProjection{
+					TagFamilies: []*modelv1.TagProjection_TagFamily{
+						{Name: "default", Tags: []string{"entity_id"}},
+					},
+				},
+				FieldProjection: &measurev1.QueryRequest_FieldProjection{
+					Names: []string{"value"},
+				},
+				Stages: []string{"warm"},
+			}
+			var resp *measurev1.QueryResponse
+			gomega.Eventually(func() error {
+				var qErr error
+				resp, qErr = queryClient.Query(ctx, req)
+				if qErr != nil {
+					return qErr
+				}
+				if len(resp.DataPoints) != wantCount {
+					return fmt.Errorf("want %d data points, got %d", wantCount, len(resp.DataPoints))
+				}
+				return nil
+			}, flags.EventuallyTimeout).Should(gomega.Succeed())
+			return resp.DataPoints
+		}
+		// expectValues asserts the returned points are exactly the wanted
+		// timestamp(ms) -> field-value set.
+		expectValues := func(dps []*measurev1.DataPoint, want map[int64]int64, desc string) {
+			got := make(map[int64]int64, len(dps))
+			for _, dp := range dps {
+				gomega.Expect(dp.GetFields()).To(gomega.HaveLen(1), desc+": each point has one field")
+				got[dp.GetTimestamp().AsTime().UnixMilli()] = dp.GetFields()[0].GetValue().GetInt().GetValue()
+			}
+			gomega.Expect(got).To(gomega.Equal(want), desc)
+		}
+		msVal := func(t time.Time) int64 { return t.UnixMilli() }
+
+		// Q1: same-segment single row — T0 via chunk-sync, value 100.
+		expectValues(runQuery(singleTargetTS, singleTargetTS.Add(time.Millisecond), 1),
+			map[int64]int64{msVal(singleTargetTS): 100}, "Q1 single-target row")
+		// Q2: same-segment single row — T1 via row-replay (left of boundary), value 200.
+		expectValues(runQuery(crossLeftTS, crossLeftTS.Add(time.Millisecond), 1),
+			map[int64]int64{msVal(crossLeftTS): 200}, "Q2 row-replay left side")
+		// Q3: same-segment single row — T2 via row-replay (right of boundary, the
+		//     segment the pre-fix bug failed to create), value 300.
+		expectValues(runQuery(crossRightTS, crossRightTS.Add(time.Millisecond), 1),
+			map[int64]int64{msVal(crossRightTS): 300}, "Q3 row-replay right side")
+		// Q5: same-segment MULTI-row — [T0,T1] both land in one target segment
+		//     (T0 chunk-sync + T1 row-replay); the query must return both.
+		expectValues(runQuery(singleTargetTS, crossLeftTS.Add(time.Millisecond), 2),
+			map[int64]int64{msVal(singleTargetTS): 100, msVal(crossLeftTS): 200},
+			"Q5 same-segment two rows (chunk-sync + row-replay co-located)")
+		// Q4: cross-segment aggregate — [T0,T2] spans both target segments; must
+		//     return all 3 rows with correct values.
+		expectValues(runQuery(singleTargetTS, crossRightTS.Add(time.Millisecond), 3),
+			map[int64]int64{msVal(singleTargetTS): 100, msVal(crossLeftTS): 200, msVal(crossRightTS): 300},
+			"Q4 cross-segment aggregate")
+	})
+})
+
+// Stream cross-segment migration regression and ElementID consistency.
+//
+// Combines chunk-sync vs row-replay distribution and raw_element_id
+// path consistency. The sw_cross_segment_stream group is 2d source / 3d target, same
+// coprime layout as the measure variant. We write three elements:
+//
+//	E0: t=T_SINGLE, eid="shared-id"   → source seg-A (chunk-sync)  → target seg-α
+//	E1: t=T_A,      eid="shared-id"   → source seg-B (row-replay) → target seg-α
+//	E2: t=T_B,      eid="other-id"    → source seg-B (row-replay) → target seg-β
+//
+// After migration the warm-stage query layer dedups by storage eID
+// (query_by_ts.go:255). Without the raw_element_id fix, E0 (via chunk-sync) and E1
+// (via row-replay) would land at the target with different eIDs and the query would
+// return 2 rows for "shared-id" instead of 1. The fix forces both paths to keep
+// the source-side uint64 eID so dedup converges.
+var _ = ginkgo.Describe("Stream cross-segment migration", ginkgo.Ordered, func() {
+	const (
+		streamGroup    = "sw_cross_segment_stream"
+		streamResource = "cross_segment_log"
+	)
+
+	ginkgo.It("stream cross-segment + raw_element_id consistency", func() {
+		singleTargetTS, crossLeftTS, crossRightTS := crossSegmentTimestamps()
+		ginkgo.By(fmt.Sprintf("seeding stream with T_SINGLE=%s T_A=%s T_B=%s",
+			singleTargetTS.Format(time.RFC3339),
+			crossLeftTS.Format(time.RFC3339),
+			crossRightTS.Format(time.RFC3339)))
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		liaisonConn, dialErr := grpchelper.Conn(SharedContext.LiaisonAddr, 10*time.Second,
+			grpc.WithTransportCredentials(insecure.NewCredentials()))
+		gomega.Expect(dialErr).NotTo(gomega.HaveOccurred())
+		defer func() { _ = liaisonConn.Close() }()
+		streamClient := streamv1.NewStreamServiceClient(liaisonConn)
+		writeStream, writeErr := streamClient.Write(ctx)
+		gomega.Expect(writeErr).NotTo(gomega.HaveOccurred())
+
+		md := &commonv1.Metadata{Group: streamGroup, Name: streamResource}
+		sendElement := func(ts time.Time, elementID, businessID, entityID string, first bool) {
+			req := &streamv1.WriteRequest{
+				Element: &streamv1.ElementValue{
+					ElementId: elementID,
+					Timestamp: timestamppb.New(ts),
+					TagFamilies: []*modelv1.TagFamilyForWrite{
+						{Tags: []*modelv1.TagValue{
+							{Value: &modelv1.TagValue_Str{Str: &modelv1.Str{Value: businessID}}},
+							{Value: &modelv1.TagValue_Str{Str: &modelv1.Str{Value: entityID}}},
+						}},
+					},
+				},
+				MessageId: uint64(time.Now().UnixNano()),
+			}
+			if first {
+				req.Metadata = md
+			}
+			gomega.Expect(writeStream.Send(req)).To(gomega.Succeed())
+		}
+		sendElement(singleTargetTS, "shared-id", "biz-shared", "ent-1", true)
+		sendElement(crossLeftTS, "shared-id", "biz-shared", "ent-2", false)
+		sendElement(crossRightTS, "other-id", "biz-other", "ent-1", false)
+		drainWriteAcks(writeStream.Recv, writeStream.CloseSend)
+		time.Sleep(flags.ConsistentlyTimeout)
+
+		ginkgo.By("running stream lifecycle migration")
+		tmpDir, err := os.MkdirTemp("", "lifecycle-stream-cross")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer os.RemoveAll(tmpDir)
+		runLifecycleMigration(filepath.Join(tmpDir, "progress.json"), filepath.Join(tmpDir, "report"))
+
+		ginkgo.By("verifying physical target segment part metadata + cross-path eID dedup")
+		destGroupRoot := filepath.Join(SharedContext.DestDir, "stream", "data", streamGroup)
+		// Physical-layer validation: exactly two contiguous target segments — E0+E1
+		// (T_SINGLE & T_A) in seg-α, E2 (T_B) in seg-β — with every part inside its
+		// own segment and the boundary falling between T_A and T_B.
+		assertCrossSegmentPartMetadata(destGroupRoot, singleTargetTS, crossLeftTS, crossRightTS, 2)
+
+		// Locked sync_breakdown: E0 → 1 chunk-sync part; E1+E2 (straddling
+		// segment, same entity_id → same source shard/part) → 1 row-replay part
+		// carrying exactly 2 rows.
+		verifyCrossSegmentReport(filepath.Join(tmpDir, "report"), "stream_migration", streamGroup, "chunk_sync_parts", 1, 1, 2)
+
+		queryClient := streamv1.NewStreamServiceClient(liaisonConn)
+		// runStreamQuery issues a warm-stage query ordered by timestamp; an empty
+		// index-rule name plus the given sort means "sort by event time"
+		// (SORT_UNSPECIFIED is the server default, ascending). It waits until exactly
+		// wantCount elements are returned.
+		runStreamQuery := func(start, end time.Time, sort modelv1.Sort, wantCount int) []*streamv1.Element {
+			req := &streamv1.QueryRequest{
+				Groups: []string{streamGroup},
+				Name:   streamResource,
+				TimeRange: &modelv1.TimeRange{
+					Begin: timestamppb.New(start),
+					End:   timestamppb.New(end),
+				},
+				Projection: &modelv1.TagProjection{
+					TagFamilies: []*modelv1.TagProjection_TagFamily{
+						{Name: "searchable", Tags: []string{"business_id", "entity_id"}},
+					},
+				},
+				OrderBy: &modelv1.QueryOrder{Sort: sort},
+				Stages:  []string{"warm"},
+			}
+			var resp *streamv1.QueryResponse
+			gomega.Eventually(func() error {
+				var qErr error
+				resp, qErr = queryClient.Query(ctx, req)
+				if qErr != nil {
+					return qErr
+				}
+				if len(resp.Elements) != wantCount {
+					return fmt.Errorf("want %d elements, got %d", wantCount, len(resp.Elements))
+				}
+				return nil
+			}, flags.EventuallyTimeout).Should(gomega.Succeed())
+			return resp.Elements
+		}
+		// Stream stores element_id as a derived (hashed) identifier, so we assert
+		// the tag values plus element_id distinctness/consistency rather than the
+		// raw client-supplied string.
+		tagsOf := func(el *streamv1.Element) [2]string {
+			var biz, ent string
+			for _, tf := range el.GetTagFamilies() {
+				for _, tg := range tf.GetTags() {
+					switch tg.GetKey() {
+					case "business_id":
+						biz = tg.GetValue().GetStr().GetValue()
+					case "entity_id":
+						ent = tg.GetValue().GetStr().GetValue()
+					}
+				}
+			}
+			return [2]string{biz, ent}
+		}
+		// Q1 (eID consistency core): "shared-id" written via chunk-sync (T_SINGLE) +
+		// row-replay (T_A) must dedup to a single element with intact tags.
+		q1 := runStreamQuery(singleTargetTS, crossLeftTS.Add(time.Millisecond), modelv1.Sort_SORT_UNSPECIFIED, 1)
+		gomega.Expect(tagsOf(q1[0])).To(gomega.Equal([2]string{"biz-shared", "ent-1"}),
+			"Q1 shared-id dedup across chunk-sync+row-replay keeps tags intact (proves raw_element_id fix)")
+		sharedID := q1[0].GetElementId()
+		// Q2 (row-replay other-id): T_B alone returns 1 element with its own tags.
+		q2 := runStreamQuery(crossRightTS, crossRightTS.Add(time.Millisecond), modelv1.Sort_SORT_UNSPECIFIED, 1)
+		gomega.Expect(tagsOf(q2[0])).To(gomega.Equal([2]string{"biz-other", "ent-1"}),
+			"Q2 other-id row-replay right side keeps tags intact")
+		otherID := q2[0].GetElementId()
+		gomega.Expect(sharedID).NotTo(gomega.Equal(otherID),
+			"shared-id and other-id must be distinct logical elements")
+		// Q3 (cross-segment aggregate): exactly the two distinct elements, tags intact.
+		q3 := runStreamQuery(singleTargetTS, crossRightTS.Add(time.Millisecond), modelv1.Sort_SORT_UNSPECIFIED, 2)
+		gotElements := make(map[string][2]string, len(q3))
+		for _, el := range q3 {
+			gotElements[el.GetElementId()] = tagsOf(el)
+		}
+		gomega.Expect(gotElements).To(gomega.Equal(map[string][2]string{
+			sharedID: {"biz-shared", "ent-1"},
+			otherID:  {"biz-other", "ent-1"},
+		}), "Q3 cross-segment aggregate must return shared-id (deduped) + other-id with intact tags")
+
+		// Q4: "shared-id" exists under two entity_ids (ent-1 @T_SINGLE, ent-2 @T_A)
+		// sharing one eID, so a range covering both dedups to ONE element — stably the
+		// T_SINGLE row, regardless of sort. (+1ms: query timestamps must be ms-aligned.)
+		q4 := runStreamQuery(singleTargetTS, crossLeftTS.Add(time.Millisecond), modelv1.Sort_SORT_ASC, 1)
+		gomega.Expect(tagsOf(q4[0])[1]).To(gomega.Equal("ent-1"),
+			"Q4 cross-entity same-eID dedup keeps the T_SINGLE (chunk-sync) row")
+		gomega.Expect(q4[0].GetTimestamp().AsTime().UnixMilli()).To(gomega.Equal(singleTargetTS.UnixMilli()),
+			"Q4 survivor carries the T_SINGLE timestamp")
+	})
+})
+
+// Trace cross-segment migration regression.
+//
+// The sw_cross_segment_trace group is 2d source / 3d target, same coprime layout
+// as the measure variant. Trace routing is by traceID hash (not entity hash), so
+// the cross-segment guard depends only on the source-segment time range
+// straddling target boundaries. trace-1 carries two spans (a chunk-sync copy and
+// a row-replay span) in seg-α; trace-2 carries one row-replay span in seg-β:
+//
+//	span-1: t=T_SINGLE, trace-1 → source seg-A (chunk-sync)  → target seg-α
+//	span-2: t=T_A,      trace-1 → source seg-B (row-replay) → target seg-α
+//	span-3: t=T_B,      trace-2 → source seg-B (row-replay) → target seg-β
+//
+// After migration we validate physically that the straddling source segment is
+// split into two target segments (span-1 & span-2 in seg-α, span-3 in seg-β) and,
+// via warm-stage queries, that trace-1 surfaces BOTH its chunk-sync and row-replay
+// spans and a cross-segment range returns both distinct traces.
+var _ = ginkgo.Describe("Trace cross-segment migration", ginkgo.Ordered, func() {
+	const (
+		traceGroup    = "sw_cross_segment_trace"
+		traceResource = "cross_segment_trace_item"
+	)
+
+	ginkgo.It("trace cross-segment row-replay routes spans by per-row timestamp", func() {
+		singleTargetTS, crossLeftTS, crossRightTS := crossSegmentTimestamps()
+		ginkgo.By(fmt.Sprintf("seeding trace with T_SINGLE=%s T_A=%s T_B=%s",
+			singleTargetTS.Format(time.RFC3339),
+			crossLeftTS.Format(time.RFC3339),
+			crossRightTS.Format(time.RFC3339)))
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		liaisonConn, dialErr := grpchelper.Conn(SharedContext.LiaisonAddr, 10*time.Second,
+			grpc.WithTransportCredentials(insecure.NewCredentials()))
+		gomega.Expect(dialErr).NotTo(gomega.HaveOccurred())
+		defer func() { _ = liaisonConn.Close() }()
+		traceClient := tracev1.NewTraceServiceClient(liaisonConn)
+		writeStream, writeErr := traceClient.Write(ctx)
+		gomega.Expect(writeErr).NotTo(gomega.HaveOccurred())
+
+		md := &commonv1.Metadata{Group: traceGroup, Name: traceResource}
+		sendSpan := func(ts time.Time, traceID, spanID string, version uint64, first bool) {
+			tags := []*modelv1.TagValue{
+				{Value: &modelv1.TagValue_Str{Str: &modelv1.Str{Value: traceID}}},
+				{Value: &modelv1.TagValue_Str{Str: &modelv1.Str{Value: spanID}}},
+				{Value: &modelv1.TagValue_Timestamp{Timestamp: timestamppb.New(ts)}},
+			}
+			req := &tracev1.WriteRequest{
+				Tags:    tags,
+				Span:    []byte("span-" + spanID),
+				Version: version,
+			}
+			if first {
+				req.Metadata = md
+			}
+			gomega.Expect(writeStream.Send(req)).To(gomega.Succeed())
+		}
+		sendSpan(singleTargetTS, "trace-1", "span-1", 1, true)
+		sendSpan(crossLeftTS, "trace-1", "span-2", 2, false)
+		sendSpan(crossRightTS, "trace-2", "span-3", 3, false)
+		drainWriteAcks(writeStream.Recv, writeStream.CloseSend)
+		time.Sleep(flags.ConsistentlyTimeout)
+
+		ginkgo.By("running trace lifecycle migration")
+		tmpDir, err := os.MkdirTemp("", "lifecycle-trace-cross")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer os.RemoveAll(tmpDir)
+		runLifecycleMigration(filepath.Join(tmpDir, "progress.json"), filepath.Join(tmpDir, "report"))
+
+		ginkgo.By("verifying physical trace target segment part metadata")
+		// Trace row-replay publishes per-row InternalWriteRequests; the receiver's
+		// writeCallback must place each row in the target segment matching its
+		// timestamp. We validate physically (every part's metadata.json range stays
+		// inside its own segment, span-1 & span-2 share one target segment, span-3
+		// lands in a different one) and then via warm-stage queries below.
+		destGroupRoot := filepath.Join(SharedContext.DestDir, "trace", "data", traceGroup)
+		// Exactly two contiguous target segments — span-1 & span-2 in seg-α, span-3
+		// in seg-β — with every part inside its own segment and the boundary falling
+		// between T_A and T_B.
+		assertCrossSegmentPartMetadata(destGroupRoot, singleTargetTS, crossLeftTS, crossRightTS, 2)
+
+		// Locked sync_breakdown: span-1 (single-target segment) → 1 chunk-sync
+		// shard; span-2+span-3 (straddling segment, shard_num=1 → both in source
+		// shard 0 → 1 part) → 1 row-replay part carrying exactly 2 rows.
+		verifyCrossSegmentReport(filepath.Join(tmpDir, "report"), "trace_migration", traceGroup, "chunk_sync_shards", 1, 1, 2)
+
+		// Query the warm stage and validate both placement AND span identity:
+		// per-timestamp single-span queries, the same-segment multi-span query,
+		// and the cross-segment aggregate. The OrderBy timestamp index rule lets a
+		// pure time-range query return every span in range (no trace_id filter).
+		ginkgo.By("querying warm stage for trace spans")
+		queryClient := tracev1.NewTraceServiceClient(liaisonConn)
+		runTraceQuery := func(start, end time.Time, wantCount int) []*tracev1.Trace {
+			req := &tracev1.QueryRequest{
+				Groups: []string{traceGroup},
+				Name:   traceResource,
+				TimeRange: &modelv1.TimeRange{
+					Begin: timestamppb.New(start),
+					End:   timestamppb.New(end),
+				},
+				TagProjection: []string{"trace_id", "span_id"},
+				OrderBy: &modelv1.QueryOrder{
+					IndexRuleName: "cross_segment_timestamp",
+					Sort:          modelv1.Sort_SORT_ASC,
+				},
+				Stages: []string{"warm"},
+			}
+			var resp *tracev1.QueryResponse
+			gomega.Eventually(func() error {
+				var qErr error
+				resp, qErr = queryClient.Query(ctx, req)
+				if qErr != nil {
+					return qErr
+				}
+				if len(resp.Traces) != wantCount {
+					return fmt.Errorf("want %d traces, got %d", wantCount, len(resp.Traces))
+				}
+				return nil
+			}, flags.EventuallyTimeout).Should(gomega.Succeed())
+			return resp.Traces
+		}
+		// expectSpans asserts the returned trace_id -> sorted span_id set, catching a
+		// row-replay that drops a span, corrupts an id, or misroutes a segment.
+		expectSpans := func(traces []*tracev1.Trace, want map[string][]string, desc string) {
+			got := make(map[string][]string, len(traces))
+			for _, tr := range traces {
+				ids := make([]string, 0, len(tr.GetSpans()))
+				for _, sp := range tr.GetSpans() {
+					ids = append(ids, sp.GetSpanId())
+				}
+				sort.Strings(ids)
+				got[tr.GetTraceId()] = ids
+			}
+			gomega.Expect(got).To(gomega.Equal(want), desc)
+		}
+		// trace-1 carries span-1 (copy/chunk-sync @T_SINGLE) and span-2 (row-replay
+		// @T_A), both in seg-α; trace-2 carries span-3 (row-replay @T_B) in seg-β. A
+		// trace query returns the full matching trace within the scanned segment(s),
+		// so any window overlapping trace-1 returns BOTH its spans.
+		// Q1: copy span's window -> trace-1 with both spans (copy + replay).
+		expectSpans(runTraceQuery(singleTargetTS, singleTargetTS.Add(time.Millisecond), 1),
+			map[string][]string{"trace-1": {"span-1", "span-2"}},
+			"Q1 copy-span window returns trace-1's copy + replay spans")
+		// Q2: replay span's window -> the SAME full trace-1, proving the copy span is
+		// reachable from the replay span's window too.
+		expectSpans(runTraceQuery(crossLeftTS, crossLeftTS.Add(time.Millisecond), 1),
+			map[string][]string{"trace-1": {"span-1", "span-2"}},
+			"Q2 replay-span window also returns both of trace-1's spans")
+		// Q3: window covering both of trace-1's span timestamps -> still both spans.
+		expectSpans(runTraceQuery(singleTargetTS, crossLeftTS.Add(time.Millisecond), 1),
+			map[string][]string{"trace-1": {"span-1", "span-2"}},
+			"Q3 [T_SINGLE,T_A] returns trace-1 with both spans")
+		// Q4: seg-β window -> isolated trace-2 with its row-replay span.
+		expectSpans(runTraceQuery(crossRightTS, crossRightTS.Add(time.Millisecond), 1),
+			map[string][]string{"trace-2": {"span-3"}}, "Q4 isolated trace-2 (row-replay)")
+		// Q5: cross-segment range -> both distinct traces (trace-1 with 2 spans,
+		// trace-2 with 1).
+		expectSpans(runTraceQuery(singleTargetTS, crossRightTS.Add(time.Millisecond), 2),
+			map[string][]string{"trace-1": {"span-1", "span-2"}, "trace-2": {"span-3"}},
+			"Q5 cross-segment aggregate (2 distinct traces)")
+	})
+})

--- a/test/cases/lifecycle/lifecycle.go
+++ b/test/cases/lifecycle/lifecycle.go
@@ -21,7 +21,9 @@ package lifecycle_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -522,26 +524,20 @@ func runLifecycleMigration(progressFile, reportDir string) {
 	gomega.Expect(lifecycleCmd.Execute()).To(gomega.Succeed())
 }
 
-// drainWriteAcks closes a client-streaming write and fails the spec if any
-// server-side ack reports a non-success status, surfacing per-row rejections
-// that a bare CloseSend would swallow.
+// drainWriteAcks closes a client-streaming write and fails the spec on any
+// non-success ack or non-EOF stream error, surfacing per-row rejections and
+// server-side stream failures that a bare CloseSend would swallow.
 func drainWriteAcks[R interface{ GetStatus() string }](recv func() (R, error), closeSend func() error) {
-	ackErrs := make(chan error, 8)
-	go func() {
-		defer close(ackErrs)
-		for {
-			resp, recvErr := recv()
-			if recvErr != nil {
-				return
-			}
-			if status := resp.GetStatus(); status != "" && status != "STATUS_SUCCEED" {
-				ackErrs <- fmt.Errorf("write rejected: %s", status)
-			}
-		}
-	}()
 	gomega.Expect(closeSend()).To(gomega.Succeed())
-	for ackErr := range ackErrs {
-		gomega.Expect(ackErr).NotTo(gomega.HaveOccurred(), "write ack must succeed")
+	for {
+		resp, recvErr := recv()
+		if errors.Is(recvErr, io.EOF) {
+			return
+		}
+		gomega.Expect(recvErr).NotTo(gomega.HaveOccurred(), "write stream recv must not fail")
+		if status := resp.GetStatus(); status != "" {
+			gomega.Expect(status).To(gomega.Equal("STATUS_SUCCEED"), "write ack must succeed")
+		}
 	}
 }
 


### PR DESCRIPTION
## Why

  The lifecycle migration moves expired data from one stage to the next (hot → warm → cold). Each stage may define a **different `segment_interval`**. The original migration copied whole part files into
   a single target segment chosen from the part's timestamp (the "chunk-sync" path). That is only correct when every source part falls entirely inside one target segment.

  When the source and target segment intervals are **not multiples of each other** (their day-grids don't align — e.g. a 5-day source interval migrating into 7-day target segments), a single source
  part's rows can **straddle a target segment boundary**. Chunk-copying such a part dumps **all** of its rows into one target segment, so the rows that belong to the adjacent segment end up in the wrong
   place: the migrated part's `[minTimestamp, maxTimestamp]` escapes its target segment's `[start, start+interval)` bounds. This produces mis-segmented data and breaks per-segment assumptions for later
  queries and retention.

  ## What

  Detect source parts that cross a target segment boundary and migrate them with **row-level replay** instead of a file copy:

  - **Part fully inside one target segment** → unchanged fast **chunk-sync** (copies the part file).
  - **Part spanning ≥2 target segments** → **row-replay**: re-publish each row so the receiving node routes it to the target segment that matches the row's own timestamp. No row lands in the wrong
  segment.

  ### Supporting changes
  - **Per-part flush-and-confirm**: each migrated part is flushed and its server-side acks confirmed before it is marked complete (the batch publisher is closed/reopened per part), so a part is only
  recorded as migrated once it is durably delivered; on failure it is recorded as an error instead of silently lost.
  - **Source-segment completion key**: migration progress is keyed on the *source* segment instead of the target, fixing a collision where multiple source segments mapping to one target segment could be
   wrongly treated as already-migrated.
  - **`raw_element_id` consistency (stream)**: a new `raw_element_id` is carried through row-replay so an element migrated via both chunk-sync and row-replay keeps one storage element id; the warm-stage
   query dedup then converges to a single row instead of duplicating it.
  - **Migration report** now breaks down `chunk_sync` vs `row_replay` parts/rows per group so the path taken is observable.

  ## Tests
  - New `row_replay_*` unit tests for the per-type replayers and progress tracking.
  - Distributed e2e (`TestPropertyLifecycle`): added measure / stream / trace cross-segment specs that seed boundary-straddling data, run the migration, and verify (a) the **physical** layout — every
  migrated part stays within its own target segment, segments split correctly, exact segment count + contiguous boundaries — and (b) the **gRPC query** results from the warm stage (per-timestamp,
  same-segment, and cross-segment aggregate). Stream specs also assert `raw_element_id` dedup; trace adds a `cross_segment_timestamp` index rule so warm-stage queries are verifiable.
  - `make lint`, lifecycle unit tests, and the distributed e2e (5/5) all pass.


- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Fixes apache/skywalking#<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-banyandb/blob/main/CHANGES.md).
