### PR TITLE
Add vectorized pull-mode trace query pipeline

### DIFF
--- a/banyand/internal/sidx/block_scanner.go
+++ b/banyand/internal/sidx/block_scanner.go
@@ -218,6 +218,101 @@ func (bsn *blockScanner) scan(ctx context.Context, blockCh chan *blockScanResult
 	releaseBlockScanResultBatch(batch)
 }
 
+func (bsn *blockScanner) scanSync(ctx context.Context, consume func(*blockScanResultBatch) error) error {
+	if len(bsn.parts) < 1 {
+		return nil
+	}
+	if !bsn.checkContext(ctx) {
+		return ctx.Err()
+	}
+
+	var (
+		totalBlockBytes uint64
+		scannedBlocks   int
+	)
+
+	var skipRecorder blockSkipRecorderFunc
+	if tracer := query.GetTracer(ctx); tracer != nil {
+		span, spanCtx := tracer.StartSpan(ctx, "sidx.scan-blocks")
+		bsn.span = span
+		ctx = spanCtx
+		skipRecorder = bsn.recordSkip
+		span.Tagf("part_count", "%d", len(bsn.parts))
+		span.Tagf("series_id_count", "%d", len(bsn.seriesIDs))
+		span.Tagf("min_key", "%d", bsn.minKey)
+		span.Tagf("max_key", "%d", bsn.maxKey)
+		span.Tagf("ascending", "%t", bsn.asc)
+		span.Tagf("batch_size", "%d", bsn.batchSize)
+		defer func() {
+			if span != nil {
+				span.Tagf("scanned_blocks", "%d", scannedBlocks)
+				span.Tagf("total_block_bytes", "%d", totalBlockBytes)
+				bsn.flushSkipSummaryToSpan()
+				span.Stop()
+			}
+		}()
+	}
+
+	it := generateIter()
+	defer releaseIter(it)
+
+	it.init(bsn.parts, bsn.seriesIDs, bsn.minKey, bsn.maxKey, bsn.filter, bsn.asc, skipRecorder)
+	batch := generateBlockScanResultBatch()
+	if it.Error() != nil {
+		batch.err = fmt.Errorf("cannot init iter: %w", it.Error())
+		return consume(batch)
+	}
+
+	batchThreshold := bsn.batchSize
+	if batchThreshold <= 0 {
+		batchThreshold = blockScannerBatchSize
+	}
+
+	for it.nextBlock() {
+		if !bsn.checkContext(ctx) {
+			releaseBlockScanResultBatch(batch)
+			return ctx.Err()
+		}
+
+		bm, p := it.current()
+		if err := bsn.validateBlockMetadata(bm, p, it); err != nil {
+			batch.err = err
+			return consume(batch)
+		}
+
+		blockSize := bm.uncompressedSize
+		if exceeded, err := bsn.checkQuotaExceeded(totalBlockBytes, blockSize, batch); exceeded {
+			if err != nil {
+				batch.err = err
+			}
+			return consume(batch)
+		}
+
+		bsn.addBlockToBatch(batch, bm, p)
+		totalBlockBytes += blockSize
+		scannedBlocks++
+
+		if len(batch.bss) >= batchThreshold || len(batch.bss) >= cap(batch.bss) {
+			if consumeErr := consume(batch); consumeErr != nil {
+				return consumeErr
+			}
+			batch = generateBlockScanResultBatch()
+		}
+	}
+
+	if it.Error() != nil {
+		batch.err = fmt.Errorf("cannot iterate iter: %w", it.Error())
+		return consume(batch)
+	}
+
+	if len(batch.bss) > 0 {
+		return consume(batch)
+	}
+
+	releaseBlockScanResultBatch(batch)
+	return nil
+}
+
 // checkContext returns false if context is canceled.
 func (bsn *blockScanner) checkContext(ctx context.Context) bool {
 	select {

--- a/banyand/internal/sidx/interfaces.go
+++ b/banyand/internal/sidx/interfaces.go
@@ -70,6 +70,8 @@ type SIDX interface {
 	// The returned QueryResponse channel contains ordered batches limited by req.MaxBatchSize
 	// unique Data elements (when positive). The error channel delivers any fatal execution error.
 	StreamingQuery(ctx context.Context, req QueryRequest) (<-chan *QueryResponse, <-chan error)
+	// QuerySync executes the query synchronously and returns all matching responses.
+	QuerySync(ctx context.Context, req QueryRequest) ([]*QueryResponse, error)
 	// ScanQuery executes a synchronous full scan query without requiring series IDs.
 	// It scans all blocks in parts sequentially and applies filters to each row.
 	// Returns a slice of QueryResponse objects containing all matching results.
@@ -191,12 +193,10 @@ func (qr *QueryResponse) Validate() error {
 func (qr *QueryResponse) CopyFrom(other *QueryResponse) {
 	qr.Error = other.Error
 
-	// Copy parallel arrays
 	qr.Keys = append(qr.Keys[:0], other.Keys...)
 	qr.SIDs = append(qr.SIDs[:0], other.SIDs...)
 	qr.PartIDs = append(qr.PartIDs[:0], other.PartIDs...)
 
-	// Deep copy data
 	if cap(qr.Data) < len(other.Data) {
 		qr.Data = make([][]byte, len(other.Data))
 	} else {
@@ -206,35 +206,19 @@ func (qr *QueryResponse) CopyFrom(other *QueryResponse) {
 		qr.Data[i] = append(qr.Data[i][:0], data...)
 	}
 
-	// Copy metadata
 	qr.Metadata = other.Metadata
 }
 
 // Stats contains system statistics and performance metrics.
 type Stats struct {
-	// MemoryUsageBytes tracks current memory usage
 	MemoryUsageBytes int64
-
-	// DiskUsageBytes tracks current disk usage
-	DiskUsageBytes int64
-
-	// ElementCount tracks total number of elements
-	ElementCount int64
-
-	// PartCount tracks number of parts (memory + disk)
-	PartCount int64
-
-	// QueryCount tracks total queries executed
-	QueryCount atomic.Int64
-
-	// WriteCount tracks total write operations
-	WriteCount atomic.Int64
-
-	// LastFlushTime tracks when last flush occurred
-	LastFlushTime int64
-
-	// LastMergeTime tracks when last merge occurred
-	LastMergeTime int64
+	DiskUsageBytes   int64
+	ElementCount     int64
+	PartCount        int64
+	QueryCount       atomic.Int64
+	WriteCount       atomic.Int64
+	LastFlushTime    int64
+	LastMergeTime    int64
 }
 
 // ResponseMetadata provides query execution information for monitoring and debugging.
@@ -339,7 +323,6 @@ func (wr WriteRequest) Validate() error {
 	if len(wr.Data) == 0 {
 		return fmt.Errorf("data cannot be empty")
 	}
-	// Validate tags if present
 	for i, tag := range wr.Tags {
 		if tag.Name == "" {
 			return fmt.Errorf("tag[%d] name cannot be empty", i)
@@ -356,7 +339,6 @@ func (qr QueryRequest) Validate() error {
 	if qr.MaxBatchSize < 0 {
 		return fmt.Errorf("maxBatchSize cannot be negative")
 	}
-	// Validate key range
 	if qr.MinKey != nil && qr.MaxKey != nil && *qr.MinKey > *qr.MaxKey {
 		return fmt.Errorf("MinKey cannot be greater than MaxKey")
 	}
@@ -395,7 +377,6 @@ func (qr *QueryRequest) Reset() {
 
 // CopyFrom copies the QueryRequest from other to qr.
 func (qr *QueryRequest) CopyFrom(other *QueryRequest) {
-	// Deep copy for SeriesIDs if it's a slice
 	if other.SeriesIDs != nil {
 		qr.SeriesIDs = make([]common.SeriesID, len(other.SeriesIDs))
 		copy(qr.SeriesIDs, other.SeriesIDs)
@@ -406,7 +387,6 @@ func (qr *QueryRequest) CopyFrom(other *QueryRequest) {
 	qr.Filter = other.Filter
 	qr.Order = other.Order
 
-	// Deep copy if TagProjection is a slice
 	if other.TagProjection != nil {
 		qr.TagProjection = make([]model.TagProjection, len(other.TagProjection))
 		copy(qr.TagProjection, other.TagProjection)
@@ -416,7 +396,6 @@ func (qr *QueryRequest) CopyFrom(other *QueryRequest) {
 
 	qr.MaxBatchSize = other.MaxBatchSize
 
-	// Copy key range pointers
 	if other.MinKey != nil {
 		minKey := *other.MinKey
 		qr.MinKey = &minKey
@@ -443,101 +422,3 @@ func (qr *QueryRequest) CopyFrom(other *QueryRequest) {
 		qr.MaxTimestamp = nil
 	}
 }
-
-// Interface Usage Examples and Best Practices
-//
-// These examples demonstrate how the component interfaces work together and can be used
-// independently for testing, mocking, and modular implementations.
-
-// Example: Using Writer interface independently
-//
-//	writer := NewWriter(options)
-//	reqs := []WriteRequest{
-//		{SeriesID: 1, Key: 100, Data: []byte("data1")},
-//		{SeriesID: 1, Key: 101, Data: []byte("data2")},
-//	}
-//	if err := writer.Write(ctx, reqs); err != nil {
-//		log.Fatalf("write failed: %v", err)
-//	}
-
-// Example: Using StreamingQuery interface independently
-//
-//	querier := NewQuerier(options)
-//	req := QueryRequest{
-//		Name: "my-index",
-//		Filter: createKeyRangeFilter(100, 200),
-//		Order: &index.OrderBy{Sort: modelv1.Sort_SORT_ASC},
-//	}
-//	resultsCh, errCh := querier.StreamingQuery(ctx, req)
-//	for batch := range resultsCh {
-//		if batch.Error != nil {
-//			log.Printf("query execution error: %v", batch.Error)
-//		}
-//		// Process batch.Keys, batch.Data, batch.Tags, etc.
-//	}
-//	if err := <-errCh; err != nil {
-//		log.Fatalf("query failed: %v", err)
-//	}
-
-// Example: Interface composition in SIDX
-//
-//	type sidxImpl struct {
-//		writer  Writer
-//		querier Querier
-//		flusher Flusher
-//		merger  Merger
-//	}
-//
-//	func (s *sidxImpl) Write(ctx context.Context, reqs []WriteRequest) error {
-//		return s.writer.Write(ctx, reqs)
-//	}
-//
-//	func (s *sidxImpl) StreamingQuery(ctx context.Context, req QueryRequest) (<-chan *QueryResponse, <-chan error) {
-//		return s.querier.StreamingQuery(ctx, req)
-//	}
-//
-//	func (s *sidxImpl) Flush() error {
-//		return s.flusher.Flush()
-//	}
-//
-//	func (s *sidxImpl) Merge() error {
-//		return s.merger.Merge()
-//	}
-
-// Example: Mock implementations for testing
-//
-//	type mockWriter struct {
-//		writeFunc func(context.Context, []WriteRequest) error
-//	}
-//
-//	func (m *mockWriter) Write(ctx context.Context, reqs []WriteRequest) error {
-//		if m.writeFunc != nil {
-//			return m.writeFunc(ctx, reqs)
-//		}
-//		return nil
-//	}
-//
-//	// Test usage
-//	writer := &mockWriter{
-//		writeFunc: func(ctx context.Context, reqs []WriteRequest) error {
-//			// Custom test logic
-//			return nil
-//		},
-//	}
-
-//nolint:godot
-// Interface Design Principles.
-//
-// 1. **Single Responsibility**: Each interface has a focused, well-defined purpose.
-// 2. **Minimal Surface Area**: Interfaces expose only essential methods
-// 3. **Composability**: Interfaces can be combined to create larger systems
-// 4. **Testability**: Small interfaces are easy to mock and test
-// 5. **Modularity**: Implementations can be swapped independently
-// 6. **Documentation**: Clear contracts and usage examples
-//
-// Interface Decoupling Benefits:
-// - Independent testing of components
-// - Easy mocking for unit tests
-// - Flexible implementation strategies
-// - Clear separation of concerns
-// - Simplified dependency injection

--- a/banyand/internal/sidx/query.go
+++ b/banyand/internal/sidx/query.go
@@ -55,6 +55,42 @@ func (s *sidx) StreamingQuery(ctx context.Context, req QueryRequest) (<-chan *Qu
 	return resultsCh, errCh
 }
 
+// QuerySync executes the query synchronously without spawning scanner or cursor workers.
+func (s *sidx) QuerySync(ctx context.Context, req QueryRequest) ([]*QueryResponse, error) {
+	if validateErr := req.Validate(); validateErr != nil {
+		return nil, validateErr
+	}
+	s.totalQueries.Add(1)
+
+	var queryErr error
+	ctx, span := startStreamingSpan(ctx, req)
+	defer func() {
+		finalizeStreamingSpan(span, &queryErr)
+	}()
+
+	snap := s.currentSnapshot()
+	if snap == nil {
+		if span != nil {
+			span.Tag("snapshot", "nil")
+		}
+		return nil, nil
+	}
+	defer snap.decRef() //nolint:contextcheck // reference counting cleanup does not require context.
+
+	resources, ok := s.prepareSyncResources(ctx, req, snap, span)
+	if !ok {
+		return nil, nil
+	}
+	defer resources.cleanup()
+
+	results, processErr := s.processSyncLoop(ctx, req, resources)
+	if processErr != nil {
+		queryErr = processErr
+		return nil, processErr
+	}
+	return results, nil
+}
+
 type batchMetrics struct {
 	totalBlocksScanned    int
 	totalCursorsCreated   int
@@ -106,6 +142,14 @@ func (s *sidx) runStreamingQuery(ctx context.Context, req QueryRequest, resultsC
 type streamingQueryResources struct {
 	tagsToLoad map[string]struct{}
 	blockCh    <-chan *blockScanResultBatch
+	heap       *blockCursorHeap
+	cleanup    func()
+	asc        bool
+}
+
+type syncQueryResources struct {
+	tagsToLoad map[string]struct{}
+	scanner    *blockScanner
 	heap       *blockCursorHeap
 	cleanup    func()
 	asc        bool
@@ -238,6 +282,109 @@ func (s *sidx) prepareStreamingResources(
 		heap:       blockHeap,
 		cleanup:    cleanup,
 	}, true
+}
+
+func (s *sidx) prepareSyncResources(
+	ctx context.Context,
+	req QueryRequest,
+	snap *Snapshot,
+	span *query.Span,
+) (*syncQueryResources, bool) {
+	var prepareSpan *query.Span
+	if tracer := query.GetTracer(ctx); tracer != nil {
+		prepareSpan, _ = tracer.StartSpan(ctx, "sidx.prepare-sync-resources")
+		defer prepareSpan.Stop()
+	}
+
+	minKey, maxKey := extractKeyRange(req)
+	asc := extractOrdering(req)
+	parts := selectPartsForQuery(snap, minKey, maxKey, req.MinTimestamp, req.MaxTimestamp)
+	if span != nil {
+		span.Tagf("min_key", "%d", minKey)
+		span.Tagf("max_key", "%d", maxKey)
+		span.Tagf("ascending", "%t", asc)
+		span.Tagf("part_count", "%d", len(parts))
+	}
+	if prepareSpan != nil {
+		prepareSpan.Tagf("min_key", "%d", minKey)
+		prepareSpan.Tagf("max_key", "%d", maxKey)
+		prepareSpan.Tagf("ascending", "%t", asc)
+		prepareSpan.Tagf("part_count", "%d", len(parts))
+	}
+	if len(parts) == 0 {
+		return nil, false
+	}
+
+	seriesIDs := make([]common.SeriesID, len(req.SeriesIDs))
+	copy(seriesIDs, req.SeriesIDs)
+	sort.Slice(seriesIDs, func(i, j int) bool {
+		return seriesIDs[i] < seriesIDs[j]
+	})
+
+	tagsToLoad := determineTagsToLoad(req)
+	bs := &blockScanner{
+		pm:        s.pm,
+		filter:    req.Filter,
+		l:         s.l,
+		parts:     parts,
+		seriesIDs: seriesIDs,
+		minKey:    minKey,
+		maxKey:    maxKey,
+		asc:       asc,
+		batchSize: req.MaxBatchSize,
+	}
+	blockHeap := generateBlockCursorHeap(asc)
+	cleanup := func() {
+		bs.close()
+		releaseBlockCursorHeap(blockHeap)
+	}
+	return &syncQueryResources{
+		tagsToLoad: tagsToLoad,
+		scanner:    bs,
+		asc:        asc,
+		heap:       blockHeap,
+		cleanup:    cleanup,
+	}, true
+}
+
+func (s *sidx) processSyncLoop(ctx context.Context, req QueryRequest, resources *syncQueryResources) ([]*QueryResponse, error) {
+	var results []*QueryResponse
+	var metrics *batchMetrics
+	if query.GetTracer(ctx) != nil {
+		metrics = &batchMetrics{}
+	}
+	consume := func(batch *blockScanResultBatch) error {
+		defer releaseBlockScanResultBatch(batch)
+		if batch.err != nil {
+			return batch.err
+		}
+		if metrics != nil {
+			metrics.totalBlocksScanned += len(batch.bss)
+		}
+		cursors, cursorsErr := s.buildCursorsForBatchSync(ctx, batch, resources.tagsToLoad, req, resources.asc, metrics)
+		if cursorsErr != nil {
+			return cursorsErr
+		}
+		if metrics != nil {
+			metrics.totalCursorsCreated += len(cursors)
+		}
+		resources.heap.pushCursors(cursors)
+		chunks, mergeErr := resources.heap.mergeSync(ctx, req.MaxBatchSize, metrics)
+		if mergeErr != nil {
+			return mergeErr
+		}
+		results = append(results, chunks...)
+		return nil
+	}
+	if scanErr := resources.scanner.scanSync(ctx, consume); scanErr != nil {
+		return nil, scanErr
+	}
+	chunks, mergeErr := resources.heap.mergeSync(ctx, req.MaxBatchSize, metrics)
+	if mergeErr != nil {
+		return nil, mergeErr
+	}
+	results = append(results, chunks...)
+	return results, nil
 }
 
 func (s *sidx) processStreamingLoop(
@@ -458,6 +605,44 @@ func (s *sidx) buildCursorsForBatch(
 		return nil, err
 	}
 
+	return cursors, nil
+}
+
+func (s *sidx) buildCursorsForBatchSync(
+	ctx context.Context,
+	batch *blockScanResultBatch,
+	tagsToLoad map[string]struct{},
+	req QueryRequest,
+	asc bool,
+	metrics *batchMetrics,
+) ([]*blockCursor, error) {
+	if len(batch.bss) == 0 {
+		return nil, nil
+	}
+	tmpBlock := generateBlock()
+	defer releaseBlock(tmpBlock)
+
+	cursors := make([]*blockCursor, 0, len(batch.bss))
+	for _, bsResult := range batch.bss {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			for _, cursor := range cursors {
+				releaseBlockCursor(cursor)
+			}
+			return nil, ctxErr
+		}
+		bc := generateBlockCursor()
+		bc.init(bsResult.p, &bsResult.bm, req)
+		if s.loadBlockCursor(bc, tmpBlock, bsResult, tagsToLoad, req, s.pm, metrics) {
+			if asc {
+				bc.idx = 0
+			} else {
+				bc.idx = len(bc.userKeys) - 1
+			}
+			cursors = append(cursors, bc)
+			continue
+		}
+		releaseBlockCursor(bc)
+	}
 	return cursors, nil
 }
 

--- a/banyand/internal/sidx/query_test.go
+++ b/banyand/internal/sidx/query_test.go
@@ -76,6 +76,33 @@ func TestSIDX_Query_BasicQuery(t *testing.T) {
 	}
 }
 
+func TestSIDX_QuerySyncMatchesStreamingQuery(t *testing.T) {
+	sidx := createTestSIDX(t)
+	defer func() {
+		assert.NoError(t, sidx.Close())
+	}()
+
+	ctx := context.Background()
+	reqs := []WriteRequest{
+		createTestWriteRequest(1, 100, "data100"),
+		createTestWriteRequest(1, 200, "data200"),
+		createTestWriteRequest(1, 150, "data150"),
+	}
+	writeTestData(t, sidx, reqs, 44, 44)
+	waitForIntroducerLoop()
+
+	queryReq := createTestQueryRequest(1)
+	queryReq.MaxBatchSize = 2
+	streamingRows := collectStreamingRows(ctx, t, sidx, queryReq)
+	syncQuerier, ok := sidx.(interface {
+		QuerySync(context.Context, QueryRequest) ([]*QueryResponse, error)
+	})
+	require.True(t, ok)
+	syncRows, err := syncQuerier.QuerySync(ctx, queryReq)
+	require.NoError(t, err)
+	require.Equal(t, flattenQueryRows(streamingRows), flattenQueryRows(syncRows))
+}
+
 func TestSIDX_Query_EmptyResult(t *testing.T) {
 	sidx := createTestSIDX(t)
 	defer func() {
@@ -97,6 +124,42 @@ func TestSIDX_Query_EmptyResult(t *testing.T) {
 	}
 
 	assert.Equal(t, 0, resultCount)
+}
+
+type queryRow struct {
+	data   string
+	key    int64
+	series common.SeriesID
+	partID uint64
+}
+
+func collectStreamingRows(ctx context.Context, t *testing.T, sidx SIDX, req QueryRequest) []*QueryResponse {
+	t.Helper()
+	resultsCh, errCh := sidx.StreamingQuery(ctx, req)
+	var results []*QueryResponse
+	for res := range resultsCh {
+		require.NoError(t, res.Error)
+		results = append(results, res)
+	}
+	if err, ok := <-errCh; ok {
+		require.NoError(t, err)
+	}
+	return results
+}
+
+func flattenQueryRows(results []*QueryResponse) []queryRow {
+	var rows []queryRow
+	for _, result := range results {
+		for rowIdx := range result.Keys {
+			rows = append(rows, queryRow{
+				key:    result.Keys[rowIdx],
+				data:   string(result.Data[rowIdx]),
+				series: result.SIDs[rowIdx],
+				partID: result.PartIDs[rowIdx],
+			})
+		}
+	}
+	return rows
 }
 
 func TestSIDX_Query_KeyRangeFilter(t *testing.T) {

--- a/banyand/internal/sidx/sidx.go
+++ b/banyand/internal/sidx/sidx.go
@@ -849,6 +849,87 @@ func (bch *blockCursorHeap) merge(ctx context.Context, batchSize int, resultsCh 
 	return nil
 }
 
+func (bch *blockCursorHeap) mergeSync(ctx context.Context, batchSize int, metrics *batchMetrics) ([]*QueryResponse, error) {
+	if !bch.initialized || bch.Len() == 0 {
+		return nil, nil
+	}
+
+	step := -1
+	if bch.asc {
+		step = 1
+	}
+
+	var results []*QueryResponse
+	batch := &QueryResponse{
+		Keys:    make([]int64, 0),
+		Data:    make([][]byte, 0),
+		SIDs:    make([]common.SeriesID, 0),
+		PartIDs: make([]uint64, 0),
+	}
+	seenData := make(map[uint64][][]byte)
+
+	for bch.Len() > 0 {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		topBC := bch.bcc[0]
+		if topBC.idx < 0 || topBC.idx >= len(topBC.userKeys) {
+			heap.Pop(bch)
+			continue
+		}
+
+		currentData := topBC.data[topBC.idx]
+		h := convert.Hash(currentData)
+		bucket := seenData[h]
+		duplicate := false
+		for _, existing := range bucket {
+			if bytes.Equal(existing, currentData) {
+				duplicate = true
+				break
+			}
+		}
+		if !duplicate && topBC.copyTo(batch) {
+			seenData[h] = append(bucket, currentData)
+		}
+
+		topBC.idx += step
+		if bch.asc {
+			if topBC.idx >= len(topBC.userKeys) {
+				heap.Pop(bch)
+			} else {
+				heap.Fix(bch, 0)
+			}
+		} else {
+			if topBC.idx < 0 {
+				heap.Pop(bch)
+			} else {
+				heap.Fix(bch, 0)
+			}
+		}
+
+		if batchSize > 0 && batch.Len() >= batchSize {
+			if metrics != nil {
+				metrics.record(batch)
+			}
+			results = append(results, batch)
+			batch = &QueryResponse{
+				Keys:    make([]int64, 0),
+				Data:    make([][]byte, 0),
+				SIDs:    make([]common.SeriesID, 0),
+				PartIDs: make([]uint64, 0),
+			}
+		}
+	}
+
+	if batch.Len() > 0 {
+		if metrics != nil {
+			metrics.record(batch)
+		}
+		results = append(results, batch)
+	}
+	return results, nil
+}
+
 var blockCursorHeapPool = pool.Register[*blockCursorHeap]("sidx-blockCursorHeap")
 
 func generateBlockCursorHeap(asc bool) *blockCursorHeap {

--- a/banyand/trace/block.go
+++ b/banyand/trace/block.go
@@ -487,29 +487,31 @@ func (bc *blockCursor) copyAllTo(r *model.TraceResult) {
 
 func (bc *blockCursor) loadData(tmpBlock *block) bool {
 	tmpBlock.reset()
-	bc.bm.tagProjection = bc.tagProjection
 	var t map[string]*dataBlock
-	projectionNames := make([]string, len(bc.tagProjection.Names))
-	copy(projectionNames, bc.tagProjection.Names)
-	for i, name := range bc.tagProjection.Names {
-		for typedTag, block := range bc.bm.tags {
-			if decodeTypedTag(typedTag) != name {
-				continue
-			}
-			if hasTypeSuffix(typedTag) {
-				schemaType, ok := bc.schemaTagTypes[name]
-				if !ok {
+	var projectionNames []string
+	if bc.tagProjection != nil && len(bc.tagProjection.Names) > 0 {
+		projectionNames = make([]string, len(bc.tagProjection.Names))
+		copy(projectionNames, bc.tagProjection.Names)
+		for i, name := range bc.tagProjection.Names {
+			for typedTag, block := range bc.bm.tags {
+				if decodeTypedTag(typedTag) != name {
 					continue
 				}
-				if bmType, ok := bc.bm.tagType[typedTag]; !ok || bmType != schemaType {
-					continue
+				if hasTypeSuffix(typedTag) {
+					schemaType, ok := bc.schemaTagTypes[name]
+					if !ok {
+						continue
+					}
+					if bmType, ok := bc.bm.tagType[typedTag]; !ok || bmType != schemaType {
+						continue
+					}
+					projectionNames[i] = typedTag
 				}
-				projectionNames[i] = typedTag
+				if t == nil {
+					t = make(map[string]*dataBlock, len(bc.tagProjection.Names))
+				}
+				t[typedTag] = block
 			}
-			if t == nil {
-				t = make(map[string]*dataBlock, len(bc.tagProjection.Names))
-			}
-			t[typedTag] = block
 		}
 	}
 

--- a/banyand/trace/metadata.go
+++ b/banyand/trace/metadata.go
@@ -567,7 +567,7 @@ func newSupplier(path string, svc *standalone, nodeLabels map[string]string) *su
 
 func (s *supplier) OpenResource(spec resourceSchema.Resource) (resourceSchema.IndexListener, error) {
 	traceSchema := spec.Schema().(*databasev1.Trace)
-	return openTrace(traceSchema, s.l, s.pm, s.schemaRepo), nil
+	return openTrace(traceSchema, s.l, s.pm, s.schemaRepo, s.option.vectorized), nil
 }
 
 func (s *supplier) ResourceSchema(md *commonv1.Metadata) (resourceSchema.ResourceSchema, error) {
@@ -688,7 +688,7 @@ func newQueueSupplier(path string, svc *liaison, traceDataNodeRegistry grpc.Node
 
 func (qs *queueSupplier) OpenResource(spec resourceSchema.Resource) (resourceSchema.IndexListener, error) {
 	traceSchema := spec.Schema().(*databasev1.Trace)
-	return openTrace(traceSchema, qs.l, qs.pm, qs.schemaRepo), nil
+	return openTrace(traceSchema, qs.l, qs.pm, qs.schemaRepo, qs.option.vectorized), nil
 }
 
 func (qs *queueSupplier) ResourceSchema(md *commonv1.Metadata) (resourceSchema.ResourceSchema, error) {

--- a/banyand/trace/query.go
+++ b/banyand/trace/query.go
@@ -20,6 +20,7 @@ package trace
 import (
 	"context"
 	"fmt"
+	"maps"
 	"sort"
 	"time"
 
@@ -36,6 +37,7 @@ import (
 	pbv1 "github.com/apache/skywalking-banyandb/pkg/pb/v1"
 	"github.com/apache/skywalking-banyandb/pkg/pool"
 	"github.com/apache/skywalking-banyandb/pkg/query/model"
+	vtrace "github.com/apache/skywalking-banyandb/pkg/query/vectorized/trace"
 )
 
 var traceQueryResultTracker = pool.RegisterTracker("trace.queryResult")
@@ -152,6 +154,7 @@ func (t *trace) Query(ctx context.Context, tqo model.TraceQueryOptions) (model.T
 		if err != nil {
 			return nil, err
 		}
+		vtrace.IncrQueryCount()
 		traceQueryResultTracker.Acquire(vectorizedResult)
 		return vectorizedResult, nil
 	case len(qo.traceIDs) > 0:
@@ -468,9 +471,7 @@ func (qr *queryResult) acceptScanBatch(batch *scanBatch) bool {
 		if qr.keys == nil {
 			qr.keys = make(map[string]int64, len(batch.keys))
 		}
-		for k, v := range batch.keys {
-			qr.keys[k] = v
-		}
+		maps.Copy(qr.keys, batch.keys)
 	}
 
 	return true

--- a/banyand/trace/query.go
+++ b/banyand/trace/query.go
@@ -134,19 +134,38 @@ func (t *trace) Query(ctx context.Context, tqo model.TraceQueryOptions) (model.T
 		result.keys = make(map[string]int64)
 	}
 
-	var traceBatchCh <-chan traceBatch
 	switch {
+	case t.vectorized.Enabled:
+		// Assign errors to err so the deferred result.Release() fires on failure,
+		// releasing segments, the timeout context, and the tracing span.
+		var vectorizedBatch traceBatch
+		if vectorizedBatch, err = t.buildVectorizedPhase1TraceBatch(pipelineCtx, qo, sidxInstances, sidxQueryRequest, useSIDXStreaming, tqo.MaxTraceSize); err != nil {
+			return nil, err
+		}
+		var vectorizedScanBatch *scanBatch
+		if vectorizedScanBatch, err = t.buildVectorizedScanBatch(pipelineCtx, tables, qo, vectorizedBatch); err != nil {
+			return nil, err
+		}
+		var vectorizedResult *vectorizedTraceQueryResult
+		vectorizedResult, err = newVectorizedTraceQueryResult(
+			pipelineCtx, vectorizedScanBatch, qo, segments, cancel, result.finishResultSpan, result.recordResult)
+		if err != nil {
+			return nil, err
+		}
+		traceQueryResultTracker.Acquire(vectorizedResult)
+		return vectorizedResult, nil
 	case len(qo.traceIDs) > 0:
-		traceBatchCh = staticTraceBatchSource(pipelineCtx, qo.traceIDs, tqo.MaxTraceSize, result.keys)
+		traceBatchCh := staticTraceBatchSource(pipelineCtx, qo.traceIDs, tqo.MaxTraceSize, result.keys)
+		result.cursorBatchCh = t.startBlockScanStage(pipelineCtx, tables, qo, traceBatchCh)
 	case useSIDXStreaming:
 		var streamDone <-chan struct{}
-		traceBatchCh, streamDone = t.streamSIDXTraceBatches(pipelineCtx, sidxInstances, sidxQueryRequest, tqo.MaxTraceSize)
+		traceBatchCh, streamDone := t.streamSIDXTraceBatches(pipelineCtx, sidxInstances, sidxQueryRequest, tqo.MaxTraceSize)
 		result.streamDone = streamDone
+		result.cursorBatchCh = t.startBlockScanStage(pipelineCtx, tables, qo, traceBatchCh)
 	default:
-		return nilResult, errors.New("invalid query options: either traceIDs or order must be specified")
+		err = errors.New("invalid query options: either traceIDs or order must be specified")
+		return nilResult, err
 	}
-
-	result.cursorBatchCh = t.startBlockScanStage(pipelineCtx, tables, qo, traceBatchCh)
 
 	traceQueryResultTracker.Acquire(&result)
 	return &result, nil
@@ -379,6 +398,9 @@ func (qr *queryResult) ensureCurrentBatch() bool {
 	qr.releaseCurrentBatch()
 
 	for {
+		if qr.cursorBatchCh == nil {
+			return false
+		}
 		select {
 		case batch, ok := <-qr.cursorBatchCh:
 			if !ok {
@@ -387,65 +409,71 @@ func (qr *queryResult) ensureCurrentBatch() bool {
 			if batch == nil {
 				continue
 			}
-
-			if batch.err != nil {
-				qr.err = batch.err
-				return true
-			}
-
-			qr.currentBatch = batch
-			qr.currentIndex = 0
-
-			// Use the ordered list of trace IDs to maintain the sorted order from SIDX stream
-			qr.currentTraceIDs = batch.traceIDsOrder
-
-			qr.currentCursorGroups = make(map[string][]*blockCursor, len(qr.currentTraceIDs))
-
-			// Stream cursors from channel and group by traceID
-			if batch.cursorCh != nil {
-				for result := range batch.cursorCh {
-					if result.err != nil {
-						qr.err = result.err
-						// Release any cursors we've already collected
-						for _, cursors := range qr.currentCursorGroups {
-							for _, bc := range cursors {
-								releaseBlockCursor(bc)
-							}
-						}
-						qr.currentCursorGroups = nil
-						// Release snapshots from this batch on error
-						for _, s := range batch.snapshots {
-							s.decRef()
-						}
-						qr.currentBatch = nil
-						return true
-					}
-					if result.cursor != nil {
-						if qr.recordCursor != nil {
-							qr.recordCursor(result.cursor)
-						}
-						traceID := result.cursor.bm.traceID
-						qr.currentCursorGroups[traceID] = append(qr.currentCursorGroups[traceID], result.cursor)
-					}
-				}
-			}
-
-			if len(batch.keys) > 0 {
-				if qr.keys == nil {
-					qr.keys = make(map[string]int64, len(batch.keys))
-				}
-				for k, v := range batch.keys {
-					qr.keys[k] = v
-				}
-			}
-
-			return true
+			return qr.acceptScanBatch(batch)
 
 		case <-qr.ctx.Done():
 			qr.err = errors.WithMessagef(qr.ctx.Err(), "interrupt: hit %d", qr.hit)
 			return true
 		}
 	}
+}
+
+func (qr *queryResult) acceptScanBatch(batch *scanBatch) bool {
+	if batch.err != nil {
+		qr.err = batch.err
+		return true
+	}
+
+	qr.currentBatch = batch
+	qr.currentIndex = 0
+	qr.currentTraceIDs = batch.traceIDsOrder
+	qr.currentCursorGroups = make(map[string][]*blockCursor, len(qr.currentTraceIDs))
+
+	for _, cursor := range batch.cursors {
+		if qr.recordCursor != nil {
+			qr.recordCursor(cursor)
+		}
+		traceID := cursor.bm.traceID
+		qr.currentCursorGroups[traceID] = append(qr.currentCursorGroups[traceID], cursor)
+	}
+	batch.cursors = nil
+
+	if batch.cursorCh != nil {
+		for result := range batch.cursorCh {
+			if result.err != nil {
+				qr.err = result.err
+				for _, cursors := range qr.currentCursorGroups {
+					for _, bc := range cursors {
+						releaseBlockCursor(bc)
+					}
+				}
+				qr.currentCursorGroups = nil
+				for _, s := range batch.snapshots {
+					s.decRef()
+				}
+				qr.currentBatch = nil
+				return true
+			}
+			if result.cursor != nil {
+				if qr.recordCursor != nil {
+					qr.recordCursor(result.cursor)
+				}
+				traceID := result.cursor.bm.traceID
+				qr.currentCursorGroups[traceID] = append(qr.currentCursorGroups[traceID], result.cursor)
+			}
+		}
+	}
+
+	if len(batch.keys) > 0 {
+		if qr.keys == nil {
+			qr.keys = make(map[string]int64, len(batch.keys))
+		}
+		for k, v := range batch.keys {
+			qr.keys[k] = v
+		}
+	}
+
+	return true
 }
 
 func (qr *queryResult) loadTraceCursors(cursors []*blockCursor) ([]*blockCursor, error) {
@@ -541,20 +569,7 @@ func (qr *queryResult) Release() {
 	// Drain all batches and their cursor channels to ensure scanTraceIDsInline completes
 	if qr.cursorBatchCh != nil {
 		for batch := range qr.cursorBatchCh {
-			if batch != nil {
-				if batch.cursorCh != nil {
-					// Drain the cursor channel to ensure scanTraceIDsInline goroutine finishes
-					for result := range batch.cursorCh {
-						if result.cursor != nil {
-							releaseBlockCursor(result.cursor)
-						}
-					}
-				}
-				// Release snapshots from drained batches
-				for _, s := range batch.snapshots {
-					s.decRef()
-				}
-			}
+			qr.releaseScanBatch(batch)
 		}
 		qr.cursorBatchCh = nil
 	}
@@ -568,6 +583,29 @@ func (qr *queryResult) Release() {
 	qr.segments = qr.segments[:0]
 
 	qr.finishTracing(qr.err)
+}
+
+func (qr *queryResult) releaseScanBatch(batch *scanBatch) {
+	if batch == nil {
+		return
+	}
+	for _, cursor := range batch.cursors {
+		if cursor != nil {
+			releaseBlockCursor(cursor)
+		}
+	}
+	batch.cursors = nil
+	if batch.cursorCh != nil {
+		for result := range batch.cursorCh {
+			if result.cursor != nil {
+				releaseBlockCursor(result.cursor)
+			}
+		}
+	}
+	for _, s := range batch.snapshots {
+		s.decRef()
+	}
+	batch.snapshots = nil
 }
 
 func (qr *queryResult) finishTracing(err error) {

--- a/banyand/trace/query.go
+++ b/banyand/trace/query.go
@@ -54,6 +54,7 @@ type queryOptions struct {
 	schemaTagTypes map[string]pbv1.ValueType
 	traceIDs       []string
 	model.TraceQueryOptions
+	QueryMemoryMiB int
 }
 
 func (t *trace) Query(ctx context.Context, tqo model.TraceQueryOptions) (model.TraceQueryResult, error) {
@@ -113,6 +114,7 @@ func (t *trace) Query(ctx context.Context, tqo model.TraceQueryOptions) (model.T
 		TraceQueryOptions: storageTQO,
 		traceIDs:          tqo.TraceIDs,
 		schemaTagTypes:    schemaTagTypes,
+		QueryMemoryMiB:    t.vectorized.QueryMemoryMiB,
 	}
 
 	if err = t.resolveSeriesEntities(ctx, segments, &qo, tqo.Name, tqo.Entities); err != nil {

--- a/banyand/trace/query_test.go
+++ b/banyand/trace/query_test.go
@@ -238,6 +238,14 @@ func TestOmitIdentityTagProjection(t *testing.T) {
 		Names:  []string{"service_id", "duration"},
 	}, got)
 	require.Equal(t, []string{"trace_id", "service_id", "span_id", "duration"}, projection.Names)
+
+	// Identity-only projection: all names stripped → empty Names slice (r.Tags == nil).
+	identityOnly := &model.TagProjection{Family: "default", Names: []string{"trace_id", "span_id"}}
+	stripped := omitIdentityTagProjection(identityOnly, "trace_id", "span_id")
+	require.Empty(t, stripped.Names)
+
+	// Nil projection passthrough.
+	require.Nil(t, omitIdentityTagProjection(nil, "trace_id", "span_id"))
 }
 
 func TestQueryResultMultipleBatches(t *testing.T) {

--- a/banyand/trace/query_vectorized.go
+++ b/banyand/trace/query_vectorized.go
@@ -119,7 +119,11 @@ func materializeVectorizedTraceResults(ctx context.Context, batch *scanBatch, qo
 		return nil, batch.err
 	}
 
-	loaded, loadErr := loadTraceCursorsSync(ctx, batch.cursors)
+	var budgetBytes int64
+	if qo.QueryMemoryMiB > 0 {
+		budgetBytes = int64(qo.QueryMemoryMiB) * 1024 * 1024
+	}
+	loaded, loadErr := loadTraceCursorsSync(ctx, batch.cursors, budgetBytes)
 	batch.cursors = nil
 	if loadErr != nil {
 		return nil, loadErr
@@ -199,10 +203,8 @@ func (s *loadedCursorSource) closeAll() {
 	s.idx = len(s.cursors)
 }
 
-// Init is a no-op.
 func (s *loadedCursorSource) Init(context.Context) error { return nil }
 
-// OutputSchema returns the Phase-2 schema.
 func (s *loadedCursorSource) OutputSchema() *vectorized.BatchSchema { return s.schema }
 
 // Close releases all remaining unread cursors. Idempotent.
@@ -217,8 +219,12 @@ func (s *loadedCursorSource) Close() error {
 
 // NextBatch emits one Phase-2 RecordBatch per loaded blockCursor.
 // Each span in the cursor becomes one row in the batch.
-func (s *loadedCursorSource) NextBatch(_ context.Context) (*vectorized.RecordBatch, error) {
+func (s *loadedCursorSource) NextBatch(ctx context.Context) (*vectorized.RecordBatch, error) {
 	for s.idx < len(s.cursors) {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			s.closeAll()
+			return nil, ctxErr
+		}
 		bc := s.cursors[s.idx]
 		s.idx++
 		if len(bc.spans) == 0 {
@@ -286,10 +292,26 @@ func findCursorTag(bc *blockCursor, tagName string, schemaTagTypes map[string]pb
 	return nil
 }
 
-func loadTraceCursorsSync(ctx context.Context, cursors []*blockCursor) ([]*blockCursor, error) {
+// loadTraceCursorsSync loads span data for each cursor from disk.
+// budgetBytes is a soft span-loading threshold: it caps the cumulative uncompressed
+// span bytes loaded across cursors. SIDX responses, tags, record-batch overhead, and
+// other per-query allocations are not counted. Pass 0 to disable the cap.
+// Two complementary gates enforce the threshold:
+//  1. Hard stop: once usedBytes >= budgetBytes, remaining cursors are released
+//     without calling loadData.
+//  2. Metadata preflight: cursor.bm.uncompressedSpanSizeBytes (written at flush,
+//     available without loading) is used to predict whether a cursor would push
+//     usedBytes over budgetBytes. If so the cursor is skipped before loadData.
+//
+// First-block exception: the first cursor always loads regardless of the budget
+// so that a query never returns zero results due to a too-small budget. This means
+// a single oversized block can exceed budgetBytes; the threshold is best-effort,
+// not a hard memory cap.
+func loadTraceCursorsSync(ctx context.Context, cursors []*blockCursor, budgetBytes int64) ([]*blockCursor, error) {
 	if len(cursors) == 0 {
 		return nil, nil
 	}
+	var usedBytes int64
 	filtered := cursors[:0]
 	for curIdx, cursor := range cursors {
 		select {
@@ -305,14 +327,39 @@ func loadTraceCursorsSync(ctx context.Context, cursors []*blockCursor) ([]*block
 			return nil, fmt.Errorf("interrupt while loading trace data: %w", ctx.Err())
 		default:
 		}
+		if budgetBytes > 0 {
+			// Hard stop: prior cursors already filled the budget.
+			if usedBytes >= budgetBytes {
+				releaseBlockCursor(cursor)
+				for _, pendingCursor := range cursors[curIdx+1:] {
+					releaseBlockCursor(pendingCursor)
+				}
+				return filtered, nil
+			}
+			// Metadata preflight: skip this cursor without calling loadData when its
+			// uncompressed-size estimate would push usedBytes over the budget.
+			// The guard usedBytes > 0 ensures the first cursor always loads.
+			if usedBytes > 0 && usedBytes+int64(cursor.bm.uncompressedSpanSizeBytes) > budgetBytes {
+				releaseBlockCursor(cursor)
+				for _, pendingCursor := range cursors[curIdx+1:] {
+					releaseBlockCursor(pendingCursor)
+				}
+				return filtered, nil
+			}
+		}
 		tmpBlock := generateBlock()
 		loaded := cursor.loadData(tmpBlock)
 		releaseBlock(tmpBlock)
-		if loaded {
-			filtered = append(filtered, cursor)
+		if !loaded {
+			releaseBlockCursor(cursor)
 			continue
 		}
-		releaseBlockCursor(cursor)
+		if budgetBytes > 0 {
+			for _, span := range cursor.spans {
+				usedBytes += int64(len(span))
+			}
+		}
+		filtered = append(filtered, cursor)
 	}
 	return filtered, nil
 }
@@ -333,29 +380,9 @@ func releaseVectorizedScanBatch(batch *scanBatch) {
 	batch.snapshots = nil
 }
 
-type syncSIDXQuerier interface {
-	QuerySync(context.Context, sidx.QueryRequest) ([]*sidx.QueryResponse, error)
-}
-
 func sidxInstancesToVectorizedIterators(
 	ctx context.Context,
 	instances []sidx.SIDX,
-	req sidx.QueryRequest,
-) ([]itersort.Iterator[*vtrace.MergeItem], error) {
-	syncInstances := make([]syncSIDXQuerier, 0, len(instances))
-	for instanceIdx, instance := range instances {
-		syncInstance, ok := instance.(syncSIDXQuerier)
-		if !ok {
-			return nil, fmt.Errorf("sidx instance %d does not support synchronous query", instanceIdx)
-		}
-		syncInstances = append(syncInstances, syncInstance)
-	}
-	return syncSIDXQuerierToVectorizedIterators(ctx, syncInstances, req)
-}
-
-func syncSIDXQuerierToVectorizedIterators(
-	ctx context.Context,
-	instances []syncSIDXQuerier,
 	req sidx.QueryRequest,
 ) ([]itersort.Iterator[*vtrace.MergeItem], error) {
 	iters := make([]itersort.Iterator[*vtrace.MergeItem], 0, len(instances))
@@ -388,7 +415,13 @@ func (t *trace) buildVectorizedPhase1TraceBatch(
 	}
 	switch {
 	case len(qo.traceIDs) > 0:
-		plan, buildErr := vtrace.BuildStaticPhase1(qo.traceIDs, nil, maxRows, batchSize)
+		// Mirror the push path: truncate the raw list to maxTraceSize first (preserving
+		// duplicates), then let Phase-1's DistinctTraceID deduplicate within that window.
+		ids := qo.traceIDs
+		if maxRows > 0 && int(maxRows) < len(ids) {
+			ids = ids[:maxRows]
+		}
+		plan, buildErr := vtrace.BuildStaticPhase1(ids, nil, 0, batchSize)
 		if buildErr != nil {
 			return traceBatch{}, fmt.Errorf("build static vectorized trace phase1: %w", buildErr)
 		}
@@ -398,7 +431,10 @@ func (t *trace) buildVectorizedPhase1TraceBatch(
 		if iterErr != nil {
 			return traceBatch{}, iterErr
 		}
-		plan, buildErr := vtrace.BuildMergePhase1(iters, sidxRequestDesc(req), maxRows, batchSize)
+		// Ordered SIDX path: MaxTraceSize controls SIDX batch size (MaxBatchSize in the
+		// request), not the total result cap. The push path emits all matching traces in
+		// batches; vectorized must do the same. Pass 0 to disable the Phase-1 trace cap.
+		plan, buildErr := vtrace.BuildMergePhase1(iters, sidxRequestDesc(req), 0, batchSize)
 		if buildErr != nil {
 			return traceBatch{}, fmt.Errorf("build ordered vectorized trace phase1: %w", buildErr)
 		}

--- a/banyand/trace/query_vectorized.go
+++ b/banyand/trace/query_vectorized.go
@@ -1,0 +1,563 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trace
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+	"sort"
+
+	modelv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/model/v1"
+	"github.com/apache/skywalking-banyandb/banyand/internal/sidx"
+	"github.com/apache/skywalking-banyandb/banyand/internal/storage"
+	"github.com/apache/skywalking-banyandb/pkg/convert"
+	itersort "github.com/apache/skywalking-banyandb/pkg/iter/sort"
+	pbv1 "github.com/apache/skywalking-banyandb/pkg/pb/v1"
+	"github.com/apache/skywalking-banyandb/pkg/query/model"
+	"github.com/apache/skywalking-banyandb/pkg/query/vectorized"
+	vtrace "github.com/apache/skywalking-banyandb/pkg/query/vectorized/trace"
+)
+
+type vectorizedTraceQueryResult struct {
+	ctx              context.Context
+	cancel           context.CancelFunc
+	finishResultSpan func(int, error)
+	recordResult     func(*model.TraceResult)
+	err              error
+	results          []*model.TraceResult
+	segments         []storage.Segment[*tsTable, option]
+	idx              int
+	released         bool
+}
+
+func newVectorizedTraceQueryResult(
+	ctx context.Context,
+	batch *scanBatch,
+	qo queryOptions,
+	segments []storage.Segment[*tsTable, option],
+	cancel context.CancelFunc,
+	finishResultSpan func(int, error),
+	recordResult func(*model.TraceResult),
+) (*vectorizedTraceQueryResult, error) {
+	results, materializeErr := materializeVectorizedTraceResults(ctx, batch, qo)
+	releaseVectorizedScanBatch(batch)
+	if materializeErr != nil {
+		return nil, materializeErr
+	}
+	return &vectorizedTraceQueryResult{
+		ctx:              ctx,
+		cancel:           cancel,
+		finishResultSpan: finishResultSpan,
+		recordResult:     recordResult,
+		results:          results,
+		segments:         segments,
+	}, nil
+}
+
+func (r *vectorizedTraceQueryResult) Pull() *model.TraceResult {
+	select {
+	case <-r.ctx.Done():
+		r.err = r.ctx.Err()
+		return &model.TraceResult{Error: r.err}
+	default:
+	}
+	if r.err != nil {
+		return &model.TraceResult{Error: r.err}
+	}
+	if r.idx >= len(r.results) {
+		return nil
+	}
+	result := r.results[r.idx]
+	r.idx++
+	if r.recordResult != nil {
+		r.recordResult(result)
+	}
+	return result
+}
+
+func (r *vectorizedTraceQueryResult) Release() {
+	if r.released {
+		return
+	}
+	r.released = true
+	traceQueryResultTracker.Release(r)
+	if r.cancel != nil {
+		r.cancel()
+	}
+	for i := range r.segments {
+		r.segments[i].DecRef()
+	}
+	r.segments = nil
+	if r.finishResultSpan != nil {
+		r.finishResultSpan(r.idx, r.err)
+		r.finishResultSpan = nil
+	}
+}
+
+func materializeVectorizedTraceResults(ctx context.Context, batch *scanBatch, qo queryOptions) ([]*model.TraceResult, error) {
+	if batch == nil {
+		return nil, nil
+	}
+	if batch.err != nil {
+		return nil, batch.err
+	}
+
+	loaded, loadErr := loadTraceCursorsSync(ctx, batch.cursors)
+	batch.cursors = nil
+	if loadErr != nil {
+		return nil, loadErr
+	}
+	if len(loaded) == 0 {
+		return nil, nil
+	}
+
+	var tagCols []string
+	if qo.TagProjection != nil && len(qo.TagProjection.Names) > 0 {
+		tagCols = append([]string(nil), qo.TagProjection.Names...)
+	}
+	schema := vtrace.NewPhase2Schema(tagCols)
+	source := newLoadedCursorSource(loaded, schema, batch.keys, tagCols, qo.schemaTagTypes)
+
+	phase2Plan, buildErr := vtrace.BuildPhase2(source, batch.traceIDsOrder)
+	if buildErr != nil {
+		source.closeAll()
+		return nil, fmt.Errorf("build vectorized trace phase2: %w", buildErr)
+	}
+	if initErr := phase2Plan.Pipeline.Init(ctx); initErr != nil {
+		phase2Plan.Pipeline.Close() //nolint:errcheck
+		return nil, fmt.Errorf("init vectorized trace phase2: %w", initErr)
+	}
+	defer phase2Plan.Pipeline.Close() //nolint:errcheck
+
+	results := make([]*model.TraceResult, 0, len(batch.traceIDsOrder))
+	for {
+		outBatch, nextErr := phase2Plan.Pipeline.Next(ctx)
+		if nextErr != nil {
+			return nil, fmt.Errorf("pull vectorized trace phase2: %w", nextErr)
+		}
+		if outBatch == nil {
+			break
+		}
+		result := vtrace.BatchToTraceResult(outBatch, schema)
+		if result != nil {
+			results = append(results, result)
+		}
+	}
+	return results, nil
+}
+
+// loadedCursorSource is a PullOperator that wraps already-loaded []*blockCursor
+// and emits one Phase-2 RecordBatch per cursor.
+type loadedCursorSource struct {
+	schema         *vectorized.BatchSchema
+	keys           map[string]int64
+	schemaTagTypes map[string]pbv1.ValueType
+	cursors        []*blockCursor
+	tagCols        []string
+	idx            int
+	closed         bool
+}
+
+func newLoadedCursorSource(
+	cursors []*blockCursor,
+	schema *vectorized.BatchSchema,
+	keys map[string]int64,
+	tagCols []string,
+	schemaTagTypes map[string]pbv1.ValueType,
+) *loadedCursorSource {
+	return &loadedCursorSource{
+		cursors:        cursors,
+		schema:         schema,
+		keys:           keys,
+		tagCols:        tagCols,
+		schemaTagTypes: schemaTagTypes,
+	}
+}
+
+// closeAll releases any remaining cursors without marking the source closed.
+func (s *loadedCursorSource) closeAll() {
+	for remainIdx := s.idx; remainIdx < len(s.cursors); remainIdx++ {
+		releaseBlockCursor(s.cursors[remainIdx])
+	}
+	s.idx = len(s.cursors)
+}
+
+// Init is a no-op.
+func (s *loadedCursorSource) Init(context.Context) error { return nil }
+
+// OutputSchema returns the Phase-2 schema.
+func (s *loadedCursorSource) OutputSchema() *vectorized.BatchSchema { return s.schema }
+
+// Close releases all remaining unread cursors. Idempotent.
+func (s *loadedCursorSource) Close() error {
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+	s.closeAll()
+	return nil
+}
+
+// NextBatch emits one Phase-2 RecordBatch per loaded blockCursor.
+// Each span in the cursor becomes one row in the batch.
+func (s *loadedCursorSource) NextBatch(_ context.Context) (*vectorized.RecordBatch, error) {
+	for s.idx < len(s.cursors) {
+		bc := s.cursors[s.idx]
+		s.idx++
+		if len(bc.spans) == 0 {
+			releaseBlockCursor(bc)
+			continue
+		}
+
+		batch := vectorized.NewRecordBatch(s.schema, len(bc.spans))
+		tid := bc.bm.traceID
+		key := s.keys[tid]
+
+		tidCol := vtrace.Phase2TraceIDs(batch)
+		keyCol := vtrace.Phase2Keys(batch)
+		spanCol := vtrace.Phase2Spans(batch)
+		spanIDCol := vtrace.Phase2SpanIDs(batch)
+		// Tag-column handles and the cursor's matching tag are loop-invariant
+		// across spans; resolve them once per cursor.
+		tagCols := make([]*vectorized.TypedColumn[*modelv1.TagValue], len(s.tagCols))
+		cursorTags := make([]*tag, len(s.tagCols))
+		for tagIdx, tagName := range s.tagCols {
+			tagCols[tagIdx] = vtrace.Phase2TagCol(batch, tagIdx)
+			cursorTags[tagIdx] = findCursorTag(bc, tagName, s.schemaTagTypes)
+		}
+
+		for spanIdx, span := range bc.spans {
+			tidCol.Append(tid)
+			keyCol.Append(key)
+			spanCol.Append(span)
+			spanID := ""
+			if spanIdx < len(bc.spanIDs) {
+				spanID = bc.spanIDs[spanIdx]
+			}
+			spanIDCol.Append(spanID)
+
+			for tagIdx := range s.tagCols {
+				tv := pbv1.NullTagValue
+				if cursorTag := cursorTags[tagIdx]; cursorTag != nil && spanIdx < len(cursorTag.values) {
+					tv = mustDecodeTagValue(cursorTag.valueType, cursorTag.values[spanIdx])
+				}
+				tagCols[tagIdx].Append(tv)
+			}
+		}
+		batch.Len = len(bc.spans)
+		releaseBlockCursor(bc)
+		return batch, nil
+	}
+	return nil, nil
+}
+
+// findCursorTag returns the cursor's tag whose decoded name and value type match
+// the schema expectation, or nil when the cursor has no such tag. A name match
+// with a mismatched type keeps scanning so a correctly-typed variant still wins.
+func findCursorTag(bc *blockCursor, tagName string, schemaTagTypes map[string]pbv1.ValueType) *tag {
+	schemaType, hasSchemaType := schemaTagTypes[tagName]
+	if !hasSchemaType {
+		return nil
+	}
+	for tagIdx := range bc.tags {
+		cursorTag := &bc.tags[tagIdx]
+		if decodeTypedTag(cursorTag.name) != tagName || cursorTag.valueType != schemaType {
+			continue
+		}
+		return cursorTag
+	}
+	return nil
+}
+
+func loadTraceCursorsSync(ctx context.Context, cursors []*blockCursor) ([]*blockCursor, error) {
+	if len(cursors) == 0 {
+		return nil, nil
+	}
+	filtered := cursors[:0]
+	for curIdx, cursor := range cursors {
+		select {
+		case <-ctx.Done():
+			// filtered aliases cursors[:0]: its entries are the loaded cursors,
+			// cursors[curIdx:] are untouched; everything in between was already released.
+			for _, loadedCursor := range filtered {
+				releaseBlockCursor(loadedCursor)
+			}
+			for _, pendingCursor := range cursors[curIdx:] {
+				releaseBlockCursor(pendingCursor)
+			}
+			return nil, fmt.Errorf("interrupt while loading trace data: %w", ctx.Err())
+		default:
+		}
+		tmpBlock := generateBlock()
+		loaded := cursor.loadData(tmpBlock)
+		releaseBlock(tmpBlock)
+		if loaded {
+			filtered = append(filtered, cursor)
+			continue
+		}
+		releaseBlockCursor(cursor)
+	}
+	return filtered, nil
+}
+
+func releaseVectorizedScanBatch(batch *scanBatch) {
+	if batch == nil {
+		return
+	}
+	for _, cursor := range batch.cursors {
+		if cursor != nil {
+			releaseBlockCursor(cursor)
+		}
+	}
+	batch.cursors = nil
+	for _, snapshot := range batch.snapshots {
+		snapshot.decRef()
+	}
+	batch.snapshots = nil
+}
+
+type syncSIDXQuerier interface {
+	QuerySync(context.Context, sidx.QueryRequest) ([]*sidx.QueryResponse, error)
+}
+
+func sidxInstancesToVectorizedIterators(
+	ctx context.Context,
+	instances []sidx.SIDX,
+	req sidx.QueryRequest,
+) ([]itersort.Iterator[*vtrace.MergeItem], error) {
+	syncInstances := make([]syncSIDXQuerier, 0, len(instances))
+	for instanceIdx, instance := range instances {
+		syncInstance, ok := instance.(syncSIDXQuerier)
+		if !ok {
+			return nil, fmt.Errorf("sidx instance %d does not support synchronous query", instanceIdx)
+		}
+		syncInstances = append(syncInstances, syncInstance)
+	}
+	return syncSIDXQuerierToVectorizedIterators(ctx, syncInstances, req)
+}
+
+func syncSIDXQuerierToVectorizedIterators(
+	ctx context.Context,
+	instances []syncSIDXQuerier,
+	req sidx.QueryRequest,
+) ([]itersort.Iterator[*vtrace.MergeItem], error) {
+	iters := make([]itersort.Iterator[*vtrace.MergeItem], 0, len(instances))
+	for instanceIdx, instance := range instances {
+		responses, queryErr := instance.QuerySync(ctx, req)
+		if queryErr != nil {
+			return nil, fmt.Errorf("query sidx instance %d synchronously: %w", instanceIdx, queryErr)
+		}
+		batches, convertErr := sidxResponsesToVectorizedBatches(responses)
+		if convertErr != nil {
+			return nil, fmt.Errorf("convert sidx instance %d response: %w", instanceIdx, convertErr)
+		}
+		iters = append(iters, vtrace.NewSidxResponseIterator(batches))
+	}
+	return iters, nil
+}
+
+func (t *trace) buildVectorizedPhase1TraceBatch(
+	ctx context.Context,
+	qo queryOptions,
+	sidxInstances []sidx.SIDX,
+	req sidx.QueryRequest,
+	useSIDX bool,
+	maxTraceSize int,
+) (traceBatch, error) {
+	batchSize := t.vectorized.BatchSize
+	maxRows := uint32(0)
+	if maxTraceSize > 0 {
+		maxRows = uint32(maxTraceSize)
+	}
+	switch {
+	case len(qo.traceIDs) > 0:
+		plan, buildErr := vtrace.BuildStaticPhase1(qo.traceIDs, nil, maxRows, batchSize)
+		if buildErr != nil {
+			return traceBatch{}, fmt.Errorf("build static vectorized trace phase1: %w", buildErr)
+		}
+		return drainVectorizedPhase1(ctx, plan, 0)
+	case useSIDX:
+		iters, iterErr := sidxInstancesToVectorizedIterators(ctx, sidxInstances, req)
+		if iterErr != nil {
+			return traceBatch{}, iterErr
+		}
+		plan, buildErr := vtrace.BuildMergePhase1(iters, sidxRequestDesc(req), maxRows, batchSize)
+		if buildErr != nil {
+			return traceBatch{}, fmt.Errorf("build ordered vectorized trace phase1: %w", buildErr)
+		}
+		return drainVectorizedPhase1(ctx, plan, 0)
+	default:
+		return traceBatch{}, fmt.Errorf("invalid query options: either traceIDs or order must be specified")
+	}
+}
+
+func (t *trace) buildVectorizedScanBatch(ctx context.Context, tables []*tsTable, qo queryOptions, batch traceBatch) (*scanBatch, error) {
+	if batch.err != nil {
+		return &scanBatch{traceBatch: batch, err: batch.err}, nil
+	}
+	snapshots := make([]*snapshot, 0, len(tables))
+	for _, table := range tables {
+		s := table.currentSnapshot()
+		if s == nil {
+			continue
+		}
+		snapshots = append(snapshots, s)
+	}
+	if len(snapshots) == 0 {
+		return &scanBatch{traceBatch: batch}, nil
+	}
+
+	partSelectionCtx, finishPartSelection := startPartSelectionSpan(ctx, &batch, snapshots)
+	parts, groupedIDs, metrics := selectVectorizedTraceParts(batch, snapshots)
+	if finishPartSelection != nil {
+		finishPartSelection(metrics, len(parts))
+	}
+	cursors, scanErr := t.scanPartsInlineSync(partSelectionCtx, parts, groupedIDs, qo)
+	if scanErr != nil {
+		for _, s := range snapshots {
+			s.decRef()
+		}
+		return nil, scanErr
+	}
+	return &scanBatch{
+		traceBatch: batch,
+		cursors:    cursors,
+		snapshots:  snapshots,
+	}, nil
+}
+
+func selectVectorizedTraceParts(batch traceBatch, snapshots []*snapshot) ([]*part, [][]string, *partSelectionMetrics) {
+	parts := make([]*part, 0)
+	groupedIDs := make([][]string, 0)
+	allTraceIDs := make([]string, 0)
+	for _, ids := range batch.traceIDs {
+		allTraceIDs = append(allTraceIDs, ids...)
+	}
+	sort.Strings(allTraceIDs)
+
+	bloomFilteredPartIDs := make([]uint64, 0)
+	totalGroupedIDs := 0
+	for _, s := range snapshots {
+		for _, pw := range s.parts {
+			p := pw.p
+			partID := p.partMetadata.ID
+
+			var idsFromSIDX []string
+			if traceIDsFromSIDX, exists := batch.traceIDs[partID]; exists {
+				idsFromSIDX = append([]string(nil), traceIDsFromSIDX...)
+			}
+			var idsForPart []string
+			for _, traceID := range allTraceIDs {
+				if slices.Contains(idsFromSIDX, traceID) || p.traceIDFilter.filter.MightContain(convert.StringToBytes(traceID)) {
+					idsForPart = append(idsForPart, traceID)
+				}
+			}
+			if len(idsForPart) > 0 {
+				parts = append(parts, p)
+				groupedIDs = append(groupedIDs, idsForPart)
+				totalGroupedIDs += len(idsForPart)
+				continue
+			}
+			bloomFilteredPartIDs = append(bloomFilteredPartIDs, partID)
+		}
+	}
+	return parts, groupedIDs, &partSelectionMetrics{
+		bloomFilteredPartIDs: bloomFilteredPartIDs,
+		totalGroupedIDs:      totalGroupedIDs,
+	}
+}
+
+func sidxRequestDesc(req sidx.QueryRequest) bool {
+	return req.Order != nil && req.Order.Sort == modelv1.Sort_SORT_DESC
+}
+
+func sidxResponseToVectorizedBatch(resp *sidx.QueryResponse) (*vtrace.SidxRowBatch, error) {
+	if resp == nil {
+		return nil, nil
+	}
+	if validateErr := resp.Validate(); validateErr != nil {
+		return nil, fmt.Errorf("invalid sidx query response: %w", validateErr)
+	}
+	out := &vtrace.SidxRowBatch{
+		Error:   resp.Error,
+		Keys:    append([]int64(nil), resp.Keys...),
+		Data:    make([][]byte, len(resp.Data)),
+		SIDs:    make([]int64, len(resp.SIDs)),
+		PartIDs: make([]int64, len(resp.PartIDs)),
+	}
+	for rowIdx, data := range resp.Data {
+		out.Data[rowIdx] = append([]byte(nil), data...)
+	}
+	for rowIdx, seriesID := range resp.SIDs {
+		out.SIDs[rowIdx] = int64(seriesID)
+	}
+	for rowIdx, partID := range resp.PartIDs {
+		out.PartIDs[rowIdx] = int64(partID)
+	}
+	return out, nil
+}
+
+func sidxResponsesToVectorizedBatches(responses []*sidx.QueryResponse) ([]*vtrace.SidxRowBatch, error) {
+	out := make([]*vtrace.SidxRowBatch, 0, len(responses))
+	for _, resp := range responses {
+		batch, convertErr := sidxResponseToVectorizedBatch(resp)
+		if convertErr != nil {
+			return nil, convertErr
+		}
+		if batch != nil {
+			out = append(out, batch)
+		}
+	}
+	return out, nil
+}
+
+func drainVectorizedPhase1(ctx context.Context, plan *vtrace.Phase1Plan, seq int) (traceBatch, error) {
+	if plan == nil || plan.Pipeline == nil || plan.Carry == nil {
+		return traceBatch{}, fmt.Errorf("vectorized trace phase1 plan is nil")
+	}
+	if initErr := plan.Pipeline.Init(ctx); initErr != nil {
+		return traceBatch{}, fmt.Errorf("initialize vectorized trace phase1: %w", initErr)
+	}
+	defer plan.Pipeline.Close() //nolint:errcheck // best-effort cleanup; query result path reports pull errors.
+	for {
+		batch, nextErr := plan.Pipeline.Next(ctx)
+		if nextErr != nil {
+			return traceBatch{}, fmt.Errorf("pull vectorized trace phase1: %w", nextErr)
+		}
+		if batch == nil {
+			break
+		}
+	}
+	carry := plan.Carry
+	return traceBatch{
+		seq:           seq,
+		traceIDs:      cloneTraceIDsByPart(carry.TraceIDsByPart()),
+		traceIDsOrder: append([]string(nil), carry.Order()...),
+		keys:          maps.Clone(carry.Keys()),
+	}, nil
+}
+
+func cloneTraceIDsByPart(in map[int64][]string) map[uint64][]string {
+	out := make(map[uint64][]string, len(in))
+	for partID, traceIDs := range in {
+		out[uint64(partID)] = slices.Clone(traceIDs)
+	}
+	return out
+}

--- a/banyand/trace/query_vectorized.go
+++ b/banyand/trace/query_vectorized.go
@@ -295,7 +295,7 @@ func findCursorTag(bc *blockCursor, tagName string, schemaTagTypes map[string]pb
 // loadTraceCursorsSync loads span data for each cursor from disk.
 // budgetBytes is a soft span-loading threshold: it caps the cumulative uncompressed
 // span bytes loaded across cursors. SIDX responses, tags, record-batch overhead, and
-// other per-query allocations are not counted. Pass 0 to disable the cap.
+// other per-query allocations are not counted. Pass 0 (or any non-positive value) to disable the cap.
 // Two complementary gates enforce the threshold:
 //  1. Hard stop: once usedBytes >= budgetBytes, remaining cursors are released
 //     without calling loadData.
@@ -495,13 +495,15 @@ func selectVectorizedTraceParts(batch traceBatch, snapshots []*snapshot) ([]*par
 			p := pw.p
 			partID := p.partMetadata.ID
 
-			var idsFromSIDX []string
+			sidxSet := make(map[string]struct{})
 			if traceIDsFromSIDX, exists := batch.traceIDs[partID]; exists {
-				idsFromSIDX = append([]string(nil), traceIDsFromSIDX...)
+				for _, id := range traceIDsFromSIDX {
+					sidxSet[id] = struct{}{}
+				}
 			}
 			var idsForPart []string
 			for _, traceID := range allTraceIDs {
-				if slices.Contains(idsFromSIDX, traceID) || p.traceIDFilter.filter.MightContain(convert.StringToBytes(traceID)) {
+				if _, inSIDX := sidxSet[traceID]; inSIDX || p.traceIDFilter.filter.MightContain(convert.StringToBytes(traceID)) {
 					idsForPart = append(idsForPart, traceID)
 				}
 			}

--- a/banyand/trace/query_vectorized_test.go
+++ b/banyand/trace/query_vectorized_test.go
@@ -195,9 +195,9 @@ func TestLoadedCursorSource(t *testing.T) {
 // fakeSIDXWithSync wraps fakeSIDX (satisfies sidx.SIDX) and adds QuerySync so that
 // sidxInstancesToVectorizedIterators can cast it to syncSIDXQuerier.
 type fakeSIDXWithSync struct {
+	syncErr error
 	*fakeSIDX
 	syncResponses []*sidx.QueryResponse
-	syncErr       error
 }
 
 func (f *fakeSIDXWithSync) QuerySync(_ context.Context, _ sidx.QueryRequest) ([]*sidx.QueryResponse, error) {

--- a/banyand/trace/query_vectorized_test.go
+++ b/banyand/trace/query_vectorized_test.go
@@ -25,7 +25,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/apache/skywalking-banyandb/api/common"
+	modelv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/model/v1"
 	"github.com/apache/skywalking-banyandb/banyand/internal/sidx"
+	"github.com/apache/skywalking-banyandb/pkg/index"
+	"github.com/apache/skywalking-banyandb/pkg/query/model"
 	vtrace "github.com/apache/skywalking-banyandb/pkg/query/vectorized/trace"
 )
 
@@ -187,4 +190,80 @@ func TestLoadedCursorSource(t *testing.T) {
 	require.Nil(t, done)
 
 	require.NoError(t, source.Close())
+}
+
+// fakeSIDXWithSync wraps fakeSIDX (satisfies sidx.SIDX) and adds QuerySync so that
+// sidxInstancesToVectorizedIterators can cast it to syncSIDXQuerier.
+type fakeSIDXWithSync struct {
+	*fakeSIDX
+	syncResponses []*sidx.QueryResponse
+	syncErr       error
+}
+
+func (f *fakeSIDXWithSync) QuerySync(_ context.Context, _ sidx.QueryRequest) ([]*sidx.QueryResponse, error) {
+	return f.syncResponses, f.syncErr
+}
+
+// TestVectorizedOrderModeSmokeTest exercises the full order-mode vectorized path end-to-end:
+// fake sidx → Phase-1 merge batch → Phase-2 scan → Pull results.
+func TestVectorizedOrderModeSmokeTest(t *testing.T) {
+	tst, cleanup := newParityTSTable(t, tsTS1)
+	defer cleanup()
+
+	tr := newParityTrace()
+
+	ctx := context.Background()
+	req := sidx.QueryRequest{
+		Order: &index.OrderBy{Sort: modelv1.Sort_SORT_ASC},
+	}
+
+	// fakeSIDXInst returns trace1 < trace2 < trace3 in ASC key order.
+	// PartIDs=0 won't match any real part; the bloom filter fallback picks them up.
+	fakeSIDXInst := &fakeSIDXWithSync{
+		fakeSIDX: &fakeSIDX{},
+		syncResponses: []*sidx.QueryResponse{
+			{
+				Keys:    []int64{1, 2, 3},
+				Data:    [][]byte{encodeTraceIDForTest("trace1"), encodeTraceIDForTest("trace2"), encodeTraceIDForTest("trace3")},
+				SIDs:    []common.SeriesID{0, 0, 0},
+				PartIDs: []uint64{0, 0, 0},
+			},
+		},
+	}
+
+	qo := queryOptions{
+		TraceQueryOptions: model.TraceQueryOptions{
+			TagProjection: allTagProjections,
+			Order:         req.Order,
+		},
+		schemaTagTypes: testSchemaTagTypes,
+	}
+
+	// Phase 1: build ordered traceBatch from the fake sidx.
+	batch, phase1Err := tr.buildVectorizedPhase1TraceBatch(ctx, qo, []sidx.SIDX{fakeSIDXInst}, req, true, 0)
+	require.NoError(t, phase1Err)
+	require.ElementsMatch(t, []string{"trace1", "trace2", "trace3"}, batch.traceIDsOrder)
+	require.Equal(t, map[string]int64{"trace1": 1, "trace2": 2, "trace3": 3}, batch.keys)
+
+	// Phase 2: scan parts → load span data.
+	sb, phase2Err := tr.buildVectorizedScanBatch(ctx, []*tsTable{tst}, qo, batch)
+	require.NoError(t, phase2Err)
+	require.NotNil(t, sb)
+
+	result, matErr := newVectorizedTraceQueryResult(ctx, sb, qo, nil, nil, nil, nil)
+	require.NoError(t, matErr)
+	require.NotNil(t, result)
+	defer result.Release()
+
+	got := collectResults(t, result)
+	require.Len(t, got, 3, "order-mode vectorized query must return one result per trace")
+	require.Equal(t, "trace1", got[0].TID)
+	require.Equal(t, [][]byte{[]byte("span1")}, got[0].Spans)
+	require.Equal(t, []string{"span1"}, got[0].SpanIDs)
+	require.Equal(t, "trace2", got[1].TID)
+	require.Equal(t, [][]byte{[]byte("span2")}, got[1].Spans)
+	require.Equal(t, []string{"span2"}, got[1].SpanIDs)
+	require.Equal(t, "trace3", got[2].TID)
+	require.Equal(t, [][]byte{[]byte("span3")}, got[2].Spans)
+	require.Equal(t, []string{"span3"}, got[2].SpanIDs)
 }

--- a/banyand/trace/query_vectorized_test.go
+++ b/banyand/trace/query_vectorized_test.go
@@ -80,6 +80,144 @@ func TestBuildVectorizedPhase1TraceBatchStatic(t *testing.T) {
 	require.Equal(t, map[string]int64{"trace-a": 0}, batch.keys)
 }
 
+// TestBuildVectorizedPhase1TraceBatchStaticDedupLimitParity guards against the
+// regression where deduplication happened BEFORE limit truncation, causing
+// vectorized to return different results than the push path for duplicate IDs.
+// Push path: traceIDs[:limit] → emit first occurrence only.
+// Vectorized (fixed): same — truncate first, then dedup within the window.
+func TestBuildVectorizedPhase1TraceBatchStaticDedupLimitParity(t *testing.T) {
+	tr := &trace{vectorized: vtrace.VectorizedConfig{Enabled: true, BatchSize: 10, QueryMemoryMiB: 1}}
+	// [a, a, b] limit 2: push takes first 2 raw = [a, a], emits a once.
+	// Vectorized must do the same: truncate to [a, a], dedup → [a].
+	batch, err := tr.buildVectorizedPhase1TraceBatch(context.Background(), queryOptions{
+		traceIDs: []string{"a", "a", "b"},
+	}, nil, sidx.QueryRequest{}, false, 2)
+	require.NoError(t, err)
+	require.Equal(t, []string{"a"}, batch.traceIDsOrder,
+		"[a,a,b] limit 2 must yield [a], not [a,b] or [a,a]")
+}
+
+// TestLoadTraceCursorsSyncBudgetPreCheck verifies that the hard-stop and metadata
+// preflight gates in loadTraceCursorsSync prevent over-loading when a budget is set.
+// The test uses budget=1 byte so that after cursor[0] loads any real span data,
+// usedBytes >= 1 and every subsequent cursor is stopped by the hard-stop gate.
+// Loaded cursors are verified to have non-empty spans, confirming loadData ran for
+// them. Cursors absent from the result were released without loading — proven by the
+// fact that filtered count is strictly less than the total.
+func TestLoadTraceCursorsSyncBudgetPreCheck(t *testing.T) {
+	tst, cleanup := newParityTSTable(t, tsTS1)
+	defer cleanup()
+
+	tr := newParityTrace()
+	ctx := context.Background()
+	qo := queryOptions{
+		TraceQueryOptions: model.TraceQueryOptions{TagProjection: allTagProjections},
+		schemaTagTypes:    testSchemaTagTypes,
+		traceIDs:          []string{"trace1", "trace2", "trace3"},
+	}
+
+	phase1Batch, phase1Err := tr.buildVectorizedPhase1TraceBatch(ctx, qo, nil, sidx.QueryRequest{}, false, 0)
+	require.NoError(t, phase1Err)
+
+	sb, sbErr := tr.buildVectorizedScanBatch(ctx, []*tsTable{tst}, qo, phase1Batch)
+	require.NoError(t, sbErr)
+	require.NotNil(t, sb)
+
+	totalCursors := len(sb.cursors)
+	cursors := sb.cursors
+	sb.cursors = nil
+	releaseVectorizedScanBatch(sb)
+
+	require.GreaterOrEqual(t, totalCursors, 2,
+		"fixture must produce ≥2 cursors to exercise the budget gates; check newParityTSTable data")
+
+	// Budget = 1 byte: cursor[0] always loads (usedBytes starts at 0, hard-stop fires only
+	// when usedBytes >= 1). After cursor[0] loads any real span bytes, usedBytes >= 1 and
+	// every subsequent cursor is stopped by the hard-stop gate before loadData is called.
+	loaded, loadErr := loadTraceCursorsSync(ctx, cursors, 1)
+	require.NoError(t, loadErr)
+	require.Less(t, len(loaded), totalCursors,
+		"hard-stop gate must prevent loading cursors once prior spans fill the 1-byte budget")
+	for _, c := range loaded {
+		require.NotEmpty(t, c.spans, "a cursor in the loaded set must have span data (loadData ran)")
+		releaseBlockCursor(c)
+	}
+}
+
+// TestLoadTraceCursorsSyncMetadataPreflight verifies that the metadata preflight
+// gate (not the hard-stop gate) skips a cursor when its bm.uncompressedSpanSizeBytes
+// estimate would push usedBytes over the budget.
+// The test uses budget = firstSize + 1, so after cursor[0] loads (usedBytes = firstSize)
+// the hard-stop condition (usedBytes >= budget) is FALSE, but the preflight condition
+// (usedBytes + cursor[1].estimate > budget) is TRUE — proving the preflight gate fires.
+func TestLoadTraceCursorsSyncMetadataPreflight(t *testing.T) {
+	tst, cleanup := newParityTSTable(t, tsTS1)
+	defer cleanup()
+
+	tr := newParityTrace()
+	ctx := context.Background()
+	qo := queryOptions{
+		TraceQueryOptions: model.TraceQueryOptions{TagProjection: allTagProjections},
+		schemaTagTypes:    testSchemaTagTypes,
+		traceIDs:          []string{"trace1", "trace2", "trace3"},
+	}
+
+	phase1Batch, phase1Err := tr.buildVectorizedPhase1TraceBatch(ctx, qo, nil, sidx.QueryRequest{}, false, 0)
+	require.NoError(t, phase1Err)
+
+	// First pass: measure cursor[0]'s actual span size with an unlimited budget.
+	sb, sbErr := tr.buildVectorizedScanBatch(ctx, []*tsTable{tst}, qo, phase1Batch)
+	require.NoError(t, sbErr)
+	require.NotNil(t, sb)
+	require.GreaterOrEqual(t, len(sb.cursors), 2,
+		"fixture must produce ≥2 cursors; check newParityTSTable data")
+
+	for _, c := range sb.cursors[1:] {
+		releaseBlockCursor(c)
+	}
+	c0Only := sb.cursors[:1]
+	sb.cursors = nil
+	releaseVectorizedScanBatch(sb)
+
+	loaded0, loadErr0 := loadTraceCursorsSync(ctx, c0Only, 0)
+	require.NoError(t, loadErr0)
+	require.Len(t, loaded0, 1, "cursor[0] must load from the test fixture")
+	var firstSize int64
+	for _, span := range loaded0[0].spans {
+		firstSize += int64(len(span))
+	}
+	releaseBlockCursor(loaded0[0])
+	require.Greater(t, firstSize, int64(0), "cursor[0] must have non-empty span data")
+
+	// Second pass: fresh cursors for the actual preflight test.
+	sb2, sbErr2 := tr.buildVectorizedScanBatch(ctx, []*tsTable{tst}, qo, phase1Batch)
+	require.NoError(t, sbErr2)
+	require.NotNil(t, sb2)
+	require.GreaterOrEqual(t, len(sb2.cursors), 2)
+	cursors2 := sb2.cursors
+	sb2.cursors = nil
+	releaseVectorizedScanBatch(sb2)
+	for _, c := range cursors2[2:] {
+		releaseBlockCursor(c)
+	}
+
+	// Set cursor[1]'s metadata estimate so the preflight fires:
+	//   usedBytes (= firstSize) + estimate (= firstSize+1) > budget (= firstSize+1)
+	// The hard-stop condition usedBytes >= budget is FALSE (firstSize < firstSize+1),
+	// so only the preflight branch is responsible for skipping cursor[1].
+	cursors2[1].bm.uncompressedSpanSizeBytes = uint64(firstSize) + 1
+	budget := firstSize + 1
+
+	loaded, loadErr := loadTraceCursorsSync(ctx, cursors2[:2], budget)
+	require.NoError(t, loadErr)
+	require.Len(t, loaded, 1,
+		"metadata preflight must skip cursor[1]: usedBytes+estimate > budget while usedBytes < budget")
+	require.NotEmpty(t, loaded[0].spans, "loaded cursor must have span data (loadData ran)")
+	for _, c := range loaded {
+		releaseBlockCursor(c)
+	}
+}
+
 func TestNewVectorizedTraceQueryResultEmptyBatch(t *testing.T) {
 	finished := false
 	result, err := newVectorizedTraceQueryResult(context.Background(), &scanBatch{}, queryOptions{}, nil, nil, func(hit int, resultErr error) {
@@ -107,14 +245,14 @@ func TestQueryResultSyncCursorLoaderHonorsContextCancel(t *testing.T) {
 	// loadTraceCursorsSync owns the cursors: on cancellation it releases
 	// every loaded and pending cursor itself, so no defer-release here.
 	cursor := generateBlockCursor()
-	filtered, err := loadTraceCursorsSync(ctx, []*blockCursor{cursor})
+	filtered, err := loadTraceCursorsSync(ctx, []*blockCursor{cursor}, 0)
 	require.Nil(t, filtered)
 	require.Error(t, err)
 }
 
 func TestSyncSIDXQuerierToVectorizedIterators(t *testing.T) {
-	iters, err := syncSIDXQuerierToVectorizedIterators(context.Background(), []syncSIDXQuerier{
-		&fakeSyncSIDX{responses: []*sidx.QueryResponse{
+	iters, err := sidxInstancesToVectorizedIterators(context.Background(), []sidx.SIDX{
+		&fakeSyncSIDX{fakeSIDX: &fakeSIDX{}, responses: []*sidx.QueryResponse{
 			{
 				Keys:    []int64{1},
 				Data:    [][]byte{{0x01, 'a'}},
@@ -135,18 +273,19 @@ func TestSyncSIDXQuerierToVectorizedIterators(t *testing.T) {
 }
 
 func TestSyncSIDXQuerierToVectorizedIteratorsReturnsQueryError(t *testing.T) {
-	_, err := syncSIDXQuerierToVectorizedIterators(context.Background(), []syncSIDXQuerier{
-		&fakeSyncSIDX{err: fmt.Errorf("boom")},
+	_, err := sidxInstancesToVectorizedIterators(context.Background(), []sidx.SIDX{
+		&fakeSyncSIDX{fakeSIDX: &fakeSIDX{}, err: fmt.Errorf("boom")},
 	}, sidx.QueryRequest{})
 	require.Error(t, err)
 }
 
 type fakeSyncSIDX struct {
-	err       error
+	err error
+	*fakeSIDX
 	responses []*sidx.QueryResponse
 }
 
-func (f *fakeSyncSIDX) QuerySync(context.Context, sidx.QueryRequest) ([]*sidx.QueryResponse, error) {
+func (f *fakeSyncSIDX) QuerySync(_ context.Context, _ sidx.QueryRequest) ([]*sidx.QueryResponse, error) {
 	return f.responses, f.err
 }
 

--- a/banyand/trace/query_vectorized_test.go
+++ b/banyand/trace/query_vectorized_test.go
@@ -1,0 +1,190 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trace
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/apache/skywalking-banyandb/api/common"
+	"github.com/apache/skywalking-banyandb/banyand/internal/sidx"
+	vtrace "github.com/apache/skywalking-banyandb/pkg/query/vectorized/trace"
+)
+
+func TestSidxResponseToVectorizedBatch(t *testing.T) {
+	resp := &sidx.QueryResponse{
+		Keys:    []int64{1},
+		Data:    [][]byte{{0x01, 'a'}},
+		SIDs:    []common.SeriesID{2},
+		PartIDs: []uint64{3},
+	}
+	batch, err := sidxResponseToVectorizedBatch(resp)
+	require.NoError(t, err)
+	require.Equal(t, []int64{1}, batch.Keys)
+	require.Equal(t, [][]byte{{0x01, 'a'}}, batch.Data)
+	require.Equal(t, []int64{2}, batch.SIDs)
+	require.Equal(t, []int64{3}, batch.PartIDs)
+
+	resp.Data[0][1] = 'b'
+	require.Equal(t, []byte{0x01, 'a'}, batch.Data[0])
+}
+
+func TestSidxResponseToVectorizedBatchRejectsInvalidShape(t *testing.T) {
+	_, err := sidxResponseToVectorizedBatch(&sidx.QueryResponse{
+		Keys: []int64{1},
+		Data: [][]byte{{0x01, 'a'}},
+	})
+	require.Error(t, err)
+}
+
+func TestDrainVectorizedPhase1(t *testing.T) {
+	plan, err := vtrace.BuildStaticPhase1([]string{"trace-a", "trace-b", "trace-c"}, map[string]int64{"trace-b": 2}, 2, 10)
+	require.NoError(t, err)
+	batch, err := drainVectorizedPhase1(context.Background(), plan, 7)
+	require.NoError(t, err)
+	require.Equal(t, 7, batch.seq)
+	require.Equal(t, map[uint64][]string{0: {"trace-a", "trace-b"}}, batch.traceIDs)
+	require.Equal(t, []string{"trace-a", "trace-b"}, batch.traceIDsOrder)
+	require.Equal(t, map[string]int64{"trace-a": 0, "trace-b": 2}, batch.keys)
+}
+
+func TestBuildVectorizedPhase1TraceBatchStatic(t *testing.T) {
+	tr := &trace{vectorized: vtrace.VectorizedConfig{Enabled: true, BatchSize: 1, QueryMemoryMiB: 1}}
+	batch, err := tr.buildVectorizedPhase1TraceBatch(context.Background(), queryOptions{
+		traceIDs: []string{"trace-a", "trace-b"},
+	}, nil, sidx.QueryRequest{}, false, 1)
+	require.NoError(t, err)
+	require.Equal(t, []string{"trace-a"}, batch.traceIDsOrder)
+	require.Equal(t, map[uint64][]string{0: {"trace-a"}}, batch.traceIDs)
+	require.Equal(t, map[string]int64{"trace-a": 0}, batch.keys)
+}
+
+func TestNewVectorizedTraceQueryResultEmptyBatch(t *testing.T) {
+	finished := false
+	result, err := newVectorizedTraceQueryResult(context.Background(), &scanBatch{}, queryOptions{}, nil, nil, func(hit int, resultErr error) {
+		finished = true
+		require.Equal(t, 0, hit)
+		require.NoError(t, resultErr)
+	}, nil)
+	require.NoError(t, err)
+	require.Nil(t, result.Pull())
+	result.Release()
+	require.True(t, finished)
+}
+
+func TestNewVectorizedTraceQueryResultReturnsBatchError(t *testing.T) {
+	_, err := newVectorizedTraceQueryResult(context.Background(), &scanBatch{
+		traceBatch: traceBatch{err: fmt.Errorf("batch failed")},
+		err:        fmt.Errorf("batch failed"),
+	}, queryOptions{}, nil, nil, nil, nil)
+	require.Error(t, err)
+}
+
+func TestQueryResultSyncCursorLoaderHonorsContextCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	// loadTraceCursorsSync owns the cursors: on cancellation it releases
+	// every loaded and pending cursor itself, so no defer-release here.
+	cursor := generateBlockCursor()
+	filtered, err := loadTraceCursorsSync(ctx, []*blockCursor{cursor})
+	require.Nil(t, filtered)
+	require.Error(t, err)
+}
+
+func TestSyncSIDXQuerierToVectorizedIterators(t *testing.T) {
+	iters, err := syncSIDXQuerierToVectorizedIterators(context.Background(), []syncSIDXQuerier{
+		&fakeSyncSIDX{responses: []*sidx.QueryResponse{
+			{
+				Keys:    []int64{1},
+				Data:    [][]byte{{0x01, 'a'}},
+				SIDs:    []common.SeriesID{2},
+				PartIDs: []uint64{3},
+			},
+		}},
+	}, sidx.QueryRequest{})
+	require.NoError(t, err)
+	require.Len(t, iters, 1)
+	require.True(t, iters[0].Next())
+	item := iters[0].Val()
+	require.Equal(t, int64(1), item.Key)
+	require.Equal(t, int64(2), item.SeriesID)
+	require.Equal(t, int64(3), item.PartID)
+	require.Equal(t, []byte{0x01, 'a'}, item.Payload)
+	require.NoError(t, iters[0].Close())
+}
+
+func TestSyncSIDXQuerierToVectorizedIteratorsReturnsQueryError(t *testing.T) {
+	_, err := syncSIDXQuerierToVectorizedIterators(context.Background(), []syncSIDXQuerier{
+		&fakeSyncSIDX{err: fmt.Errorf("boom")},
+	}, sidx.QueryRequest{})
+	require.Error(t, err)
+}
+
+type fakeSyncSIDX struct {
+	err       error
+	responses []*sidx.QueryResponse
+}
+
+func (f *fakeSyncSIDX) QuerySync(context.Context, sidx.QueryRequest) ([]*sidx.QueryResponse, error) {
+	return f.responses, f.err
+}
+
+func TestLoadedCursorSource(t *testing.T) {
+	// Build two fake blockCursors with 2 spans each.
+	cursorA := generateBlockCursor()
+	cursorA.bm.traceID = "trace-a"
+	cursorA.spans = [][]byte{[]byte("spanA1"), []byte("spanA2")}
+	cursorA.spanIDs = []string{"sA1", "sA2"}
+
+	cursorB := generateBlockCursor()
+	cursorB.bm.traceID = "trace-b"
+	cursorB.spans = [][]byte{[]byte("spanB1"), []byte("spanB2")}
+	cursorB.spanIDs = []string{"sB1", "sB2"}
+
+	keys := map[string]int64{"trace-a": 10, "trace-b": 20}
+	schema := vtrace.NewPhase2Schema(nil)
+	source := newLoadedCursorSource([]*blockCursor{cursorA, cursorB}, schema, keys, nil, nil)
+
+	ctx := context.Background()
+	require.NoError(t, source.Init(ctx))
+
+	batchA, err := source.NextBatch(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, batchA)
+	require.Equal(t, 2, batchA.Len)
+	require.Equal(t, []string{"trace-a", "trace-a"}, vtrace.Phase2TraceIDs(batchA).Data())
+	require.Equal(t, []int64{10, 10}, vtrace.Phase2Keys(batchA).Data())
+	require.Equal(t, [][]byte{[]byte("spanA1"), []byte("spanA2")}, vtrace.Phase2Spans(batchA).Data())
+	require.Equal(t, []string{"sA1", "sA2"}, vtrace.Phase2SpanIDs(batchA).Data())
+
+	batchB, err := source.NextBatch(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, batchB)
+	require.Equal(t, 2, batchB.Len)
+	require.Equal(t, []string{"trace-b", "trace-b"}, vtrace.Phase2TraceIDs(batchB).Data())
+	require.Equal(t, []int64{20, 20}, vtrace.Phase2Keys(batchB).Data())
+
+	done, err := source.NextBatch(ctx)
+	require.NoError(t, err)
+	require.Nil(t, done)
+
+	require.NoError(t, source.Close())
+}

--- a/banyand/trace/streaming_pipeline.go
+++ b/banyand/trace/streaming_pipeline.go
@@ -364,7 +364,7 @@ func newSIDXStreamRunner(
 		streamCtx:    streamCtx,
 		cancelFunc:   cancel,
 		req:          req,
-		batchSize: batchSize,
+		batchSize:    batchSize,
 		heap:         &sidxStreamHeap{asc: asc},
 		seenTraceIDs: make(map[string]struct{}),
 		batch:        newTraceBatch(0, batchSize),

--- a/banyand/trace/streaming_pipeline.go
+++ b/banyand/trace/streaming_pipeline.go
@@ -307,7 +307,6 @@ type sidxStreamRunner struct {
 	req            sidx.QueryRequest
 	batch          traceBatch
 	errWg          sync.WaitGroup
-	maxTraceSize   int
 	nextSeq        int
 	total          atomic.Int64
 	batchesEmitted atomic.Int64
@@ -365,8 +364,7 @@ func newSIDXStreamRunner(
 		streamCtx:    streamCtx,
 		cancelFunc:   cancel,
 		req:          req,
-		maxTraceSize: maxTraceSize,
-		batchSize:    batchSize,
+		batchSize: batchSize,
 		heap:         &sidxStreamHeap{asc: asc},
 		seenTraceIDs: make(map[string]struct{}),
 		batch:        newTraceBatch(0, batchSize),

--- a/banyand/trace/streaming_pipeline.go
+++ b/banyand/trace/streaming_pipeline.go
@@ -48,6 +48,7 @@ type traceBatch struct {
 type scanBatch struct {
 	err       error
 	cursorCh  <-chan scanCursorResult
+	cursors   []*blockCursor
 	snapshots []*snapshot
 	traceBatch
 }
@@ -809,8 +810,27 @@ type scanCursorResult struct {
 }
 
 func (t *trace) scanPartsInline(ctx context.Context, parts []*part, groupedIDs [][]string, qo queryOptions, out chan<- scanCursorResult) {
-	if len(parts) == 0 {
+	cursors, scanErr := t.scanPartsInlineSync(ctx, parts, groupedIDs, qo)
+	if scanErr != nil {
+		select {
+		case out <- scanCursorResult{err: scanErr}:
+		case <-ctx.Done():
+		}
 		return
+	}
+	for _, cursor := range cursors {
+		select {
+		case out <- scanCursorResult{cursor: cursor}:
+		case <-ctx.Done():
+			releaseBlockCursor(cursor)
+			return
+		}
+	}
+}
+
+func (t *trace) scanPartsInlineSync(ctx context.Context, parts []*part, groupedIDs [][]string, qo queryOptions) ([]*blockCursor, error) {
+	if len(parts) == 0 {
+		return nil, nil
 	}
 
 	recordBlock, finishSpan := startAggregatedBlockScanSpan(ctx, groupedIDs, parts)
@@ -836,15 +856,12 @@ func (t *trace) scanPartsInline(ctx context.Context, parts []*part, groupedIDs [
 	tstIter.init(bma, parts, groupedIDs)
 	if initErr := tstIter.Error(); initErr != nil {
 		spanErr = fmt.Errorf("cannot init tstIter: %w", initErr)
-		select {
-		case out <- scanCursorResult{err: spanErr}:
-		case <-ctx.Done():
-		}
-		return
+		return nil, spanErr
 	}
 
 	quota := t.pm.AvailableBytes()
 	hit := 0
+	cursors := make([]*blockCursor, 0)
 
 	for tstIter.nextBlock() {
 		if hit%checkDoneEvery == 0 {
@@ -852,7 +869,10 @@ func (t *trace) scanPartsInline(ctx context.Context, parts []*part, groupedIDs [
 			case <-ctx.Done():
 				spanErr = pkgerrors.WithMessagef(ctx.Err(), "interrupt: scanned %d blocks, remained %d/%d parts to scan",
 					cursorCount, len(tstIter.piPool)-tstIter.idx, len(tstIter.piPool))
-				return
+				for _, cursor := range cursors {
+					releaseBlockCursor(cursor)
+				}
+				return nil, spanErr
 			default:
 			}
 		}
@@ -869,15 +889,11 @@ func (t *trace) scanPartsInline(ctx context.Context, parts []*part, groupedIDs [
 			releaseBlockCursor(bc)
 			if cursorCount > 0 {
 				// Have results, return them successfully by just closing channel
-				return
+				return cursors, nil
 			}
 			// No results, send error
 			spanErr = fmt.Errorf("block scan quota exceeded: block size %d bytes, quota is %d bytes", blockSize, quota)
-			select {
-			case out <- scanCursorResult{err: spanErr}:
-			case <-ctx.Done():
-			}
-			return
+			return nil, spanErr
 		}
 
 		// Quota OK, send cursor
@@ -886,22 +902,15 @@ func (t *trace) scanPartsInline(ctx context.Context, parts []*part, groupedIDs [
 		}
 		spanBlockBytes += blockSize
 		cursorCount++
-
-		select {
-		case out <- scanCursorResult{cursor: bc}:
-		case <-ctx.Done():
-			releaseBlockCursor(bc)
-			spanErr = pkgerrors.WithMessagef(ctx.Err(), "interrupt: scanned %d blocks", cursorCount)
-			return
-		}
+		cursors = append(cursors, bc)
 	}
 
 	if iterErr := tstIter.Error(); iterErr != nil {
 		spanErr = fmt.Errorf("cannot iterate tstIter: %w", iterErr)
-		select {
-		case out <- scanCursorResult{err: spanErr}:
-		case <-ctx.Done():
+		for _, cursor := range cursors {
+			releaseBlockCursor(cursor)
 		}
-		return
+		return nil, spanErr
 	}
+	return cursors, nil
 }

--- a/banyand/trace/streaming_pipeline_test.go
+++ b/banyand/trace/streaming_pipeline_test.go
@@ -66,6 +66,10 @@ func (f *fakeSIDX) ConvertToMemPart([]sidx.WriteRequest, int64, *int64, *int64) 
 func (f *fakeSIDX) Query(context.Context, sidx.QueryRequest) (*sidx.QueryResponse, error) {
 	panic("not implemented")
 }
+
+func (f *fakeSIDX) QuerySync(_ context.Context, _ sidx.QueryRequest) ([]*sidx.QueryResponse, error) {
+	return f.responses, nil
+}
 func (f *fakeSIDX) Stats(context.Context) (*sidx.Stats, error) { return &sidx.Stats{}, nil }
 func (f *fakeSIDX) Close() error                               { return nil }
 func (f *fakeSIDX) Flush(map[uint64]struct{}) (*sidx.FlusherIntroduction, error) {
@@ -192,7 +196,6 @@ func TestStreamSIDXTraceBatches_ProducesOrderedBatches(t *testing.T) {
 		t.Fatalf("expected 2 batches, got %d", len(batches))
 	}
 
-	// First batch should have trace IDs grouped by partID
 	wantBatch0 := map[uint64][]string{
 		100: {"a"},
 		101: {"b"},
@@ -201,7 +204,6 @@ func TestStreamSIDXTraceBatches_ProducesOrderedBatches(t *testing.T) {
 		t.Fatalf("first batch mismatch (-want +got):\n%s", diff)
 	}
 
-	// Second batch should have trace ID in partID 102
 	wantBatch1 := map[uint64][]string{
 		102: {"c"},
 	}
@@ -264,7 +266,6 @@ func TestStreamSIDXTraceBatches_OrdersDescending(t *testing.T) {
 		t.Fatalf("expected 2 batches, got %d", len(batches))
 	}
 
-	// First batch should have trace IDs grouped by partID
 	wantBatch0 := map[uint64][]string{
 		200: {"e"},
 		201: {"d"},
@@ -273,7 +274,6 @@ func TestStreamSIDXTraceBatches_OrdersDescending(t *testing.T) {
 		t.Fatalf("first batch mismatch (-want +got):\n%s", diff)
 	}
 
-	// Second batch should have trace ID in partID 202
 	wantBatch1 := map[uint64][]string{
 		202: {"c"},
 	}
@@ -334,7 +334,6 @@ func TestStreamSIDXTraceBatches_PropagatesErrorAfterCancellation(t *testing.T) {
 			errSeen = true
 			continue
 		}
-		// Check if batch has any trace IDs in the map
 		for _, ids := range batch.traceIDs {
 			if len(ids) > 0 {
 				dataSeen = true
@@ -595,6 +594,10 @@ func (f *fakeSIDXInfinite) ScanQuery(context.Context, sidx.ScanQueryRequest) ([]
 	return nil, nil
 }
 
+func (f *fakeSIDXInfinite) QuerySync(_ context.Context, _ sidx.QueryRequest) ([]*sidx.QueryResponse, error) {
+	return nil, nil
+}
+
 func (f *fakeSIDXInfinite) StreamingQuery(ctx context.Context, _ sidx.QueryRequest) (<-chan *sidx.QueryResponse, <-chan error) {
 	results := make(chan *sidx.QueryResponse)
 	errCh := make(chan error, 1)
@@ -612,7 +615,6 @@ func (f *fakeSIDXInfinite) StreamingQuery(ctx context.Context, _ sidx.QueryReque
 				errCh <- ctx.Err()
 				return
 			default:
-				// Generate a batch of responses
 				batchSize := f.batchSize
 				if batchSize <= 0 {
 					batchSize = 10
@@ -630,7 +632,7 @@ func (f *fakeSIDXInfinite) StreamingQuery(ctx context.Context, _ sidx.QueryReque
 					}
 					traceID := prefix + "-" + strconv.Itoa(counter)
 					data[i] = encodeTraceIDForTest(traceID)
-					partIDs[i] = uint64(1000 + counter) // Generate unique partIDs
+					partIDs[i] = uint64(1000 + counter)
 					key++
 					counter++
 				}
@@ -646,7 +648,6 @@ func (f *fakeSIDXInfinite) StreamingQuery(ctx context.Context, _ sidx.QueryReque
 					errCh <- ctx.Err()
 					return
 				case results <- resp:
-					// Continue to next iteration
 				}
 			}
 		}

--- a/banyand/trace/svc_liaison.go
+++ b/banyand/trace/svc_liaison.go
@@ -141,6 +141,7 @@ func (l *liaison) FlagSet() *run.FlagSet {
 		"percentage of BanyanDB's allowed disk usage allocated to failed parts storage. "+
 			"Calculated as: totalDisk * trace-max-disk-usage-percent * failed-parts-max-size-percent / 10000. "+
 			"Set to 0 to disable copying failed parts. Valid range: 0-100")
+	bindVectorizedFlags(fs, &l.option.vectorized)
 	return fs
 }
 
@@ -162,8 +163,7 @@ func (l *liaison) Validate() error {
 	if l.failedPartsMaxSizePercent < 0 || l.failedPartsMaxSizePercent > 100 {
 		return fmt.Errorf("invalid failed-parts-max-size-percent: %d%%. Must be between 0 and 100", l.failedPartsMaxSizePercent)
 	}
-
-	return nil
+	return l.option.vectorized.Validate()
 }
 
 func (l *liaison) Name() string {

--- a/banyand/trace/svc_standalone.go
+++ b/banyand/trace/svc_standalone.go
@@ -97,6 +97,7 @@ func (s *standalone) FlagSet() *run.FlagSet {
 	s.option.mergePolicy = newDefaultMergePolicy()
 	fs.IntVar(&s.option.mergePolicy.maxParts, "trace-max-merge-parts", s.option.mergePolicy.maxParts, "the maximum number of parts to merge at once")
 	fs.VarP(&s.option.mergePolicy.maxFanOutSize, "trace-max-fan-out-size", "", "the upper bound of a single file size after merge of trace")
+	bindVectorizedFlags(fs, &s.option.vectorized)
 	// Additional flags can be added here
 	return fs
 }
@@ -122,8 +123,7 @@ func (s *standalone) Validate() error {
 	if s.retentionConfig.Cooldown <= 0 {
 		return errors.New("trace-retention-cooldown must be greater than 0")
 	}
-
-	return nil
+	return s.option.vectorized.Validate()
 }
 
 func (s *standalone) Name() string {

--- a/banyand/trace/trace.go
+++ b/banyand/trace/trace.go
@@ -33,6 +33,7 @@ import (
 	"github.com/apache/skywalking-banyandb/banyand/queue"
 	"github.com/apache/skywalking-banyandb/pkg/logger"
 	"github.com/apache/skywalking-banyandb/pkg/query/model"
+	vtrace "github.com/apache/skywalking-banyandb/pkg/query/vectorized/trace"
 	"github.com/apache/skywalking-banyandb/pkg/run"
 	"github.com/apache/skywalking-banyandb/pkg/schema"
 	"github.com/apache/skywalking-banyandb/pkg/timestamp"
@@ -58,6 +59,7 @@ type option struct {
 	flushTimeout                 time.Duration
 	syncInterval                 time.Duration
 	failedPartsMaxTotalSizeBytes uint64
+	vectorized                   vtrace.VectorizedConfig
 }
 
 // Service allows inspecting the trace data.
@@ -108,6 +110,7 @@ type trace struct {
 	schemaRepo  *schemaRepo
 	name        string
 	group       string
+	vectorized  vtrace.VectorizedConfig
 }
 
 func (t *trace) GetSchema() *databasev1.Trace {
@@ -138,13 +141,30 @@ func (t *trace) parseSpec() {
 	t.indexSchema.Store(is)
 }
 
-func openTrace(schema *databasev1.Trace, l *logger.Logger, pm protector.Memory, schemaRepo *schemaRepo) *trace {
+func openTrace(schema *databasev1.Trace, l *logger.Logger, pm protector.Memory, schemaRepo *schemaRepo, vectorized vtrace.VectorizedConfig) *trace {
 	t := &trace{
 		schema:     schema,
 		l:          l,
 		pm:         pm,
 		schemaRepo: schemaRepo,
+		vectorized: vectorized,
 	}
 	t.parseSpec()
 	return t
+}
+
+// VectorizedConfig returns the per-Trace vectorized query configuration.
+func (t *trace) VectorizedConfig() vtrace.VectorizedConfig {
+	return t.vectorized
+}
+
+// bindVectorizedFlags wires VectorizedConfig fields to a run.FlagSet.
+func bindVectorizedFlags(flagS *run.FlagSet, cfg *vtrace.VectorizedConfig) {
+	defaults := vtrace.DefaultConfig()
+	flagS.BoolVar(&cfg.Enabled, "trace-vectorized-enabled", defaults.Enabled,
+		"enable the vectorized trace query path")
+	flagS.IntVar(&cfg.BatchSize, "trace-vectorized-batch-size", defaults.BatchSize,
+		"row count per vectorized trace batch")
+	flagS.IntVar(&cfg.QueryMemoryMiB, "trace-vectorized-query-memory-mib", defaults.QueryMemoryMiB,
+		"per-query memory budget for the vectorized trace path, in MiB")
 }

--- a/banyand/trace/vectorized_bench_test.go
+++ b/banyand/trace/vectorized_bench_test.go
@@ -29,7 +29,7 @@ import (
 // BenchmarkRowBasedVsVectorized_Lookup compares the original row-based goroutine path
 // (startBlockScanStage → queryResult) against the new vectorized pull path
 // (buildVectorizedScanBatch → vectorizedTraceQueryResult) for traceID lookup queries.
-// Run with: go test -bench=BenchmarkRowBasedVsVectorized_Lookup -benchmem ./banyand/trace/
+// Run with: go test -bench=BenchmarkRowBasedVsVectorized_Lookup -benchmem ./banyand/trace/.
 func BenchmarkRowBasedVsVectorized_Lookup(b *testing.B) {
 	tst, cleanup := newParityTSTable(b, tsTS1, tsTS2)
 	defer cleanup()

--- a/banyand/trace/vectorized_bench_test.go
+++ b/banyand/trace/vectorized_bench_test.go
@@ -1,0 +1,79 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trace
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/apache/skywalking-banyandb/pkg/query/model"
+)
+
+// BenchmarkRowBasedVsVectorized_Lookup compares the original row-based goroutine path
+// (startBlockScanStage → queryResult) against the new vectorized pull path
+// (buildVectorizedScanBatch → vectorizedTraceQueryResult) for traceID lookup queries.
+// Run with: go test -bench=BenchmarkRowBasedVsVectorized_Lookup -benchmem ./banyand/trace/
+func BenchmarkRowBasedVsVectorized_Lookup(b *testing.B) {
+	tst, cleanup := newParityTSTable(b, tsTS1, tsTS2)
+	defer cleanup()
+
+	tr := newParityTrace()
+	tables := []*tsTable{tst}
+	qo := queryOptions{
+		TraceQueryOptions: model.TraceQueryOptions{TagProjection: allTagProjections},
+		schemaTagTypes:    testSchemaTagTypes,
+	}
+	traceIDs := []string{"trace1", "trace2", "trace3"}
+
+	b.Run("RowBased", func(b *testing.B) {
+		b.ResetTimer()
+		for benchIdx := 0; benchIdx < b.N; benchIdx++ {
+			ctx := context.Background()
+			pushRes := pushLookupResult(ctx, tr, tables, qo, traceIDs, 0)
+			for {
+				r := pushRes.Pull()
+				if r == nil {
+					break
+				}
+			}
+			b.StopTimer()
+			pushRes.Release()
+			b.StartTimer()
+		}
+	})
+
+	b.Run("Vectorized", func(b *testing.B) {
+		b.ResetTimer()
+		for benchIdx := 0; benchIdx < b.N; benchIdx++ {
+			ctx := context.Background()
+			pullRes, pullErr := pullLookupResult(ctx, tr, tables, qo, traceIDs, 0)
+			require.NoError(b, pullErr)
+			for {
+				r := pullRes.Pull()
+				if r == nil {
+					break
+				}
+			}
+			b.StopTimer()
+			pullRes.Release()
+			b.StartTimer()
+		}
+	})
+}

--- a/banyand/trace/vectorized_parity_test.go
+++ b/banyand/trace/vectorized_parity_test.go
@@ -172,10 +172,10 @@ func TestVectorizedParityLookup(t *testing.T) {
 	tables := []*tsTable{tst}
 
 	tests := []struct {
+		tagProjection *model.TagProjection
 		name          string
 		traceIDs      []string
 		maxTraceSize  int
-		tagProjection *model.TagProjection
 		wantCount     int
 		wantNilTags   bool
 	}{
@@ -240,10 +240,10 @@ func TestVectorizedParityOrderMode(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		sortDir   modelv1.Sort
 		keys      []int64
 		traceIDs  []string
 		wantCount int
+		sortDir   modelv1.Sort
 	}{
 		{
 			name:      "ASC order all traces",

--- a/banyand/trace/vectorized_parity_test.go
+++ b/banyand/trace/vectorized_parity_test.go
@@ -239,11 +239,12 @@ func TestVectorizedParityOrderMode(t *testing.T) {
 	}
 
 	tests := []struct {
-		name      string
-		keys      []int64
-		traceIDs  []string
-		wantCount int
-		sortDir   modelv1.Sort
+		name         string
+		keys         []int64
+		traceIDs     []string
+		maxTraceSize int
+		wantCount    int
+		sortDir      modelv1.Sort
 	}{
 		{
 			name:      "ASC order all traces",
@@ -258,6 +259,24 @@ func TestVectorizedParityOrderMode(t *testing.T) {
 			keys:      []int64{3, 2, 1},
 			traceIDs:  []string{"trace3", "trace2", "trace1"},
 			wantCount: 3,
+		},
+		{
+			// MaxTraceSize is a batch-size hint for ordered SIDX queries, not a total cap.
+			// The push path emits all 3 traces in batches of 2; vectorized must match.
+			name:         "ASC order MaxTraceSize=2 with 3 traces returns all 3",
+			sortDir:      modelv1.Sort_SORT_ASC,
+			keys:         []int64{1, 2, 3},
+			traceIDs:     []string{"trace1", "trace2", "trace3"},
+			maxTraceSize: 2,
+			wantCount:    3,
+		},
+		{
+			name:         "DESC order MaxTraceSize=2 with 3 traces returns all 3",
+			sortDir:      modelv1.Sort_SORT_DESC,
+			keys:         []int64{3, 2, 1},
+			traceIDs:     []string{"trace3", "trace2", "trace1"},
+			maxTraceSize: 2,
+			wantCount:    3,
 		},
 	}
 
@@ -287,11 +306,11 @@ func TestVectorizedParityOrderMode(t *testing.T) {
 				syncResponses: sharedResp,
 			}
 
-			pushRes := pushOrderResult(ctx, tr, tables, qo, fakeSIDXInst, req, 0)
+			pushRes := pushOrderResult(ctx, tr, tables, qo, fakeSIDXInst, req, tt.maxTraceSize)
 			defer pushRes.Release()
 			pushGot := collectResults(t, pushRes)
 
-			pullRes, pullErr := pullOrderResult(ctx, tr, tables, qo, fakeSIDXInst, req, 0)
+			pullRes, pullErr := pullOrderResult(ctx, tr, tables, qo, fakeSIDXInst, req, tt.maxTraceSize)
 			require.NoError(t, pullErr)
 			defer pullRes.Release()
 			pullGot := collectResults(t, pullRes)

--- a/banyand/trace/vectorized_parity_test.go
+++ b/banyand/trace/vectorized_parity_test.go
@@ -1,0 +1,465 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trace
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
+
+	"github.com/apache/skywalking-banyandb/api/common"
+	commonv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/common/v1"
+	modelv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/model/v1"
+	"github.com/apache/skywalking-banyandb/banyand/internal/sidx"
+	"github.com/apache/skywalking-banyandb/banyand/protector"
+	"github.com/apache/skywalking-banyandb/pkg/fs"
+	"github.com/apache/skywalking-banyandb/pkg/index"
+	"github.com/apache/skywalking-banyandb/pkg/logger"
+	"github.com/apache/skywalking-banyandb/pkg/query"
+	"github.com/apache/skywalking-banyandb/pkg/query/model"
+	vtrace "github.com/apache/skywalking-banyandb/pkg/query/vectorized/trace"
+	"github.com/apache/skywalking-banyandb/pkg/test"
+	"github.com/apache/skywalking-banyandb/pkg/timestamp"
+)
+
+// collectResults drains a TraceQueryResult into a slice, asserting no per-result error.
+func collectResults(t *testing.T, result model.TraceQueryResult) []*model.TraceResult {
+	t.Helper()
+	var got []*model.TraceResult
+	for {
+		r := result.Pull()
+		if r == nil {
+			break
+		}
+		require.NoError(t, r.Error)
+		got = append(got, r)
+	}
+	return got
+}
+
+// newParityTSTable sets up an in-memory tsTable populated with the given trace sets.
+func newParityTSTable(tb testing.TB, traceSets ...*traces) (*tsTable, func()) {
+	tb.Helper()
+	tmpPath, defFn := test.Space(require.New(tb))
+	tst, tsErr := newTSTable(
+		fs.NewLocalFileSystem(), tmpPath, common.Position{},
+		logger.GetLogger("test"), timestamp.TimeRange{},
+		option{flushTimeout: 0, mergePolicy: newDefaultMergePolicyForTesting(), protector: protector.Nop{}},
+		nil,
+	)
+	require.NoError(tb, tsErr)
+	for _, ts := range traceSets {
+		tst.mustAddTraces(ts, nil)
+		time.Sleep(50 * time.Millisecond)
+	}
+	time.Sleep(100 * time.Millisecond)
+	return tst, func() { tst.Close(); defFn() }
+}
+
+func newParityTrace() *trace {
+	return &trace{
+		pm:         protector.Nop{},
+		vectorized: vtrace.VectorizedConfig{Enabled: true, BatchSize: 10, QueryMemoryMiB: 100},
+	}
+}
+
+func pushLookupResult(
+	ctx context.Context,
+	tr *trace,
+	tables []*tsTable,
+	qo queryOptions,
+	traceIDs []string,
+	maxTraceSize int,
+) *queryResult {
+	pushKeys := make(map[string]int64)
+	traceBatchCh := staticTraceBatchSource(ctx, traceIDs, maxTraceSize, pushKeys)
+	cursorBatchCh := tr.startBlockScanStage(ctx, tables, qo, traceBatchCh)
+	return &queryResult{
+		ctx:           ctx,
+		keys:          pushKeys,
+		tagProjection: qo.TagProjection,
+		cursorBatchCh: cursorBatchCh,
+	}
+}
+
+func pullLookupResult(
+	ctx context.Context,
+	tr *trace,
+	tables []*tsTable,
+	qo queryOptions,
+	traceIDs []string,
+	maxTraceSize int,
+) (*vectorizedTraceQueryResult, error) {
+	qo.traceIDs = traceIDs
+	batch, batchErr := tr.buildVectorizedPhase1TraceBatch(ctx, qo, nil, sidx.QueryRequest{}, false, maxTraceSize)
+	if batchErr != nil {
+		return nil, batchErr
+	}
+	sb, sbErr := tr.buildVectorizedScanBatch(ctx, tables, qo, batch)
+	if sbErr != nil {
+		return nil, sbErr
+	}
+	return newVectorizedTraceQueryResult(ctx, sb, qo, nil, nil, nil, nil)
+}
+
+func pushOrderResult(
+	ctx context.Context,
+	tr *trace,
+	tables []*tsTable,
+	qo queryOptions,
+	fakeSIDXInst *fakeSIDXWithSync,
+	req sidx.QueryRequest,
+	maxTraceSize int,
+) *queryResult {
+	traceBatchCh, streamDone := tr.streamSIDXTraceBatches(ctx, []sidx.SIDX{fakeSIDXInst}, req, maxTraceSize)
+	cursorBatchCh := tr.startBlockScanStage(ctx, tables, qo, traceBatchCh)
+	return &queryResult{
+		ctx:           ctx,
+		keys:          make(map[string]int64),
+		tagProjection: qo.TagProjection,
+		cursorBatchCh: cursorBatchCh,
+		streamDone:    streamDone,
+	}
+}
+
+func pullOrderResult(
+	ctx context.Context,
+	tr *trace,
+	tables []*tsTable,
+	qo queryOptions,
+	fakeSIDXInst *fakeSIDXWithSync,
+	req sidx.QueryRequest,
+	maxTraceSize int,
+) (*vectorizedTraceQueryResult, error) {
+	batch, batchErr := tr.buildVectorizedPhase1TraceBatch(ctx, qo, []sidx.SIDX{fakeSIDXInst}, req, true, maxTraceSize)
+	if batchErr != nil {
+		return nil, batchErr
+	}
+	sb, sbErr := tr.buildVectorizedScanBatch(ctx, tables, qo, batch)
+	if sbErr != nil {
+		return nil, sbErr
+	}
+	return newVectorizedTraceQueryResult(ctx, sb, qo, nil, nil, nil, nil)
+}
+
+// TestVectorizedParityLookup verifies that the push and pull paths return
+// byte-identical model.TraceResult sequences for traceID lookup mode.
+func TestVectorizedParityLookup(t *testing.T) {
+	tst, cleanup := newParityTSTable(t, tsTS1, tsTS2)
+	defer cleanup()
+
+	tr := newParityTrace()
+	tables := []*tsTable{tst}
+
+	tests := []struct {
+		name          string
+		traceIDs      []string
+		maxTraceSize  int
+		tagProjection *model.TagProjection
+		wantCount     int
+		wantNilTags   bool
+	}{
+		{name: "single trace", traceIDs: []string{"trace1"}, tagProjection: allTagProjections, wantCount: 1},
+		{name: "all traces", traceIDs: []string{"trace1", "trace2", "trace3"}, tagProjection: allTagProjections, wantCount: 3},
+		{name: "maxTraceSize=2", traceIDs: []string{"trace1", "trace2", "trace3"}, maxTraceSize: 2, tagProjection: allTagProjections, wantCount: 2},
+		{name: "missing trace", traceIDs: []string{"trace-not-exist"}, tagProjection: allTagProjections, wantCount: 0},
+		// AC8: identity-only projection → after omitIdentityTagProjection strips identity tags the
+		// storage-level projection is nil or empty; both push and pull must produce r.Tags == nil.
+		{name: "nil projection (identity-stripped)", traceIDs: []string{"trace1"}, tagProjection: nil, wantCount: 1, wantNilTags: true},
+		{name: "empty projection (identity-stripped)", traceIDs: []string{"trace1"}, tagProjection: &model.TagProjection{Names: []string{}}, wantCount: 1, wantNilTags: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			qo := queryOptions{
+				TraceQueryOptions: model.TraceQueryOptions{TagProjection: tt.tagProjection},
+				schemaTagTypes:    testSchemaTagTypes,
+			}
+
+			pushRes := pushLookupResult(ctx, tr, tables, qo, tt.traceIDs, tt.maxTraceSize)
+			defer pushRes.Release()
+			pushGot := collectResults(t, pushRes)
+
+			pullRes, pullErr := pullLookupResult(ctx, tr, tables, qo, tt.traceIDs, tt.maxTraceSize)
+			require.NoError(t, pullErr)
+			defer pullRes.Release()
+			pullGot := collectResults(t, pullRes)
+
+			require.Len(t, pushGot, tt.wantCount, "push path result count")
+			require.Len(t, pullGot, tt.wantCount, "pull path result count")
+
+			if tt.wantNilTags {
+				for _, r := range pushGot {
+					require.Nil(t, r.Tags, "push path must produce nil Tags for empty projection")
+				}
+				for _, r := range pullGot {
+					require.Nil(t, r.Tags, "pull path must produce nil Tags for empty projection")
+				}
+			}
+
+			if diff := cmp.Diff(pushGot, pullGot, protocmp.Transform()); diff != "" {
+				t.Errorf("push vs pull lookup mismatch (-push +pull):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestVectorizedParityOrderMode verifies that the push and pull paths return
+// byte-identical model.TraceResult sequences for order mode (ASC and DESC).
+func TestVectorizedParityOrderMode(t *testing.T) {
+	tst, cleanup := newParityTSTable(t, tsTS1)
+	defer cleanup()
+
+	tr := newParityTrace()
+	tables := []*tsTable{tst}
+	qo := queryOptions{
+		TraceQueryOptions: model.TraceQueryOptions{TagProjection: allTagProjections},
+		schemaTagTypes:    testSchemaTagTypes,
+	}
+
+	tests := []struct {
+		name      string
+		sortDir   modelv1.Sort
+		keys      []int64
+		traceIDs  []string
+		wantCount int
+	}{
+		{
+			name:      "ASC order all traces",
+			sortDir:   modelv1.Sort_SORT_ASC,
+			keys:      []int64{1, 2, 3},
+			traceIDs:  []string{"trace1", "trace2", "trace3"},
+			wantCount: 3,
+		},
+		{
+			name:      "DESC order all traces",
+			sortDir:   modelv1.Sort_SORT_DESC,
+			keys:      []int64{3, 2, 1},
+			traceIDs:  []string{"trace3", "trace2", "trace1"},
+			wantCount: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			req := sidx.QueryRequest{
+				Order: &index.OrderBy{Sort: tt.sortDir},
+			}
+
+			// Build response data — PartIDs=0 so bloom-filter fallback picks up the parts.
+			respData := make([][]byte, len(tt.traceIDs))
+			for dataIdx, tid := range tt.traceIDs {
+				respData[dataIdx] = encodeTraceIDForTest(tid)
+			}
+			sids := make([]common.SeriesID, len(tt.traceIDs))
+			partIDs := make([]uint64, len(tt.traceIDs))
+
+			// Push (StreamingQuery) and pull (QuerySync) share one response slice so
+			// they always use identical data and cannot drift if either path is rewired.
+			sharedResp := []*sidx.QueryResponse{
+				{Keys: tt.keys, Data: respData, SIDs: sids, PartIDs: partIDs},
+			}
+			fakeSIDXInst := &fakeSIDXWithSync{
+				fakeSIDX:      &fakeSIDX{responses: sharedResp},
+				syncResponses: sharedResp,
+			}
+
+			pushRes := pushOrderResult(ctx, tr, tables, qo, fakeSIDXInst, req, 0)
+			defer pushRes.Release()
+			pushGot := collectResults(t, pushRes)
+
+			pullRes, pullErr := pullOrderResult(ctx, tr, tables, qo, fakeSIDXInst, req, 0)
+			require.NoError(t, pullErr)
+			defer pullRes.Release()
+			pullGot := collectResults(t, pullRes)
+
+			require.Len(t, pushGot, tt.wantCount, "push path result count")
+			require.Len(t, pullGot, tt.wantCount, "pull path result count")
+
+			if diff := cmp.Diff(pushGot, pullGot, protocmp.Transform()); diff != "" {
+				t.Errorf("push vs pull order mismatch (-push +pull):\n%s", diff)
+			}
+		})
+	}
+}
+
+// TestVectorizedOverScanBound verifies AC3: with a MaxTraceSize cap, the pull path
+// builds a phase-1 batch limited to MaxTraceSize trace IDs, so the phase-2 cursor
+// count is strictly less than the uncapped cursor count on the same dataset.
+func TestVectorizedOverScanBound(t *testing.T) {
+	tst, cleanup := newParityTSTable(t, tsTS1, tsTS2)
+	defer cleanup()
+
+	tr := newParityTrace()
+	ctx := context.Background()
+	tables := []*tsTable{tst}
+	qo := queryOptions{
+		TraceQueryOptions: model.TraceQueryOptions{TagProjection: allTagProjections},
+		schemaTagTypes:    testSchemaTagTypes,
+	}
+
+	buildCursorCount := func(traceIDs []string, maxSize int) int {
+		localQO := qo
+		localQO.traceIDs = traceIDs
+		batch, batchErr := tr.buildVectorizedPhase1TraceBatch(ctx, localQO, nil, sidx.QueryRequest{}, false, maxSize)
+		require.NoError(t, batchErr)
+		sb, sbErr := tr.buildVectorizedScanBatch(ctx, tables, localQO, batch)
+		require.NoError(t, sbErr)
+		count := len(sb.cursors)
+		releaseVectorizedScanBatch(sb)
+		return count
+	}
+
+	allIDs := []string{"trace1", "trace2", "trace3"}
+	uncappedCursors := buildCursorCount(allIDs, 0) // no cap → all 3 traces
+	cappedCursors := buildCursorCount(allIDs, 2)   // capped → at most 2 traces
+
+	require.Greater(t, uncappedCursors, 0, "uncapped query must scan at least one cursor")
+	require.LessOrEqual(t, cappedCursors, uncappedCursors,
+		"AC3: pull path with maxTraceSize=2 must scan ≤ cursors of uncapped query")
+	require.Less(t, cappedCursors, uncappedCursors,
+		"AC3: pull path with maxTraceSize=2 must scan fewer cursors than uncapped (early termination)")
+}
+
+// zeroQuotaProtector implements protector.Memory with zero available bytes,
+// simulating a fully-exhausted memory quota.
+type zeroQuotaProtector struct{ protector.Nop }
+
+func (zeroQuotaProtector) AvailableBytes() int64 { return 0 }
+
+func (zeroQuotaProtector) AcquireResource(_ context.Context, _ uint64) error {
+	return fmt.Errorf("quota exhausted")
+}
+
+// TestVectorizedMemoryQuotaAC5 verifies AC5: the pull path respects the memory
+// quota via t.pm.AvailableBytes() — quota=0 on a non-empty table returns an error
+// (no cursors accumulated), matching the push path's scanPartsInline quota semantics.
+func TestVectorizedMemoryQuotaAC5(t *testing.T) {
+	tst, cleanup := newParityTSTable(t, tsTS1)
+	defer cleanup()
+
+	ctx := context.Background()
+	tables := []*tsTable{tst}
+	qo := queryOptions{
+		TraceQueryOptions: model.TraceQueryOptions{TagProjection: allTagProjections},
+		schemaTagTypes:    testSchemaTagTypes,
+	}
+
+	// Pull path with unlimited quota succeeds.
+	unlimitedTrace := &trace{
+		pm:         protector.Nop{},
+		vectorized: vtrace.VectorizedConfig{Enabled: true, BatchSize: 10, QueryMemoryMiB: 100},
+	}
+	qo.traceIDs = []string{"trace1"}
+	unlimitedBatch, unlimitedBatchErr := unlimitedTrace.buildVectorizedPhase1TraceBatch(ctx, qo, nil, sidx.QueryRequest{}, false, 0)
+	require.NoError(t, unlimitedBatchErr)
+	unlimitedSB, unlimitedSBErr := unlimitedTrace.buildVectorizedScanBatch(ctx, tables, qo, unlimitedBatch)
+	require.NoError(t, unlimitedSBErr, "unlimited quota must succeed on non-empty table")
+	require.NotEmpty(t, unlimitedSB.cursors, "unlimited quota must yield cursors")
+	releaseVectorizedScanBatch(unlimitedSB)
+
+	// Pull path with zero quota (fully exhausted) returns a scan error when no cursors
+	// have been accumulated yet, matching push path's "quota exceeded" early-exit.
+	zeroQuotaTrace := &trace{
+		pm:         zeroQuotaProtector{},
+		vectorized: vtrace.VectorizedConfig{Enabled: true, BatchSize: 10, QueryMemoryMiB: 100},
+	}
+	qo.traceIDs = []string{"trace1"}
+	zeroBatch, zeroBatchErr := zeroQuotaTrace.buildVectorizedPhase1TraceBatch(ctx, qo, nil, sidx.QueryRequest{}, false, 0)
+	require.NoError(t, zeroBatchErr)
+	zeroSB, zeroSBErr := zeroQuotaTrace.buildVectorizedScanBatch(ctx, tables, qo, zeroBatch)
+	require.Error(t, zeroSBErr, "AC5: zero-quota pull path must return error when no cursors were accumulated")
+	require.Nil(t, zeroSB, "AC5: zero-quota scan batch must be nil on error")
+}
+
+// collectAllSpanMessages recursively collects span Message fields from a span tree.
+func collectAllSpanMessages(spans []*commonv1.Span) []string {
+	var msgs []string
+	for _, s := range spans {
+		if s == nil {
+			continue
+		}
+		msgs = append(msgs, s.Message)
+		msgs = append(msgs, collectAllSpanMessages(s.Children)...)
+	}
+	return msgs
+}
+
+// TestVectorizedTracingSpansAC7 verifies AC7: the pull path emits the same key
+// spans as the push path — "part-selection" and "scan-blocks" — when a tracer
+// is present in the context.
+func TestVectorizedTracingSpansAC7(t *testing.T) {
+	tst, cleanup := newParityTSTable(t, tsTS1)
+	defer cleanup()
+
+	tr := newParityTrace()
+	tables := []*tsTable{tst}
+	qo := queryOptions{
+		TraceQueryOptions: model.TraceQueryOptions{TagProjection: allTagProjections},
+		schemaTagTypes:    testSchemaTagTypes,
+	}
+	qo.traceIDs = []string{"trace1"}
+
+	tracer, tracingCtx := query.NewTracer(context.Background(), "ac7-test")
+
+	batch, batchErr := tr.buildVectorizedPhase1TraceBatch(tracingCtx, qo, nil, sidx.QueryRequest{}, false, 0)
+	require.NoError(t, batchErr)
+	sb, sbErr := tr.buildVectorizedScanBatch(tracingCtx, tables, qo, batch)
+	require.NoError(t, sbErr)
+	releaseVectorizedScanBatch(sb)
+
+	allMsgs := collectAllSpanMessages(tracer.ToProto().Spans)
+	require.Contains(t, allMsgs, "part-selection", "AC7: pull path must emit part-selection span")
+	require.Contains(t, allMsgs, "scan-blocks", "AC7: pull path must emit scan-blocks span")
+}
+
+// TestVectorizedTTLExpiredParity verifies AC9: when TTL-expired segment filtering
+// produces an empty tables slice (as SelectSegments returns nothing for expired data),
+// both push and pull paths return zero results identically.
+func TestVectorizedTTLExpiredParity(t *testing.T) {
+	tr := newParityTrace()
+	ctx := context.Background()
+	qo := queryOptions{
+		TraceQueryOptions: model.TraceQueryOptions{TagProjection: allTagProjections},
+		schemaTagTypes:    testSchemaTagTypes,
+	}
+	traceIDs := []string{"trace1", "trace2"}
+
+	// Empty tables simulates all segments being TTL-expired (SelectSegments returned nothing).
+	emptyTables := []*tsTable{}
+
+	pushRes := pushLookupResult(ctx, tr, emptyTables, qo, traceIDs, 0)
+	defer pushRes.Release()
+	pushGot := collectResults(t, pushRes)
+
+	pullRes, pullErr := pullLookupResult(ctx, tr, emptyTables, qo, traceIDs, 0)
+	require.NoError(t, pullErr)
+	defer pullRes.Release()
+	pullGot := collectResults(t, pullRes)
+
+	require.Empty(t, pushGot, "push path must return no results for TTL-expired (empty) tables")
+	require.Empty(t, pullGot, "pull path must return no results for TTL-expired (empty) tables")
+}

--- a/pkg/query/vectorized/appendrange.go
+++ b/pkg/query/vectorized/appendrange.go
@@ -1,0 +1,118 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package vectorized
+
+import (
+	"fmt"
+
+	modelv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/model/v1"
+)
+
+// AppendColumnRange copies n rows starting at srcPos from src into dst.
+// Both columns must share the same TypedColumn[T] type. Validity bits are
+// propagated cell-by-cell via dst.MarkNullAt when src.IsNull reports null at
+// the corresponding row.
+//
+// Slice-typed cell values ([]byte / []int64 / []string) are not deep-copied
+// here. Storage decoders already produce owned cell slices, and avoiding a
+// second copy keeps egress paths allocation-stable.
+func AppendColumnRange(dst, src Column, srcPos, n int) error {
+	startLen := dst.Len()
+	switch d := dst.(type) {
+	case *TypedColumn[int64]:
+		sCol, ok := src.(*TypedColumn[int64])
+		if !ok {
+			return fmt.Errorf("AppendColumnRange: dst int64 vs src %s", src.Type())
+		}
+		sData := sCol.Data()
+		for k := range n {
+			d.Append(sData[srcPos+k])
+		}
+	case *TypedColumn[float64]:
+		sCol, ok := src.(*TypedColumn[float64])
+		if !ok {
+			return fmt.Errorf("AppendColumnRange: dst float64 vs src %s", src.Type())
+		}
+		sData := sCol.Data()
+		for k := range n {
+			d.Append(sData[srcPos+k])
+		}
+	case *TypedColumn[string]:
+		sCol, ok := src.(*TypedColumn[string])
+		if !ok {
+			return fmt.Errorf("AppendColumnRange: dst string vs src %s", src.Type())
+		}
+		sData := sCol.Data()
+		for k := range n {
+			d.Append(sData[srcPos+k])
+		}
+	case *TypedColumn[[]byte]:
+		sCol, ok := src.(*TypedColumn[[]byte])
+		if !ok {
+			return fmt.Errorf("AppendColumnRange: dst bytes vs src %s", src.Type())
+		}
+		sData := sCol.Data()
+		for k := range n {
+			d.Append(sData[srcPos+k])
+		}
+	case *TypedColumn[[]int64]:
+		sCol, ok := src.(*TypedColumn[[]int64])
+		if !ok {
+			return fmt.Errorf("AppendColumnRange: dst int64[] vs src %s", src.Type())
+		}
+		sData := sCol.Data()
+		for k := range n {
+			d.Append(sData[srcPos+k])
+		}
+	case *TypedColumn[[]string]:
+		sCol, ok := src.(*TypedColumn[[]string])
+		if !ok {
+			return fmt.Errorf("AppendColumnRange: dst string[] vs src %s", src.Type())
+		}
+		sData := sCol.Data()
+		for k := range n {
+			d.Append(sData[srcPos+k])
+		}
+	case *TypedColumn[*modelv1.TagValue]:
+		sCol, ok := src.(*TypedColumn[*modelv1.TagValue])
+		if !ok {
+			return fmt.Errorf("AppendColumnRange: dst tagvalue vs src %s", src.Type())
+		}
+		sData := sCol.Data()
+		for k := range n {
+			d.Append(sData[srcPos+k])
+		}
+	case *TypedColumn[*modelv1.FieldValue]:
+		sCol, ok := src.(*TypedColumn[*modelv1.FieldValue])
+		if !ok {
+			return fmt.Errorf("AppendColumnRange: dst fieldvalue vs src %s", src.Type())
+		}
+		sData := sCol.Data()
+		for k := range n {
+			d.Append(sData[srcPos+k])
+		}
+	default:
+		return fmt.Errorf("AppendColumnRange: unsupported dst type %s", dst.Type())
+	}
+	for k := range n {
+		if src.IsNull(srcPos + k) {
+			dst.MarkNullAt(startLen + k)
+		}
+	}
+	return nil
+}

--- a/pkg/query/vectorized/appendrange_test.go
+++ b/pkg/query/vectorized/appendrange_test.go
@@ -1,0 +1,175 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package vectorized
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	modelv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/model/v1"
+)
+
+func TestAppendColumnRangeCopiesSupportedTypes(t *testing.T) {
+	tests := []struct {
+		assert func(t *testing.T, dst Column)
+		src    Column
+		dst    Column
+		name   string
+	}{
+		{
+			name: "int64",
+			src: func() Column {
+				col := NewInt64Column(3)
+				col.Append(1)
+				col.Append(2)
+				col.Append(3)
+				return col
+			}(),
+			dst: NewInt64Column(2),
+			assert: func(t *testing.T, dst Column) {
+				require.Equal(t, []int64{2, 3}, dst.(*TypedColumn[int64]).Data())
+			},
+		},
+		{
+			name: "float64",
+			src: func() Column {
+				col := NewFloat64Column(3)
+				col.Append(1.5)
+				col.Append(2.5)
+				col.Append(3.5)
+				return col
+			}(),
+			dst: NewFloat64Column(2),
+			assert: func(t *testing.T, dst Column) {
+				require.Equal(t, []float64{2.5, 3.5}, dst.(*TypedColumn[float64]).Data())
+			},
+		},
+		{
+			name: "string",
+			src: func() Column {
+				col := NewStringColumn(3)
+				col.Append("a")
+				col.Append("b")
+				col.Append("c")
+				return col
+			}(),
+			dst: NewStringColumn(2),
+			assert: func(t *testing.T, dst Column) {
+				require.Equal(t, []string{"b", "c"}, dst.(*TypedColumn[string]).Data())
+			},
+		},
+		{
+			name: "bytes",
+			src: func() Column {
+				col := NewBytesColumn(3)
+				col.Append([]byte("a"))
+				col.Append([]byte("b"))
+				col.Append([]byte("c"))
+				return col
+			}(),
+			dst: NewBytesColumn(2),
+			assert: func(t *testing.T, dst Column) {
+				require.Equal(t, [][]byte{[]byte("b"), []byte("c")}, dst.(*TypedColumn[[]byte]).Data())
+			},
+		},
+		{
+			name: "int64 array",
+			src: func() Column {
+				col := NewInt64ArrayColumn(3)
+				col.Append([]int64{1})
+				col.Append([]int64{2})
+				col.Append([]int64{3})
+				return col
+			}(),
+			dst: NewInt64ArrayColumn(2),
+			assert: func(t *testing.T, dst Column) {
+				require.Equal(t, [][]int64{{2}, {3}}, dst.(*TypedColumn[[]int64]).Data())
+			},
+		},
+		{
+			name: "string array",
+			src: func() Column {
+				col := NewStrArrayColumn(3)
+				col.Append([]string{"a"})
+				col.Append([]string{"b"})
+				col.Append([]string{"c"})
+				return col
+			}(),
+			dst: NewStrArrayColumn(2),
+			assert: func(t *testing.T, dst Column) {
+				require.Equal(t, [][]string{{"b"}, {"c"}}, dst.(*TypedColumn[[]string]).Data())
+			},
+		},
+		{
+			name: "tag value",
+			src: func() Column {
+				col := NewTagValueColumn(3)
+				col.Append(&modelv1.TagValue{Value: &modelv1.TagValue_Str{Str: &modelv1.Str{Value: "a"}}})
+				col.Append(&modelv1.TagValue{Value: &modelv1.TagValue_Str{Str: &modelv1.Str{Value: "b"}}})
+				col.Append(&modelv1.TagValue{Value: &modelv1.TagValue_Str{Str: &modelv1.Str{Value: "c"}}})
+				return col
+			}(),
+			dst: NewTagValueColumn(2),
+			assert: func(t *testing.T, dst Column) {
+				data := dst.(*TypedColumn[*modelv1.TagValue]).Data()
+				require.Equal(t, "b", data[0].GetStr().Value)
+				require.Equal(t, "c", data[1].GetStr().Value)
+			},
+		},
+		{
+			name: "field value",
+			src: func() Column {
+				col := NewFieldValueColumn(3)
+				col.Append(&modelv1.FieldValue{Value: &modelv1.FieldValue_Int{Int: &modelv1.Int{Value: 1}}})
+				col.Append(&modelv1.FieldValue{Value: &modelv1.FieldValue_Int{Int: &modelv1.Int{Value: 2}}})
+				col.Append(&modelv1.FieldValue{Value: &modelv1.FieldValue_Int{Int: &modelv1.Int{Value: 3}}})
+				return col
+			}(),
+			dst: NewFieldValueColumn(2),
+			assert: func(t *testing.T, dst Column) {
+				data := dst.(*TypedColumn[*modelv1.FieldValue]).Data()
+				require.Equal(t, int64(2), data[0].GetInt().Value)
+				require.Equal(t, int64(3), data[1].GetInt().Value)
+			},
+		},
+	}
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			require.NoError(t, AppendColumnRange(testCase.dst, testCase.src, 1, 2))
+			testCase.assert(t, testCase.dst)
+		})
+	}
+}
+
+func TestAppendColumnRangePropagatesNulls(t *testing.T) {
+	src := NewStringColumn(3)
+	src.Append("a")
+	src.Append("b")
+	src.Append("c")
+	src.MarkNullAt(1)
+	dst := NewStringColumn(2)
+
+	require.NoError(t, AppendColumnRange(dst, src, 1, 2))
+	require.True(t, dst.IsNull(0))
+	require.False(t, dst.IsNull(1))
+}
+
+func TestAppendColumnRangeRejectsTypeMismatch(t *testing.T) {
+	require.Error(t, AppendColumnRange(NewStringColumn(1), NewInt64Column(1), 0, 0))
+}

--- a/pkg/query/vectorized/measure/batchsource.go
+++ b/pkg/query/vectorized/measure/batchsource.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 
-	modelv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/model/v1"
 	"github.com/apache/skywalking-banyandb/pkg/query"
 	"github.com/apache/skywalking-banyandb/pkg/query/model"
 	"github.com/apache/skywalking-banyandb/pkg/query/tracelabels"
@@ -225,103 +224,7 @@ func (s *BatchSourceFromBatchResult) Close() error {
 	return nil
 }
 
-// AppendColumnRange copies n rows starting at srcPos from src into dst
-// (appending). Both columns must share the same TypedColumn[T] type;
-// returns an error on mismatch. Validity bits are propagated cell-by-cell
-// via dst.MarkNullAt when src.IsNull reports null at the corresponding
-// row.
-//
-// Slice-typed cell values ([]byte / []int64 / []string) are *not*
-// deep-copied here. The upstream storage decode (in
-// banyand/measure/batch_decode.go::appendDecodedTagBytesAsTyped et al.
-// or the row-shape converter via slices.Clone) already produced a fresh
-// owned slice, and each MeasureBatch column uses its own data backing —
-// no pooling between MeasureBatch and the consumer's RecordBatch — so
-// sharing the slice reference is safe and avoids a redundant double
-// copy that would regress the egress bench gates by ~3 allocs per
-// slice-typed cell.
+// AppendColumnRange delegates to the shared vectorized helper.
 func AppendColumnRange(dst, src vectorized.Column, srcPos, n int) error {
-	startLen := dst.Len()
-	switch d := dst.(type) {
-	case *vectorized.TypedColumn[int64]:
-		sCol, ok := src.(*vectorized.TypedColumn[int64])
-		if !ok {
-			return fmt.Errorf("AppendColumnRange: dst int64 vs src %s", src.Type())
-		}
-		sData := sCol.Data()
-		for k := range n {
-			d.Append(sData[srcPos+k])
-		}
-	case *vectorized.TypedColumn[float64]:
-		sCol, ok := src.(*vectorized.TypedColumn[float64])
-		if !ok {
-			return fmt.Errorf("AppendColumnRange: dst float64 vs src %s", src.Type())
-		}
-		sData := sCol.Data()
-		for k := range n {
-			d.Append(sData[srcPos+k])
-		}
-	case *vectorized.TypedColumn[string]:
-		sCol, ok := src.(*vectorized.TypedColumn[string])
-		if !ok {
-			return fmt.Errorf("AppendColumnRange: dst string vs src %s", src.Type())
-		}
-		sData := sCol.Data()
-		for k := range n {
-			d.Append(sData[srcPos+k])
-		}
-	case *vectorized.TypedColumn[[]byte]:
-		sCol, ok := src.(*vectorized.TypedColumn[[]byte])
-		if !ok {
-			return fmt.Errorf("AppendColumnRange: dst bytes vs src %s", src.Type())
-		}
-		sData := sCol.Data()
-		for k := range n {
-			d.Append(sData[srcPos+k])
-		}
-	case *vectorized.TypedColumn[[]int64]:
-		sCol, ok := src.(*vectorized.TypedColumn[[]int64])
-		if !ok {
-			return fmt.Errorf("AppendColumnRange: dst int64[] vs src %s", src.Type())
-		}
-		sData := sCol.Data()
-		for k := range n {
-			d.Append(sData[srcPos+k])
-		}
-	case *vectorized.TypedColumn[[]string]:
-		sCol, ok := src.(*vectorized.TypedColumn[[]string])
-		if !ok {
-			return fmt.Errorf("AppendColumnRange: dst string[] vs src %s", src.Type())
-		}
-		sData := sCol.Data()
-		for k := range n {
-			d.Append(sData[srcPos+k])
-		}
-	case *vectorized.TypedColumn[*modelv1.TagValue]:
-		sCol, ok := src.(*vectorized.TypedColumn[*modelv1.TagValue])
-		if !ok {
-			return fmt.Errorf("AppendColumnRange: dst tagvalue vs src %s", src.Type())
-		}
-		sData := sCol.Data()
-		for k := range n {
-			d.Append(sData[srcPos+k])
-		}
-	case *vectorized.TypedColumn[*modelv1.FieldValue]:
-		sCol, ok := src.(*vectorized.TypedColumn[*modelv1.FieldValue])
-		if !ok {
-			return fmt.Errorf("AppendColumnRange: dst fieldvalue vs src %s", src.Type())
-		}
-		sData := sCol.Data()
-		for k := range n {
-			d.Append(sData[srcPos+k])
-		}
-	default:
-		return fmt.Errorf("AppendColumnRange: unsupported dst type %s", dst.Type())
-	}
-	for k := range n {
-		if src.IsNull(srcPos + k) {
-			dst.MarkNullAt(startLen + k)
-		}
-	}
-	return nil
+	return vectorized.AppendColumnRange(dst, src, srcPos, n)
 }

--- a/pkg/query/vectorized/trace/columns.go
+++ b/pkg/query/vectorized/trace/columns.go
@@ -1,0 +1,69 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trace
+
+import (
+	modelv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/model/v1"
+	"github.com/apache/skywalking-banyandb/pkg/query/vectorized"
+)
+
+func phase1Keys(batch *vectorized.RecordBatch) *vectorized.TypedColumn[int64] {
+	return batch.Columns[phase1ColumnKey].(*vectorized.TypedColumn[int64])
+}
+
+func phase1SeriesIDs(batch *vectorized.RecordBatch) *vectorized.TypedColumn[int64] {
+	return batch.Columns[phase1ColumnSeriesID].(*vectorized.TypedColumn[int64])
+}
+
+func phase1PartIDs(batch *vectorized.RecordBatch) *vectorized.TypedColumn[int64] {
+	return batch.Columns[phase1ColumnPartID].(*vectorized.TypedColumn[int64])
+}
+
+func phase1Payloads(batch *vectorized.RecordBatch) *vectorized.TypedColumn[[]byte] {
+	return batch.Columns[phase1ColumnPayload].(*vectorized.TypedColumn[[]byte])
+}
+
+func phase1TraceIDs(batch *vectorized.RecordBatch) *vectorized.TypedColumn[string] {
+	return batch.Columns[phase1ColumnTraceID].(*vectorized.TypedColumn[string])
+}
+
+// Phase2TraceIDs returns the traceID column from a Phase-2 batch.
+func Phase2TraceIDs(batch *vectorized.RecordBatch) *vectorized.TypedColumn[string] {
+	return batch.Columns[phase2ColumnTraceID].(*vectorized.TypedColumn[string])
+}
+
+// Phase2Keys returns the sort-key column from a Phase-2 batch.
+func Phase2Keys(batch *vectorized.RecordBatch) *vectorized.TypedColumn[int64] {
+	return batch.Columns[phase2ColumnKey].(*vectorized.TypedColumn[int64])
+}
+
+// Phase2Spans returns the span-bytes column from a Phase-2 batch.
+func Phase2Spans(batch *vectorized.RecordBatch) *vectorized.TypedColumn[[]byte] {
+	return batch.Columns[phase2ColumnSpan].(*vectorized.TypedColumn[[]byte])
+}
+
+// Phase2SpanIDs returns the spanID column from a Phase-2 batch.
+func Phase2SpanIDs(batch *vectorized.RecordBatch) *vectorized.TypedColumn[string] {
+	return batch.Columns[phase2ColumnSpanID].(*vectorized.TypedColumn[string])
+}
+
+// Phase2TagCol returns the tag column at the given dynamic index from a Phase-2 batch.
+// idx=0 is the first dynamic tag column (the first column after the fixed columns).
+func Phase2TagCol(batch *vectorized.RecordBatch, idx int) *vectorized.TypedColumn[*modelv1.TagValue] {
+	return batch.Columns[phase2FixedColumnCount+idx].(*vectorized.TypedColumn[*modelv1.TagValue])
+}

--- a/pkg/query/vectorized/trace/config.go
+++ b/pkg/query/vectorized/trace/config.go
@@ -1,0 +1,51 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trace
+
+import (
+	"fmt"
+
+	"github.com/apache/skywalking-banyandb/pkg/query/vectorized"
+)
+
+// VectorizedConfig controls the v1 vectorized Trace query path.
+type VectorizedConfig struct {
+	BatchSize      int
+	QueryMemoryMiB int
+	Enabled        bool
+}
+
+// DefaultConfig returns the default trace vectorized configuration.
+func DefaultConfig() VectorizedConfig {
+	return VectorizedConfig{
+		Enabled:        false,
+		BatchSize:      vectorized.DefaultBatchSize,
+		QueryMemoryMiB: 256,
+	}
+}
+
+// Validate rejects invalid trace vectorized configurations.
+func (c VectorizedConfig) Validate() error {
+	if c.BatchSize <= 0 {
+		return fmt.Errorf("vectorized.trace: BatchSize must be > 0, got %d", c.BatchSize)
+	}
+	if c.QueryMemoryMiB <= 0 {
+		return fmt.Errorf("vectorized.trace: QueryMemoryMiB must be > 0, got %d", c.QueryMemoryMiB)
+	}
+	return nil
+}

--- a/pkg/query/vectorized/trace/config.go
+++ b/pkg/query/vectorized/trace/config.go
@@ -25,7 +25,12 @@ import (
 
 // VectorizedConfig controls the v1 vectorized Trace query path.
 type VectorizedConfig struct {
-	BatchSize      int
+	BatchSize int
+	// QueryMemoryMiB is a soft span-loading threshold: it caps the cumulative
+	// uncompressed span bytes fetched from disk per query. SIDX responses, tags,
+	// record-batch overhead, and other per-query allocations are not counted.
+	// The first block always loads regardless of the budget (first-block exception),
+	// so a single oversized block may exceed this value.
 	QueryMemoryMiB int
 	Enabled        bool
 }

--- a/pkg/query/vectorized/trace/config_test.go
+++ b/pkg/query/vectorized/trace/config_test.go
@@ -1,0 +1,40 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trace
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/apache/skywalking-banyandb/pkg/query/vectorized"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+	require.False(t, cfg.Enabled)
+	require.Equal(t, vectorized.DefaultBatchSize, cfg.BatchSize)
+	require.Equal(t, 256, cfg.QueryMemoryMiB)
+	require.NoError(t, cfg.Validate())
+}
+
+func TestVectorizedConfigValidate(t *testing.T) {
+	require.Error(t, VectorizedConfig{BatchSize: 0, QueryMemoryMiB: 256}.Validate())
+	require.Error(t, VectorizedConfig{BatchSize: 1, QueryMemoryMiB: 0}.Validate())
+	require.NoError(t, VectorizedConfig{BatchSize: 1, QueryMemoryMiB: 1}.Validate())
+}

--- a/pkg/query/vectorized/trace/counters.go
+++ b/pkg/query/vectorized/trace/counters.go
@@ -1,0 +1,33 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trace
+
+import "sync/atomic"
+
+// Process-wide observability counter. Integration tests snapshot QueryCount()
+// before the test table runs and assert the delta is > 0 to prove the
+// vectorized path actually fired (vs silently never being reached).
+var queryCount atomic.Int64
+
+// QueryCount returns the cumulative number of vectorized trace queries
+// successfully started by this process.
+func QueryCount() int64 { return queryCount.Load() }
+
+// IncrQueryCount increments the process-wide vectorized trace query counter.
+// Called by banyand/trace when the vectorized path is taken.
+func IncrQueryCount() { queryCount.Add(1) }

--- a/pkg/query/vectorized/trace/distinct_trace_id.go
+++ b/pkg/query/vectorized/trace/distinct_trace_id.go
@@ -1,0 +1,90 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trace
+
+import (
+	"context"
+
+	"github.com/apache/skywalking-banyandb/pkg/query/vectorized"
+)
+
+// DistinctTraceID carries ordered trace IDs, part hints, and keys into Phase 2.
+type DistinctTraceID struct {
+	schema         *vectorized.BatchSchema
+	traceIDsByPart map[int64][]string
+	keys           map[string]int64
+	order          []string
+	closed         bool
+}
+
+// NewDistinctTraceID constructs the Phase-1 carry-forward fusible.
+func NewDistinctTraceID(schema *vectorized.BatchSchema) *DistinctTraceID {
+	return &DistinctTraceID{schema: schema}
+}
+
+// Init resets carry-forward state.
+func (d *DistinctTraceID) Init(context.Context) error {
+	d.traceIDsByPart = make(map[int64][]string)
+	d.keys = make(map[string]int64)
+	d.order = d.order[:0]
+	return nil
+}
+
+// OutputSchema returns the unchanged input schema.
+func (d *DistinctTraceID) OutputSchema() *vectorized.BatchSchema {
+	return d.schema
+}
+
+// Process records active rows without rewriting the selection vector.
+func (d *DistinctTraceID) Process(_ context.Context, batch *vectorized.RecordBatch) error {
+	keys := phase1Keys(batch).Data()
+	partIDs := phase1PartIDs(batch).Data()
+	traceIDs := phase1TraceIDs(batch).Data()
+	for _, rowIdx := range activeIndices(batch) {
+		traceID := traceIDs[rowIdx]
+		partID := partIDs[rowIdx]
+		d.traceIDsByPart[partID] = append(d.traceIDsByPart[partID], traceID)
+		d.keys[traceID] = keys[rowIdx]
+		d.order = append(d.order, traceID)
+	}
+	return nil
+}
+
+// Close is idempotent and a no-op.
+func (d *DistinctTraceID) Close() error {
+	if d.closed {
+		return nil
+	}
+	d.closed = true
+	return nil
+}
+
+// TraceIDsByPart returns the part-hint mapping collected so far.
+func (d *DistinctTraceID) TraceIDsByPart() map[int64][]string {
+	return d.traceIDsByPart
+}
+
+// Keys returns the traceID to sort-key mapping collected so far.
+func (d *DistinctTraceID) Keys() map[string]int64 {
+	return d.keys
+}
+
+// Order returns trace IDs in Phase-1 arrival order.
+func (d *DistinctTraceID) Order() []string {
+	return d.order
+}

--- a/pkg/query/vectorized/trace/doc.go
+++ b/pkg/query/vectorized/trace/doc.go
@@ -1,0 +1,21 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package trace implements trace-specific vectorized query operators: the
+// two-phase pull pipeline that resolves trace IDs (Phase 1) and materializes
+// spans grouped per trace (Phase 2).
+package trace

--- a/pkg/query/vectorized/trace/group_by_trace_id.go
+++ b/pkg/query/vectorized/trace/group_by_trace_id.go
@@ -1,0 +1,167 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trace
+
+import (
+	"context"
+
+	modelv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/model/v1"
+	"github.com/apache/skywalking-banyandb/pkg/query/vectorized"
+)
+
+// traceRowBucket accumulates row data for a single traceID.
+// traceID and key are constant across all rows in a group.
+type traceRowBucket struct {
+	traceID string
+	spans   [][]byte
+	spanIDs []string
+	tagCols [][]*modelv1.TagValue // one slice per tag column
+	key     int64
+}
+
+// GroupByTraceID is a BreakerOperator that groups Phase-2 rows by traceID
+// and emits one RecordBatch per traceID in Phase-1 arrival order.
+type GroupByTraceID struct {
+	schema        *vectorized.BatchSchema
+	knownTraceIDs map[string]struct{}
+	buckets       map[string]*traceRowBucket
+	traceIDsOrder []string
+	emitIdx       int
+	numTagCols    int
+}
+
+// NewGroupByTraceID constructs the GroupByTraceID BreakerOperator.
+// traceIDsOrder is the Phase-1 arrival order used to determine output ordering.
+func NewGroupByTraceID(schema *vectorized.BatchSchema, traceIDsOrder []string) *GroupByTraceID {
+	numTagCols := max(len(schema.Columns)-phase2FixedColumnCount, 0)
+	known := make(map[string]struct{}, len(traceIDsOrder))
+	for _, tid := range traceIDsOrder {
+		known[tid] = struct{}{}
+	}
+	return &GroupByTraceID{
+		schema:        schema,
+		traceIDsOrder: append([]string(nil), traceIDsOrder...),
+		knownTraceIDs: known,
+		numTagCols:    numTagCols,
+	}
+}
+
+// Init resets accumulated state.
+func (g *GroupByTraceID) Init(context.Context) error {
+	g.buckets = make(map[string]*traceRowBucket)
+	g.emitIdx = 0
+	return nil
+}
+
+// OutputSchema returns the Phase-2 schema.
+func (g *GroupByTraceID) OutputSchema() *vectorized.BatchSchema {
+	return g.schema
+}
+
+// Consume accumulates each active row into the bucket for its traceID.
+// Rows with traceIDs not in traceIDsOrder are silently dropped.
+func (g *GroupByTraceID) Consume(_ context.Context, batch *vectorized.RecordBatch) error {
+	tidCol := Phase2TraceIDs(batch)
+	keyCol := Phase2Keys(batch)
+	spanCol := Phase2Spans(batch)
+	spanIDCol := Phase2SpanIDs(batch)
+
+	tids := tidCol.Data()
+	keys := keyCol.Data()
+	spans := spanCol.Data()
+	spanIDs := spanIDCol.Data()
+	tagData := make([][]*modelv1.TagValue, g.numTagCols)
+	for tagIdx := range g.numTagCols {
+		tagData[tagIdx] = Phase2TagCol(batch, tagIdx).Data()
+	}
+
+	for _, rowIdx := range activeIndices(batch) {
+		traceID := tids[rowIdx]
+		if _, ok := g.knownTraceIDs[traceID]; !ok {
+			continue
+		}
+		bucket, exists := g.buckets[traceID]
+		if !exists {
+			bucket = &traceRowBucket{
+				traceID: traceID,
+				key:     keys[rowIdx],
+				tagCols: make([][]*modelv1.TagValue, g.numTagCols),
+			}
+			g.buckets[traceID] = bucket
+		}
+		bucket.spans = append(bucket.spans, spans[rowIdx])
+		if int(rowIdx) < len(spanIDs) {
+			bucket.spanIDs = append(bucket.spanIDs, spanIDs[rowIdx])
+		} else {
+			bucket.spanIDs = append(bucket.spanIDs, "")
+		}
+		for tagIdx := range g.numTagCols {
+			var tv *modelv1.TagValue
+			if int(rowIdx) < len(tagData[tagIdx]) {
+				tv = tagData[tagIdx][rowIdx]
+			}
+			bucket.tagCols[tagIdx] = append(bucket.tagCols[tagIdx], tv)
+		}
+	}
+	return nil
+}
+
+// Finalize is a no-op; all grouping happens in Consume.
+func (g *GroupByTraceID) Finalize(context.Context) error {
+	return nil
+}
+
+// NextBatch emits one RecordBatch per traceID in traceIDsOrder.
+// TraceIDs with no accumulated rows are skipped.
+// Returns (nil, nil) when all traceIDs have been emitted.
+func (g *GroupByTraceID) NextBatch(_ context.Context) (*vectorized.RecordBatch, error) {
+	for g.emitIdx < len(g.traceIDsOrder) {
+		traceID := g.traceIDsOrder[g.emitIdx]
+		g.emitIdx++
+		bucket, ok := g.buckets[traceID]
+		if !ok || len(bucket.spans) == 0 {
+			continue
+		}
+		batch := vectorized.NewRecordBatch(g.schema, len(bucket.spans))
+		tidOut := Phase2TraceIDs(batch)
+		keyOut := Phase2Keys(batch)
+		spanOut := Phase2Spans(batch)
+		spanIDOut := Phase2SpanIDs(batch)
+		for rowIdx, span := range bucket.spans {
+			tidOut.Append(bucket.traceID)
+			keyOut.Append(bucket.key)
+			spanOut.Append(span)
+			spanIDOut.Append(bucket.spanIDs[rowIdx])
+		}
+		for tagIdx := range g.numTagCols {
+			tagOut := Phase2TagCol(batch, tagIdx)
+			for _, tv := range bucket.tagCols[tagIdx] {
+				tagOut.Append(tv)
+			}
+		}
+		batch.Len = len(bucket.spans)
+		return batch, nil
+	}
+	return nil, nil
+}
+
+// Close releases the accumulated buckets.
+func (g *GroupByTraceID) Close() error {
+	g.buckets = nil
+	return nil
+}

--- a/pkg/query/vectorized/trace/group_by_trace_id.go
+++ b/pkg/query/vectorized/trace/group_by_trace_id.go
@@ -75,7 +75,10 @@ func (g *GroupByTraceID) OutputSchema() *vectorized.BatchSchema {
 
 // Consume accumulates each active row into the bucket for its traceID.
 // Rows with traceIDs not in traceIDsOrder are silently dropped.
-func (g *GroupByTraceID) Consume(_ context.Context, batch *vectorized.RecordBatch) error {
+func (g *GroupByTraceID) Consume(ctx context.Context, batch *vectorized.RecordBatch) error {
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return ctxErr
+	}
 	tidCol := Phase2TraceIDs(batch)
 	keyCol := Phase2Keys(batch)
 	spanCol := Phase2Spans(batch)
@@ -129,14 +132,22 @@ func (g *GroupByTraceID) Finalize(context.Context) error {
 // NextBatch emits one RecordBatch per traceID in traceIDsOrder.
 // TraceIDs with no accumulated rows are skipped.
 // Returns (nil, nil) when all traceIDs have been emitted.
-func (g *GroupByTraceID) NextBatch(_ context.Context) (*vectorized.RecordBatch, error) {
+func (g *GroupByTraceID) NextBatch(ctx context.Context) (*vectorized.RecordBatch, error) {
 	for g.emitIdx < len(g.traceIDsOrder) {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
 		traceID := g.traceIDsOrder[g.emitIdx]
 		g.emitIdx++
 		bucket, ok := g.buckets[traceID]
 		if !ok || len(bucket.spans) == 0 {
 			continue
 		}
+		// Delete the bucket before emitting so that a duplicate entry in
+		// traceIDsOrder (e.g. from a caller-supplied duplicate lookup list) is
+		// skipped on the second encounter, matching the push-path's behavior of
+		// deleting the cursor group after first emission.
+		delete(g.buckets, traceID)
 		batch := vectorized.NewRecordBatch(g.schema, len(bucket.spans))
 		tidOut := Phase2TraceIDs(batch)
 		keyOut := Phase2Keys(batch)

--- a/pkg/query/vectorized/trace/group_by_trace_id_test.go
+++ b/pkg/query/vectorized/trace/group_by_trace_id_test.go
@@ -1,0 +1,163 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trace
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/apache/skywalking-banyandb/pkg/query/vectorized"
+)
+
+// makePhase2Batch builds a Phase-2 batch with the given rows (traceID, key, span, spanID).
+func makePhase2Batch(schema *vectorized.BatchSchema, rows []phase2Row) *vectorized.RecordBatch {
+	batch := vectorized.NewRecordBatch(schema, len(rows))
+	tidCol := Phase2TraceIDs(batch)
+	keyCol := Phase2Keys(batch)
+	spanCol := Phase2Spans(batch)
+	spanIDCol := Phase2SpanIDs(batch)
+	for _, row := range rows {
+		tidCol.Append(row.traceID)
+		keyCol.Append(row.key)
+		spanCol.Append(row.span)
+		spanIDCol.Append(row.spanID)
+	}
+	batch.Len = len(rows)
+	return batch
+}
+
+type phase2Row struct {
+	traceID string
+	spanID  string
+	span    []byte
+	key     int64
+}
+
+func TestGroupByTraceID_Basic(t *testing.T) {
+	schema := NewPhase2Schema(nil)
+	order := []string{"trace-a", "trace-b", "trace-c"}
+	op := NewGroupByTraceID(schema, order)
+	ctx := context.Background()
+
+	require.NoError(t, op.Init(ctx))
+
+	// 6 rows interleaved across 3 traceIDs
+	rows := []phase2Row{
+		{traceID: "trace-a", key: 1, span: []byte("a1"), spanID: "s1"},
+		{traceID: "trace-b", key: 2, span: []byte("b1"), spanID: "s2"},
+		{traceID: "trace-c", key: 3, span: []byte("c1"), spanID: "s3"},
+		{traceID: "trace-a", key: 1, span: []byte("a2"), spanID: "s4"},
+		{traceID: "trace-b", key: 2, span: []byte("b2"), spanID: "s5"},
+		{traceID: "trace-c", key: 3, span: []byte("c2"), spanID: "s6"},
+	}
+	batch := makePhase2Batch(schema, rows)
+	require.NoError(t, op.Consume(ctx, batch))
+	require.NoError(t, op.Finalize(ctx))
+
+	// Should emit trace-a, trace-b, trace-c in order
+	outA, err := op.NextBatch(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, outA)
+	require.Equal(t, 2, outA.Len)
+	require.Equal(t, []string{"trace-a", "trace-a"}, Phase2TraceIDs(outA).Data())
+	require.Equal(t, [][]byte{[]byte("a1"), []byte("a2")}, Phase2Spans(outA).Data())
+
+	outB, err := op.NextBatch(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, outB)
+	require.Equal(t, 2, outB.Len)
+	require.Equal(t, []string{"trace-b", "trace-b"}, Phase2TraceIDs(outB).Data())
+
+	outC, err := op.NextBatch(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, outC)
+	require.Equal(t, 2, outC.Len)
+	require.Equal(t, []string{"trace-c", "trace-c"}, Phase2TraceIDs(outC).Data())
+
+	done, err := op.NextBatch(ctx)
+	require.NoError(t, err)
+	require.Nil(t, done)
+
+	require.NoError(t, op.Close())
+}
+
+func TestGroupByTraceID_SkipsUnknownTraceIDs(t *testing.T) {
+	schema := NewPhase2Schema(nil)
+	order := []string{"trace-a"}
+	op := NewGroupByTraceID(schema, order)
+	ctx := context.Background()
+
+	require.NoError(t, op.Init(ctx))
+
+	rows := []phase2Row{
+		{traceID: "trace-a", key: 1, span: []byte("a1"), spanID: "s1"},
+		{traceID: "trace-unknown", key: 9, span: []byte("u1"), spanID: "su"},
+	}
+	batch := makePhase2Batch(schema, rows)
+	require.NoError(t, op.Consume(ctx, batch))
+	require.NoError(t, op.Finalize(ctx))
+
+	outA, err := op.NextBatch(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, outA)
+	require.Equal(t, 1, outA.Len)
+	require.Equal(t, []string{"trace-a"}, Phase2TraceIDs(outA).Data())
+
+	done, err := op.NextBatch(ctx)
+	require.NoError(t, err)
+	require.Nil(t, done)
+
+	require.NoError(t, op.Close())
+}
+
+func TestGroupByTraceID_SkipsEmptyGroups(t *testing.T) {
+	schema := NewPhase2Schema(nil)
+	// trace-b is in order but no rows will be sent for it
+	order := []string{"trace-a", "trace-b", "trace-c"}
+	op := NewGroupByTraceID(schema, order)
+	ctx := context.Background()
+
+	require.NoError(t, op.Init(ctx))
+
+	rows := []phase2Row{
+		{traceID: "trace-a", key: 1, span: []byte("a1"), spanID: "s1"},
+		{traceID: "trace-c", key: 3, span: []byte("c1"), spanID: "s3"},
+	}
+	batch := makePhase2Batch(schema, rows)
+	require.NoError(t, op.Consume(ctx, batch))
+	require.NoError(t, op.Finalize(ctx))
+
+	outA, err := op.NextBatch(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, outA)
+	require.Equal(t, []string{"trace-a"}, Phase2TraceIDs(outA).Data())
+
+	// trace-b is skipped — next is trace-c
+	outC, err := op.NextBatch(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, outC)
+	require.Equal(t, []string{"trace-c"}, Phase2TraceIDs(outC).Data())
+
+	done, err := op.NextBatch(ctx)
+	require.NoError(t, err)
+	require.Nil(t, done)
+
+	require.NoError(t, op.Close())
+}

--- a/pkg/query/vectorized/trace/group_by_trace_id_test.go
+++ b/pkg/query/vectorized/trace/group_by_trace_id_test.go
@@ -127,6 +127,35 @@ func TestGroupByTraceID_SkipsUnknownTraceIDs(t *testing.T) {
 	require.NoError(t, op.Close())
 }
 
+// TestGroupByTraceID_DuplicateOrderEmitsOnce guards against the regression where
+// a duplicate entry in traceIDsOrder caused GroupByTraceID to emit the same
+// trace bucket twice (the fix is delete(g.buckets, traceID) after emission).
+func TestGroupByTraceID_DuplicateOrderEmitsOnce(t *testing.T) {
+	schema := NewPhase2Schema(nil)
+	op := NewGroupByTraceID(schema, []string{"trace-a", "trace-a"})
+	ctx := context.Background()
+
+	require.NoError(t, op.Init(ctx))
+
+	batch := makePhase2Batch(schema, []phase2Row{
+		{traceID: "trace-a", key: 1, span: []byte("s1"), spanID: "id1"},
+	})
+	require.NoError(t, op.Consume(ctx, batch))
+	require.NoError(t, op.Finalize(ctx))
+
+	out, err := op.NextBatch(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	require.Equal(t, 1, out.Len)
+	require.Equal(t, []string{"trace-a"}, Phase2TraceIDs(out).Data())
+
+	done, err := op.NextBatch(ctx)
+	require.NoError(t, err)
+	require.Nil(t, done, "duplicate traceID in traceIDsOrder must not emit the bucket twice")
+
+	require.NoError(t, op.Close())
+}
+
 func TestGroupByTraceID_SkipsEmptyGroups(t *testing.T) {
 	schema := NewPhase2Schema(nil)
 	// trace-b is in order but no rows will be sent for it

--- a/pkg/query/vectorized/trace/limit.go
+++ b/pkg/query/vectorized/trace/limit.go
@@ -1,0 +1,78 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trace
+
+import (
+	"context"
+
+	"github.com/apache/skywalking-banyandb/pkg/query/vectorized"
+)
+
+// Limit applies MaxTraceSize to the ordered Phase-1 stream.
+type Limit struct {
+	schema *vectorized.BatchSchema
+	max    uint32
+	seen   uint32
+	closed bool
+}
+
+// NewLimit constructs a trace Phase-1 limit fusible.
+func NewLimit(schema *vectorized.BatchSchema, maxRows uint32) *Limit {
+	return &Limit{schema: schema, max: maxRows}
+}
+
+// Init is a no-op.
+func (l *Limit) Init(context.Context) error {
+	return nil
+}
+
+// OutputSchema returns the unchanged input schema.
+func (l *Limit) OutputSchema() *vectorized.BatchSchema {
+	return l.schema
+}
+
+// Process rewrites selection to keep only the first max active rows.
+func (l *Limit) Process(_ context.Context, batch *vectorized.RecordBatch) error {
+	if l.max == 0 {
+		batch.Selection = activeIndices(batch)
+		return nil
+	}
+	active := activeIndices(batch)
+	out := make([]uint16, 0, len(active))
+	for _, rowIdx := range active {
+		if l.seen < l.max {
+			out = append(out, rowIdx)
+		}
+		l.seen++
+		if l.seen >= l.max {
+			batch.Selection = out
+			return vectorized.ErrLimitExhausted
+		}
+	}
+	batch.Selection = out
+	return nil
+}
+
+// Close is idempotent and a no-op.
+func (l *Limit) Close() error {
+	if l.closed {
+		return nil
+	}
+	l.closed = true
+	return nil
+}

--- a/pkg/query/vectorized/trace/limit_carry.go
+++ b/pkg/query/vectorized/trace/limit_carry.go
@@ -1,0 +1,107 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trace
+
+import (
+	"context"
+
+	"github.com/apache/skywalking-banyandb/pkg/query/vectorized"
+)
+
+// LimitedDistinctTraceID applies MaxTraceSize while carrying kept rows.
+type LimitedDistinctTraceID struct {
+	schema *vectorized.BatchSchema
+	carry  *DistinctTraceID
+	max    uint32
+	seen   uint32
+	closed bool
+}
+
+// NewLimitedDistinctTraceID constructs the Phase-1 limit and carry fusible.
+func NewLimitedDistinctTraceID(schema *vectorized.BatchSchema, maxRows uint32) *LimitedDistinctTraceID {
+	return &LimitedDistinctTraceID{
+		schema: schema,
+		carry:  NewDistinctTraceID(schema),
+		max:    maxRows,
+	}
+}
+
+// Init resets carry-forward state.
+func (l *LimitedDistinctTraceID) Init(ctx context.Context) error {
+	l.seen = 0
+	return l.carry.Init(ctx)
+}
+
+// OutputSchema returns the unchanged input schema.
+func (l *LimitedDistinctTraceID) OutputSchema() *vectorized.BatchSchema {
+	return l.schema
+}
+
+// Process rewrites selection to kept rows and records only those rows.
+func (l *LimitedDistinctTraceID) Process(_ context.Context, batch *vectorized.RecordBatch) error {
+	if l.max == 0 {
+		out := activeIndices(batch)
+		batch.Selection = out
+		keys := phase1Keys(batch).Data()
+		partIDs := phase1PartIDs(batch).Data()
+		traceIDs := phase1TraceIDs(batch).Data()
+		for _, rowIdx := range out {
+			traceID := traceIDs[rowIdx]
+			partID := partIDs[rowIdx]
+			l.carry.traceIDsByPart[partID] = append(l.carry.traceIDsByPart[partID], traceID)
+			l.carry.keys[traceID] = keys[rowIdx]
+			l.carry.order = append(l.carry.order, traceID)
+		}
+		return nil
+	}
+	keys := phase1Keys(batch).Data()
+	partIDs := phase1PartIDs(batch).Data()
+	traceIDs := phase1TraceIDs(batch).Data()
+	out := make([]uint16, 0, batch.ActiveLen())
+	for _, rowIdx := range activeIndices(batch) {
+		if l.seen < l.max {
+			traceID := traceIDs[rowIdx]
+			partID := partIDs[rowIdx]
+			l.carry.traceIDsByPart[partID] = append(l.carry.traceIDsByPart[partID], traceID)
+			l.carry.keys[traceID] = keys[rowIdx]
+			l.carry.order = append(l.carry.order, traceID)
+			out = append(out, rowIdx)
+		}
+		l.seen++
+		if l.seen >= l.max {
+			batch.Selection = out
+			return vectorized.ErrLimitExhausted
+		}
+	}
+	batch.Selection = out
+	return nil
+}
+
+// Close is idempotent and closes the embedded carry operator.
+func (l *LimitedDistinctTraceID) Close() error {
+	if l.closed {
+		return nil
+	}
+	l.closed = true
+	return l.carry.Close()
+}
+
+// Carry returns the embedded carry-forward state.
+func (l *LimitedDistinctTraceID) Carry() *DistinctTraceID {
+	return l.carry
+}

--- a/pkg/query/vectorized/trace/limit_carry.go
+++ b/pkg/query/vectorized/trace/limit_carry.go
@@ -77,14 +77,15 @@ func (l *LimitedDistinctTraceID) Process(_ context.Context, batch *vectorized.Re
 	traceIDs := phase1TraceIDs(batch).Data()
 	out := make([]uint16, 0, batch.ActiveLen())
 	for _, rowIdx := range activeIndices(batch) {
-		if l.seen < l.max {
-			traceID := traceIDs[rowIdx]
-			partID := partIDs[rowIdx]
-			l.carry.traceIDsByPart[partID] = append(l.carry.traceIDsByPart[partID], traceID)
-			l.carry.keys[traceID] = keys[rowIdx]
-			l.carry.order = append(l.carry.order, traceID)
-			out = append(out, rowIdx)
+		traceID := traceIDs[rowIdx]
+		if _, alreadySeen := l.carry.keys[traceID]; alreadySeen {
+			continue
 		}
+		partID := partIDs[rowIdx]
+		l.carry.traceIDsByPart[partID] = append(l.carry.traceIDsByPart[partID], traceID)
+		l.carry.keys[traceID] = keys[rowIdx]
+		l.carry.order = append(l.carry.order, traceID)
+		out = append(out, rowIdx)
 		l.seen++
 		if l.seen >= l.max {
 			batch.Selection = out

--- a/pkg/query/vectorized/trace/limit_carry.go
+++ b/pkg/query/vectorized/trace/limit_carry.go
@@ -62,6 +62,9 @@ func (l *LimitedDistinctTraceID) Process(_ context.Context, batch *vectorized.Re
 		traceIDs := phase1TraceIDs(batch).Data()
 		for _, rowIdx := range out {
 			traceID := traceIDs[rowIdx]
+			if _, seen := l.carry.keys[traceID]; seen {
+				continue
+			}
 			partID := partIDs[rowIdx]
 			l.carry.traceIDsByPart[partID] = append(l.carry.traceIDsByPart[partID], traceID)
 			l.carry.keys[traceID] = keys[rowIdx]

--- a/pkg/query/vectorized/trace/lint_test.go
+++ b/pkg/query/vectorized/trace/lint_test.go
@@ -1,0 +1,83 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trace
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestNoConcurrencyInVectorizedTrace is a static-analysis guard that ensures no
+// non-test source file in pkg/query/vectorized/trace/ spawns goroutines or
+// references sidx.StreamingQuery (both forbidden by the plan's H1 constraint).
+func TestNoConcurrencyInVectorizedTrace(t *testing.T) {
+	entries, readErr := os.ReadDir(".")
+	require.NoError(t, readErr)
+
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+
+		content, fileErr := os.ReadFile(name)
+		require.NoError(t, fileErr)
+		src := string(content)
+
+		require.False(
+			t,
+			containsGoroutineSpawn(src),
+			"%s must not spawn goroutines — vectorized trace operators use the synchronous pull path only", name,
+		)
+		require.NotContains(
+			t,
+			src,
+			"StreamingQuery",
+			"%s must not reference sidx.StreamingQuery — use the synchronous Query/QuerySync path instead", name,
+		)
+	}
+}
+
+// containsGoroutineSpawn returns true if src contains a goroutine spawn statement
+// on any non-comment line: "go func(", "go someIdent(", "go obj.Method(", or "run.Go(".
+func containsGoroutineSpawn(src string) bool {
+	for line := range strings.SplitSeq(src, "\n") {
+		trimmed := strings.TrimLeft(line, " \t")
+		if strings.HasPrefix(trimmed, "//") {
+			continue
+		}
+		// "go <identifier>" covers "go func(", "go someFunc(", "go obj.Method(" etc.
+		if strings.HasPrefix(trimmed, "go ") {
+			rest := strings.TrimLeft(trimmed[3:], " ")
+			if len(rest) > 0 {
+				ch := rest[0]
+				if ch == '_' || (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') {
+					return true
+				}
+			}
+		}
+		// "run.Go(" is the project's goroutine helper.
+		if strings.Contains(trimmed, "run.Go(") {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/query/vectorized/trace/phase1_ops_test.go
+++ b/pkg/query/vectorized/trace/phase1_ops_test.go
@@ -1,0 +1,94 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trace
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/apache/skywalking-banyandb/pkg/query/vectorized"
+)
+
+func TestIDDecode(t *testing.T) {
+	batch := phase1TestBatch([]*MergeItem{
+		NewMergeItem(1, 10, 100, append([]byte{idFormatV1}, []byte("trace-a")...)),
+		NewMergeItem(2, 20, 200, append([]byte{idFormatV1}, []byte("trace-b")...)),
+	})
+	op := NewIDDecode(batch.Schema)
+	require.NoError(t, op.Init(context.Background()))
+	require.NoError(t, op.Process(context.Background(), batch))
+	require.Equal(t, []string{"trace-a", "trace-b"}, phase1TraceIDs(batch).Data())
+	require.NoError(t, op.Close())
+}
+
+func TestIDDecodeRejectsMalformedPayload(t *testing.T) {
+	batch := phase1TestBatch([]*MergeItem{
+		NewMergeItem(1, 10, 100, []byte{0xff, 'x'}),
+	})
+	op := NewIDDecode(batch.Schema)
+	require.NoError(t, op.Init(context.Background()))
+	require.Error(t, op.Process(context.Background(), batch))
+}
+
+func TestDistinctTraceIDCarriesPartAndKey(t *testing.T) {
+	batch := phase1TestBatch([]*MergeItem{
+		{Key: 10, SeriesID: 1, PartID: 100, Payload: []byte("a"), TraceID: "trace-a"},
+		{Key: 20, SeriesID: 2, PartID: 200, Payload: []byte("b"), TraceID: "trace-b"},
+		{Key: 30, SeriesID: 3, PartID: 100, Payload: []byte("c"), TraceID: "trace-c"},
+	})
+	op := NewDistinctTraceID(batch.Schema)
+	require.NoError(t, op.Init(context.Background()))
+	require.NoError(t, op.Process(context.Background(), batch))
+	require.Equal(t, []string{"trace-a", "trace-b", "trace-c"}, op.Order())
+	require.Equal(t, map[int64][]string{100: {"trace-a", "trace-c"}, 200: {"trace-b"}}, op.TraceIDsByPart())
+	require.Equal(t, map[string]int64{"trace-a": 10, "trace-b": 20, "trace-c": 30}, op.Keys())
+	require.Nil(t, batch.Selection)
+}
+
+func TestLimitSelectsFirstMaxRows(t *testing.T) {
+	batch := phase1TestBatch([]*MergeItem{
+		NewMergeItem(1, 1, 1, []byte("a")),
+		NewMergeItem(2, 1, 1, []byte("b")),
+		NewMergeItem(3, 1, 1, []byte("c")),
+	})
+	op := NewLimit(batch.Schema, 2)
+	require.NoError(t, op.Init(context.Background()))
+	require.ErrorIs(t, op.Process(context.Background(), batch), vectorized.ErrLimitExhausted)
+	require.Equal(t, []uint16{0, 1}, batch.Selection)
+}
+
+func TestLimitZeroIsUnbounded(t *testing.T) {
+	batch := phase1TestBatch([]*MergeItem{
+		NewMergeItem(1, 1, 1, []byte("a")),
+		NewMergeItem(2, 1, 1, []byte("b")),
+	})
+	op := NewLimit(batch.Schema, 0)
+	require.NoError(t, op.Init(context.Background()))
+	require.NoError(t, op.Process(context.Background(), batch))
+	require.Equal(t, []uint16{0, 1}, batch.Selection)
+}
+
+func phase1TestBatch(items []*MergeItem) *vectorized.RecordBatch {
+	batch := vectorized.NewRecordBatch(NewPhase1Schema(), len(items))
+	for _, item := range items {
+		appendMergeItem(batch, item)
+	}
+	return batch
+}

--- a/pkg/query/vectorized/trace/plan.go
+++ b/pkg/query/vectorized/trace/plan.go
@@ -1,0 +1,78 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trace
+
+import (
+	itersort "github.com/apache/skywalking-banyandb/pkg/iter/sort"
+	"github.com/apache/skywalking-banyandb/pkg/query/vectorized"
+)
+
+// Phase1Plan holds the executable Phase-1 pipeline and its carry-forward operator.
+type Phase1Plan struct {
+	Pipeline *vectorized.Pipeline
+	Carry    *DistinctTraceID
+}
+
+// Phase2Plan holds the executable Phase-2 pipeline and its grouping operator.
+type Phase2Plan struct {
+	Pipeline *vectorized.Pipeline
+	Group    *GroupByTraceID
+}
+
+// BuildMergePhase1 builds the ordered sidx Phase-1 pipeline.
+func BuildMergePhase1(iters []itersort.Iterator[*MergeItem], desc bool, maxTraceSize uint32, batchSize int) (*Phase1Plan, error) {
+	source := NewSortedMerge(iters, desc, batchSize)
+	return buildPhase1(source, true, maxTraceSize)
+}
+
+// BuildStaticPhase1 builds the traceID lookup Phase-1 pipeline.
+func BuildStaticPhase1(traceIDs []string, keys map[string]int64, maxTraceSize uint32, batchSize int) (*Phase1Plan, error) {
+	source := NewStaticTraceIDSource(traceIDs, keys, batchSize)
+	return buildPhase1(source, false, maxTraceSize)
+}
+
+// BuildPhase2 builds the span-materialization Phase-2 pipeline.
+// source must emit Phase-2 schema batches. traceIDsOrder is the Phase-1 arrival order.
+func BuildPhase2(source vectorized.PullOperator, traceIDsOrder []string) (*Phase2Plan, error) {
+	schema := source.OutputSchema()
+	group := NewGroupByTraceID(schema, traceIDsOrder)
+	pipeline, buildErr := vectorized.NewPipelineBuilder().
+		From(source).
+		Apply(NewProject(schema)).
+		Break(group).
+		Build()
+	if buildErr != nil {
+		return nil, buildErr
+	}
+	return &Phase2Plan{Pipeline: pipeline, Group: group}, nil
+}
+
+func buildPhase1(source vectorized.PullOperator, decode bool, maxTraceSize uint32) (*Phase1Plan, error) {
+	schema := source.OutputSchema()
+	limitCarry := NewLimitedDistinctTraceID(schema, maxTraceSize)
+	builder := vectorized.NewPipelineBuilder().From(source)
+	if decode {
+		builder.Apply(NewIDDecode(schema))
+	}
+	builder.Apply(limitCarry)
+	pipeline, buildErr := builder.Build()
+	if buildErr != nil {
+		return nil, buildErr
+	}
+	return &Phase1Plan{Pipeline: pipeline, Carry: limitCarry.Carry()}, nil
+}

--- a/pkg/query/vectorized/trace/plan_test.go
+++ b/pkg/query/vectorized/trace/plan_test.go
@@ -1,0 +1,156 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trace
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	itersort "github.com/apache/skywalking-banyandb/pkg/iter/sort"
+	"github.com/apache/skywalking-banyandb/pkg/query/vectorized"
+)
+
+// staticPhase2Source is a minimal PullOperator emitting pre-built Phase-2 batches for tests.
+type staticPhase2Source struct {
+	schema  *vectorized.BatchSchema
+	batches []*vectorized.RecordBatch
+	pos     int
+}
+
+func (s *staticPhase2Source) Init(context.Context) error            { return nil }
+func (s *staticPhase2Source) OutputSchema() *vectorized.BatchSchema { return s.schema }
+func (s *staticPhase2Source) Close() error                          { return nil }
+func (s *staticPhase2Source) NextBatch(_ context.Context) (*vectorized.RecordBatch, error) {
+	if s.pos >= len(s.batches) {
+		return nil, nil
+	}
+	b := s.batches[s.pos]
+	s.pos++
+	return b, nil
+}
+
+func TestBuildStaticPhase1CarriesOnlyLimitedRows(t *testing.T) {
+	plan, err := BuildStaticPhase1([]string{"trace-a", "trace-b", "trace-c"}, map[string]int64{"trace-c": 3}, 2, 10)
+	require.NoError(t, err)
+	require.NoError(t, plan.Pipeline.Init(context.Background()))
+
+	batch, err := plan.Pipeline.Next(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, batch)
+	require.Equal(t, []uint16{0, 1}, batch.Selection)
+	require.Equal(t, []string{"trace-a", "trace-b"}, plan.Carry.Order())
+	require.Equal(t, map[int64][]string{0: {"trace-a", "trace-b"}}, plan.Carry.TraceIDsByPart())
+
+	done, err := plan.Pipeline.Next(context.Background())
+	require.NoError(t, err)
+	require.Nil(t, done)
+	require.NoError(t, plan.Pipeline.Close())
+}
+
+func TestBuildMergePhase1DecodesLimitsAndCarries(t *testing.T) {
+	iter := newCountingIter([]*MergeItem{
+		NewMergeItem(1, 10, 100, traceIDPayload("trace-a")),
+		NewMergeItem(2, 20, 200, traceIDPayload("trace-b")),
+	})
+	plan, err := BuildMergePhase1([]itersort.Iterator[*MergeItem]{iter}, false, 1, 10)
+	require.NoError(t, err)
+	require.NoError(t, plan.Pipeline.Init(context.Background()))
+
+	batch, err := plan.Pipeline.Next(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, batch)
+	require.Equal(t, []uint16{0}, batch.Selection)
+	require.Equal(t, []string{"trace-a"}, plan.Carry.Order())
+	require.Equal(t, map[int64][]string{100: {"trace-a"}}, plan.Carry.TraceIDsByPart())
+	require.Equal(t, map[string]int64{"trace-a": 1}, plan.Carry.Keys())
+
+	done, err := plan.Pipeline.Next(context.Background())
+	require.NoError(t, err)
+	require.Nil(t, done)
+	require.NoError(t, plan.Pipeline.Close())
+}
+
+func TestBuildPhase2(t *testing.T) {
+	schema := NewPhase2Schema(nil)
+	// Build two batches: each batch is one cursor (one traceID, two spans)
+	batchA := vectorized.NewRecordBatch(schema, 2)
+	Phase2TraceIDs(batchA).Append("trace-a")
+	Phase2TraceIDs(batchA).Append("trace-a")
+	Phase2Keys(batchA).Append(int64(10))
+	Phase2Keys(batchA).Append(int64(10))
+	Phase2Spans(batchA).Append([]byte("spanA1"))
+	Phase2Spans(batchA).Append([]byte("spanA2"))
+	Phase2SpanIDs(batchA).Append("sA1")
+	Phase2SpanIDs(batchA).Append("sA2")
+	batchA.Len = 2
+
+	batchB := vectorized.NewRecordBatch(schema, 2)
+	Phase2TraceIDs(batchB).Append("trace-b")
+	Phase2TraceIDs(batchB).Append("trace-b")
+	Phase2Keys(batchB).Append(int64(20))
+	Phase2Keys(batchB).Append(int64(20))
+	Phase2Spans(batchB).Append([]byte("spanB1"))
+	Phase2Spans(batchB).Append([]byte("spanB2"))
+	Phase2SpanIDs(batchB).Append("sB1")
+	Phase2SpanIDs(batchB).Append("sB2")
+	batchB.Len = 2
+
+	source := &staticPhase2Source{
+		schema:  schema,
+		batches: []*vectorized.RecordBatch{batchA, batchB},
+	}
+
+	traceIDsOrder := []string{"trace-a", "trace-b"}
+	plan, buildErr := BuildPhase2(source, traceIDsOrder)
+	require.NoError(t, buildErr)
+	require.NoError(t, plan.Pipeline.Init(context.Background()))
+
+	outA, err := plan.Pipeline.Next(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, outA)
+	require.Equal(t, 2, outA.Len)
+	require.Equal(t, []string{"trace-a", "trace-a"}, Phase2TraceIDs(outA).Data())
+	require.Equal(t, [][]byte{[]byte("spanA1"), []byte("spanA2")}, Phase2Spans(outA).Data())
+
+	outB, err := plan.Pipeline.Next(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, outB)
+	require.Equal(t, 2, outB.Len)
+	require.Equal(t, []string{"trace-b", "trace-b"}, Phase2TraceIDs(outB).Data())
+	require.Equal(t, [][]byte{[]byte("spanB1"), []byte("spanB2")}, Phase2Spans(outB).Data())
+
+	done, err := plan.Pipeline.Next(context.Background())
+	require.NoError(t, err)
+	require.Nil(t, done)
+
+	require.NoError(t, plan.Pipeline.Close())
+}
+
+func TestBuildStaticPhase1ZeroLimitIsUnbounded(t *testing.T) {
+	plan, err := BuildStaticPhase1([]string{"trace-a", "trace-b"}, nil, 0, 10)
+	require.NoError(t, err)
+	require.NoError(t, plan.Pipeline.Init(context.Background()))
+	batch, err := plan.Pipeline.Next(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, batch)
+	require.Equal(t, []uint16{0, 1}, batch.Selection)
+	require.Equal(t, []string{"trace-a", "trace-b"}, plan.Carry.Order())
+	require.NoError(t, plan.Pipeline.Close())
+}

--- a/pkg/query/vectorized/trace/schema.go
+++ b/pkg/query/vectorized/trace/schema.go
@@ -1,0 +1,82 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trace
+
+import "github.com/apache/skywalking-banyandb/pkg/query/vectorized"
+
+const (
+	phase1ColumnKey = iota
+	phase1ColumnSeriesID
+	phase1ColumnPartID
+	phase1ColumnPayload
+	phase1ColumnTraceID
+)
+
+// Phase-1 column names.
+const (
+	Phase1ColumnNameKey      = "key"
+	Phase1ColumnNameSeriesID = "seriesID"
+	Phase1ColumnNamePartID   = "partID"
+	Phase1ColumnNamePayload  = "payload"
+	Phase1ColumnNameTraceID  = "traceID"
+)
+
+// NewPhase1Schema returns the thin trace-ID resolution batch schema.
+func NewPhase1Schema() *vectorized.BatchSchema {
+	return vectorized.NewBatchSchema([]vectorized.ColumnDef{
+		{Name: Phase1ColumnNameKey, Role: vectorized.RoleTimestamp, Type: vectorized.ColumnTypeInt64},
+		{Name: Phase1ColumnNameSeriesID, Role: vectorized.RoleSeriesID, Type: vectorized.ColumnTypeInt64},
+		{Name: Phase1ColumnNamePartID, Role: vectorized.RoleShardID, Type: vectorized.ColumnTypeInt64},
+		{Name: Phase1ColumnNamePayload, Role: vectorized.RoleTag, Type: vectorized.ColumnTypeBytes},
+		{Name: Phase1ColumnNameTraceID, Role: vectorized.RoleTag, Type: vectorized.ColumnTypeString},
+	})
+}
+
+// Phase-2 column indices.
+const (
+	phase2ColumnTraceID = iota
+	phase2ColumnKey
+	phase2ColumnSpan
+	phase2ColumnSpanID
+	// phase2FixedColumnCount is the number of fixed (non-tag) Phase-2 columns;
+	// dynamic tag columns start at this index.
+	phase2FixedColumnCount
+)
+
+// Phase-2 column names.
+const (
+	Phase2ColumnNameTraceID = "traceID"
+	Phase2ColumnNameKey     = "key"
+	Phase2ColumnNameSpan    = "span"
+	Phase2ColumnNameSpanID  = "spanID"
+)
+
+// NewPhase2Schema returns the span-materialization batch schema.
+// tagCols are the identity-omitted projected tag names.
+func NewPhase2Schema(tagCols []string) *vectorized.BatchSchema {
+	cols := []vectorized.ColumnDef{
+		{Name: Phase2ColumnNameTraceID, Role: vectorized.RoleTag, Type: vectorized.ColumnTypeString},
+		{Name: Phase2ColumnNameKey, Role: vectorized.RoleTimestamp, Type: vectorized.ColumnTypeInt64},
+		{Name: Phase2ColumnNameSpan, Role: vectorized.RoleTag, Type: vectorized.ColumnTypeBytes},
+		{Name: Phase2ColumnNameSpanID, Role: vectorized.RoleTag, Type: vectorized.ColumnTypeString},
+	}
+	for _, name := range tagCols {
+		cols = append(cols, vectorized.ColumnDef{Name: name, Role: vectorized.RoleTag, Type: vectorized.ColumnTypeTagValue})
+	}
+	return vectorized.NewBatchSchema(cols)
+}

--- a/pkg/query/vectorized/trace/schema_test.go
+++ b/pkg/query/vectorized/trace/schema_test.go
@@ -1,0 +1,56 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trace
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/apache/skywalking-banyandb/pkg/query/vectorized"
+)
+
+func TestNewPhase1Schema(t *testing.T) {
+	schema := NewPhase1Schema()
+	require.Equal(t, phase1ColumnKey, schema.TimestampIndex())
+	require.Equal(t, phase1ColumnSeriesID, schema.SeriesIDIndex())
+	require.Equal(t, phase1ColumnPartID, schema.ShardIDIndex())
+
+	payloadIdx, ok := schema.TagIndex("", Phase1ColumnNamePayload)
+	require.True(t, ok)
+	require.Equal(t, phase1ColumnPayload, payloadIdx)
+	require.Equal(t, vectorized.ColumnTypeBytes, schema.Columns[payloadIdx].Type)
+
+	traceIDIdx, ok := schema.TagIndex("", Phase1ColumnNameTraceID)
+	require.True(t, ok)
+	require.Equal(t, phase1ColumnTraceID, traceIDIdx)
+	require.Equal(t, vectorized.ColumnTypeString, schema.Columns[traceIDIdx].Type)
+}
+
+func TestPhase1ColumnHelpers(t *testing.T) {
+	batch := vectorized.NewRecordBatch(NewPhase1Schema(), 1)
+	item := NewMergeItem(1, 2, 3, []byte("payload"))
+	item.TraceID = "trace-a"
+	appendMergeItem(batch, item)
+
+	require.Equal(t, []int64{1}, phase1Keys(batch).Data())
+	require.Equal(t, []int64{2}, phase1SeriesIDs(batch).Data())
+	require.Equal(t, []int64{3}, phase1PartIDs(batch).Data())
+	require.Equal(t, [][]byte{[]byte("payload")}, phase1Payloads(batch).Data())
+	require.Equal(t, []string{"trace-a"}, phase1TraceIDs(batch).Data())
+}

--- a/pkg/query/vectorized/trace/sidx_response_iter.go
+++ b/pkg/query/vectorized/trace/sidx_response_iter.go
@@ -1,0 +1,119 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trace
+
+import (
+	"fmt"
+)
+
+// SidxRowBatch is the sidx row shape consumed by vectorized trace Phase 1.
+type SidxRowBatch struct {
+	Error   error
+	Keys    []int64
+	Data    [][]byte
+	SIDs    []int64
+	PartIDs []int64
+}
+
+// Len returns the number of rows in the batch.
+func (b *SidxRowBatch) Len() int {
+	return len(b.Keys)
+}
+
+// SidxResponseIterator adapts ordered sidx row batches to merge items.
+type SidxResponseIterator struct {
+	curr      *MergeItem
+	err       error
+	responses []*SidxRowBatch
+	batchIdx  int
+	rowIdx    int
+	closed    bool
+}
+
+// NewSidxResponseIterator constructs a merge iterator over sidx row batches.
+func NewSidxResponseIterator(responses []*SidxRowBatch) *SidxResponseIterator {
+	return &SidxResponseIterator{responses: responses, rowIdx: -1}
+}
+
+// Next advances to the next well-formed row.
+func (i *SidxResponseIterator) Next() bool {
+	if i.err != nil || i.closed {
+		return false
+	}
+	for i.batchIdx < len(i.responses) {
+		resp := i.responses[i.batchIdx]
+		if resp == nil {
+			i.batchIdx++
+			i.rowIdx = -1
+			continue
+		}
+		if resp.Error != nil {
+			i.err = resp.Error
+			return false
+		}
+		nextRowIdx := i.rowIdx + 1
+		if nextRowIdx >= resp.Len() {
+			i.batchIdx++
+			i.rowIdx = -1
+			continue
+		}
+		if validateErr := validateSidxResponseRow(resp, nextRowIdx); validateErr != nil {
+			i.err = validateErr
+			return false
+		}
+		i.rowIdx = nextRowIdx
+		i.curr = NewMergeItem(resp.Keys[i.rowIdx], resp.SIDs[i.rowIdx], resp.PartIDs[i.rowIdx], resp.Data[i.rowIdx])
+		return true
+	}
+	return false
+}
+
+// Val returns the current merge item.
+func (i *SidxResponseIterator) Val() *MergeItem {
+	return i.curr
+}
+
+// Close marks the iterator closed.
+func (i *SidxResponseIterator) Close() error {
+	i.closed = true
+	return nil
+}
+
+// Error returns the first response or shape error observed by Next.
+func (i *SidxResponseIterator) Error() error {
+	return i.err
+}
+
+func validateSidxResponseRow(resp *SidxRowBatch, rowIdx int) error {
+	if rowIdx >= len(resp.Keys) {
+		return fmt.Errorf("sidx response row %d missing key", rowIdx)
+	}
+	if rowIdx >= len(resp.Data) {
+		return fmt.Errorf("sidx response row %d missing data", rowIdx)
+	}
+	if rowIdx >= len(resp.SIDs) {
+		return fmt.Errorf("sidx response row %d missing series id", rowIdx)
+	}
+	if rowIdx >= len(resp.PartIDs) {
+		return fmt.Errorf("sidx response row %d missing part id", rowIdx)
+	}
+	if _, decodeErr := decodeTraceIDPayload(resp.Data[rowIdx]); decodeErr != nil {
+		return fmt.Errorf("sidx response row %d invalid trace id payload: %w", rowIdx, decodeErr)
+	}
+	return nil
+}

--- a/pkg/query/vectorized/trace/sidx_response_iter_test.go
+++ b/pkg/query/vectorized/trace/sidx_response_iter_test.go
@@ -1,0 +1,78 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trace
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSidxResponseIteratorAdaptsRows(t *testing.T) {
+	iter := NewSidxResponseIterator([]*SidxRowBatch{
+		{
+			Keys:    []int64{1, 2},
+			Data:    [][]byte{traceIDPayload("a"), traceIDPayload("b")},
+			SIDs:    []int64{10, 20},
+			PartIDs: []int64{100, 200},
+		},
+	})
+
+	require.True(t, iter.Next())
+	first := iter.Val()
+	require.Equal(t, int64(1), first.Key)
+	require.Equal(t, int64(10), first.SeriesID)
+	require.Equal(t, int64(100), first.PartID)
+	require.Equal(t, traceIDPayload("a"), first.Payload)
+
+	require.True(t, iter.Next())
+	second := iter.Val()
+	require.Equal(t, int64(2), second.Key)
+	require.Equal(t, int64(20), second.SeriesID)
+	require.Equal(t, int64(200), second.PartID)
+	require.Equal(t, traceIDPayload("b"), second.Payload)
+
+	require.False(t, iter.Next())
+	require.NoError(t, iter.Error())
+	require.NoError(t, iter.Close())
+}
+
+func TestSidxResponseIteratorCapturesResponseError(t *testing.T) {
+	wantErr := errors.New("boom")
+	iter := NewSidxResponseIterator([]*SidxRowBatch{{Error: wantErr}})
+	require.False(t, iter.Next())
+	require.ErrorIs(t, iter.Error(), wantErr)
+}
+
+func TestSidxResponseIteratorRejectsMalformedPayload(t *testing.T) {
+	iter := NewSidxResponseIterator([]*SidxRowBatch{
+		{
+			Keys:    []int64{1},
+			Data:    [][]byte{{0xff, 'x'}},
+			SIDs:    []int64{10},
+			PartIDs: []int64{100},
+		},
+	})
+	require.False(t, iter.Next())
+	require.Error(t, iter.Error())
+}
+
+func traceIDPayload(traceID string) []byte {
+	return append([]byte{idFormatV1}, []byte(traceID)...)
+}

--- a/pkg/query/vectorized/trace/sort_key.go
+++ b/pkg/query/vectorized/trace/sort_key.go
@@ -1,0 +1,27 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trace
+
+import "encoding/binary"
+
+func encodeInt64SortKey(key int64) [8]byte {
+	var out [8]byte
+	binary.BigEndian.PutUint64(out[:], uint64(key))
+	out[0] ^= 0x80
+	return out
+}

--- a/pkg/query/vectorized/trace/sort_key_test.go
+++ b/pkg/query/vectorized/trace/sort_key_test.go
@@ -1,0 +1,37 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trace
+
+import (
+	"bytes"
+	"math"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncodeInt64SortKeyPreservesNumericOrder(t *testing.T) {
+	values := []int64{0, -1, 1, math.MinInt64, math.MaxInt64, -100, 100}
+	sort.Slice(values, func(i, j int) bool {
+		left := encodeInt64SortKey(values[i])
+		right := encodeInt64SortKey(values[j])
+		return bytes.Compare(left[:], right[:]) < 0
+	})
+	require.Equal(t, []int64{math.MinInt64, -100, -1, 0, 1, 100, math.MaxInt64}, values)
+}

--- a/pkg/query/vectorized/trace/sorted_merge.go
+++ b/pkg/query/vectorized/trace/sorted_merge.go
@@ -1,0 +1,166 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trace
+
+import (
+	"context"
+
+	itersort "github.com/apache/skywalking-banyandb/pkg/iter/sort"
+	"github.com/apache/skywalking-banyandb/pkg/query/vectorized"
+)
+
+// MergeItem is one sorted Phase-1 trace candidate consumed by SortedMerge.
+type MergeItem struct {
+	TraceID   string
+	Payload   []byte
+	Key       int64
+	SeriesID  int64
+	PartID    int64
+	sortField [8]byte
+}
+
+// NewMergeItem builds a merge item whose SortedField preserves numeric int64 order.
+func NewMergeItem(key, seriesID, partID int64, payload []byte) *MergeItem {
+	return &MergeItem{
+		sortField: encodeInt64SortKey(key),
+		Key:       key,
+		SeriesID:  seriesID,
+		PartID:    partID,
+		Payload:   payload,
+	}
+}
+
+// SortedField returns the order-preserving encoded key for itersort.
+func (m *MergeItem) SortedField() []byte {
+	return m.sortField[:]
+}
+
+// SortedMerge lazily merges sorted trace candidate iterators and deduplicates payloads.
+type SortedMerge struct {
+	schema    *vectorized.BatchSchema
+	pool      *vectorized.BatchPool
+	seen      map[string]struct{}
+	merger    itersort.Iterator[*MergeItem]
+	iters     []itersort.Iterator[*MergeItem]
+	batchSize int
+	desc      bool
+	eof       bool
+	closed    bool
+}
+
+// NewSortedMerge returns a streaming pull operator backed by itersort.NewItemIter.
+func NewSortedMerge(iters []itersort.Iterator[*MergeItem], desc bool, batchSize int) *SortedMerge {
+	return &SortedMerge{
+		schema:    NewPhase1Schema(),
+		iters:     iters,
+		desc:      desc,
+		batchSize: batchSize,
+		seen:      make(map[string]struct{}),
+	}
+}
+
+// Init initializes the merge heap and output pool.
+func (s *SortedMerge) Init(context.Context) error {
+	if s.batchSize <= 0 {
+		s.batchSize = vectorized.DefaultBatchSize
+	}
+	s.pool = vectorized.NewBatchPool(s.schema, s.batchSize)
+	s.merger = itersort.NewItemIter(s.iters, s.desc)
+	return nil
+}
+
+// OutputSchema returns the Phase-1 schema.
+func (s *SortedMerge) OutputSchema() *vectorized.BatchSchema {
+	return s.schema
+}
+
+// NextBatch returns the next demand-bounded merged batch.
+func (s *SortedMerge) NextBatch(ctx context.Context) (*vectorized.RecordBatch, error) {
+	if s.eof {
+		return nil, nil
+	}
+	batch := s.pool.Get()
+	for batch.Len < s.batchSize {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		if !s.merger.Next() {
+			if iterErr := s.iteratorError(); iterErr != nil {
+				return nil, iterErr
+			}
+			s.eof = true
+			break
+		}
+		item := s.merger.Val()
+		payloadKey := string(item.Payload)
+		if _, ok := s.seen[payloadKey]; ok {
+			continue
+		}
+		s.seen[payloadKey] = struct{}{}
+		appendMergeItem(batch, item)
+	}
+	if batch.Len == 0 {
+		s.pool.Put(batch)
+		return nil, nil
+	}
+	return batch, nil
+}
+
+type errorIterator interface {
+	Error() error
+}
+
+func (s *SortedMerge) iteratorError() error {
+	for _, iter := range s.iters {
+		errorIter, ok := iter.(errorIterator)
+		if !ok {
+			continue
+		}
+		if iterErr := errorIter.Error(); iterErr != nil {
+			return iterErr
+		}
+	}
+	return nil
+}
+
+// Close releases the source iterators through the underlying merger.
+func (s *SortedMerge) Close() error {
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+	if s.merger != nil {
+		return s.merger.Close()
+	}
+	var closeErr error
+	for _, iter := range s.iters {
+		if iterErr := iter.Close(); iterErr != nil && closeErr == nil {
+			closeErr = iterErr
+		}
+	}
+	return closeErr
+}
+
+func appendMergeItem(batch *vectorized.RecordBatch, item *MergeItem) {
+	batch.Columns[phase1ColumnKey].(*vectorized.TypedColumn[int64]).Append(item.Key)
+	batch.Columns[phase1ColumnSeriesID].(*vectorized.TypedColumn[int64]).Append(item.SeriesID)
+	batch.Columns[phase1ColumnPartID].(*vectorized.TypedColumn[int64]).Append(item.PartID)
+	batch.Columns[phase1ColumnPayload].(*vectorized.TypedColumn[[]byte]).Append(item.Payload)
+	batch.Columns[phase1ColumnTraceID].(*vectorized.TypedColumn[string]).Append(item.TraceID)
+	batch.Len++
+}

--- a/pkg/query/vectorized/trace/sorted_merge_test.go
+++ b/pkg/query/vectorized/trace/sorted_merge_test.go
@@ -1,0 +1,144 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trace
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	itersort "github.com/apache/skywalking-banyandb/pkg/iter/sort"
+	"github.com/apache/skywalking-banyandb/pkg/query/vectorized"
+)
+
+func TestSortedMergeMergesAscendingAndDeduplicates(t *testing.T) {
+	op := NewSortedMerge([]itersort.Iterator[*MergeItem]{
+		newCountingIter([]*MergeItem{
+			NewMergeItem(1, 10, 100, []byte("a")),
+			NewMergeItem(3, 10, 100, []byte("c")),
+		}),
+		newCountingIter([]*MergeItem{
+			NewMergeItem(2, 20, 200, []byte("b")),
+			NewMergeItem(4, 20, 200, []byte("c")),
+		}),
+	}, false, 10)
+	require.NoError(t, op.Init(context.Background()))
+	batch, err := op.NextBatch(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []int64{1, 2, 3}, int64ColumnData(batch, phase1ColumnKey))
+	require.Equal(t, [][]byte{[]byte("a"), []byte("b"), []byte("c")}, bytesColumnData(batch, phase1ColumnPayload))
+	require.NoError(t, op.Close())
+}
+
+func TestSortedMergeMergesDescending(t *testing.T) {
+	op := NewSortedMerge([]itersort.Iterator[*MergeItem]{
+		newCountingIter([]*MergeItem{
+			NewMergeItem(3, 10, 100, []byte("c")),
+			NewMergeItem(1, 10, 100, []byte("a")),
+		}),
+		newCountingIter([]*MergeItem{
+			NewMergeItem(4, 20, 200, []byte("d")),
+			NewMergeItem(2, 20, 200, []byte("b")),
+		}),
+	}, true, 10)
+	require.NoError(t, op.Init(context.Background()))
+	batch, err := op.NextBatch(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []int64{4, 3, 2, 1}, int64ColumnData(batch, phase1ColumnKey))
+	require.NoError(t, op.Close())
+}
+
+func TestSortedMergeIsDemandBoundedAndClosesSources(t *testing.T) {
+	first := newCountingIter([]*MergeItem{
+		NewMergeItem(1, 10, 100, []byte("a")),
+		NewMergeItem(3, 10, 100, []byte("c")),
+		NewMergeItem(5, 10, 100, []byte("e")),
+	})
+	second := newCountingIter([]*MergeItem{
+		NewMergeItem(2, 20, 200, []byte("b")),
+		NewMergeItem(4, 20, 200, []byte("d")),
+		NewMergeItem(6, 20, 200, []byte("f")),
+	})
+	op := NewSortedMerge([]itersort.Iterator[*MergeItem]{first, second}, false, 2)
+	require.NoError(t, op.Init(context.Background()))
+
+	batch, err := op.NextBatch(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []int64{1, 2}, int64ColumnData(batch, phase1ColumnKey))
+	require.Less(t, first.nextCalls+second.nextCalls, 6)
+
+	require.NoError(t, op.Close())
+	require.True(t, first.closed)
+	require.True(t, second.closed)
+}
+
+func TestSortedMergePropagatesIteratorError(t *testing.T) {
+	iter := NewSidxResponseIterator([]*SidxRowBatch{
+		{
+			Keys:    []int64{1},
+			Data:    [][]byte{{0xff, 'x'}},
+			SIDs:    []int64{10},
+			PartIDs: []int64{100},
+		},
+	})
+	op := NewSortedMerge([]itersort.Iterator[*MergeItem]{iter}, false, 2)
+	require.NoError(t, op.Init(context.Background()))
+	batch, err := op.NextBatch(context.Background())
+	require.Nil(t, batch)
+	require.Error(t, err)
+	require.NoError(t, op.Close())
+}
+
+func int64ColumnData(batch *vectorized.RecordBatch, colIdx int) []int64 {
+	return batch.Columns[colIdx].(*vectorized.TypedColumn[int64]).Data()
+}
+
+func bytesColumnData(batch *vectorized.RecordBatch, colIdx int) [][]byte {
+	return batch.Columns[colIdx].(*vectorized.TypedColumn[[]byte]).Data()
+}
+
+type countingIter struct {
+	items     []*MergeItem
+	idx       int
+	nextCalls int
+	closed    bool
+}
+
+func newCountingIter(items []*MergeItem) *countingIter {
+	return &countingIter{items: items, idx: -1}
+}
+
+func (i *countingIter) Next() bool {
+	i.nextCalls++
+	nextIdx := i.idx + 1
+	if nextIdx >= len(i.items) {
+		return false
+	}
+	i.idx = nextIdx
+	return true
+}
+
+func (i *countingIter) Val() *MergeItem {
+	return i.items[i.idx]
+}
+
+func (i *countingIter) Close() error {
+	i.closed = true
+	return nil
+}

--- a/pkg/query/vectorized/trace/static_source.go
+++ b/pkg/query/vectorized/trace/static_source.go
@@ -1,0 +1,98 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trace
+
+import (
+	"context"
+
+	"github.com/apache/skywalking-banyandb/pkg/query/vectorized"
+)
+
+// StaticTraceIDSource emits Phase-1 rows for direct trace-ID lookup mode.
+type StaticTraceIDSource struct {
+	schema    *vectorized.BatchSchema
+	pool      *vectorized.BatchPool
+	keys      map[string]int64
+	traceIDs  []string
+	batchSize int
+	pos       int
+	closed    bool
+}
+
+// NewStaticTraceIDSource constructs a static lookup source.
+func NewStaticTraceIDSource(traceIDs []string, keys map[string]int64, batchSize int) *StaticTraceIDSource {
+	return &StaticTraceIDSource{
+		schema:    NewPhase1Schema(),
+		traceIDs:  append([]string(nil), traceIDs...),
+		keys:      keys,
+		batchSize: batchSize,
+	}
+}
+
+// Init initializes the output pool.
+func (s *StaticTraceIDSource) Init(context.Context) error {
+	if s.batchSize <= 0 {
+		s.batchSize = vectorized.DefaultBatchSize
+	}
+	s.pool = vectorized.NewBatchPool(s.schema, s.batchSize)
+	return nil
+}
+
+// OutputSchema returns the Phase-1 schema.
+func (s *StaticTraceIDSource) OutputSchema() *vectorized.BatchSchema {
+	return s.schema
+}
+
+// NextBatch emits the next static lookup batch.
+func (s *StaticTraceIDSource) NextBatch(ctx context.Context) (*vectorized.RecordBatch, error) {
+	if s.pos >= len(s.traceIDs) {
+		return nil, nil
+	}
+	batch := s.pool.Get()
+	for batch.Len < s.batchSize && s.pos < len(s.traceIDs) {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+		traceID := s.traceIDs[s.pos]
+		key := int64(0)
+		if s.keys != nil {
+			key = s.keys[traceID]
+		}
+		item := NewMergeItem(key, 0, 0, encodeTraceIDPayload(traceID))
+		item.TraceID = traceID
+		appendMergeItem(batch, item)
+		s.pos++
+	}
+	return batch, nil
+}
+
+// Close is idempotent and a no-op.
+func (s *StaticTraceIDSource) Close() error {
+	if s.closed {
+		return nil
+	}
+	s.closed = true
+	return nil
+}
+
+func encodeTraceIDPayload(traceID string) []byte {
+	out := make([]byte, 1, len(traceID)+1)
+	out[0] = idFormatV1
+	out = append(out, traceID...)
+	return out
+}

--- a/pkg/query/vectorized/trace/static_source_test.go
+++ b/pkg/query/vectorized/trace/static_source_test.go
@@ -1,0 +1,47 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trace
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStaticTraceIDSourceEmitsLookupRows(t *testing.T) {
+	source := NewStaticTraceIDSource([]string{"trace-a", "trace-b"}, map[string]int64{"trace-b": 2}, 1)
+	require.NoError(t, source.Init(context.Background()))
+
+	first, err := source.NextBatch(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []string{"trace-a"}, phase1TraceIDs(first).Data())
+	require.Equal(t, []int64{0}, phase1Keys(first).Data())
+	require.Equal(t, [][]byte{encodeTraceIDPayload("trace-a")}, phase1Payloads(first).Data())
+
+	second, err := source.NextBatch(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []string{"trace-b"}, phase1TraceIDs(second).Data())
+	require.Equal(t, []int64{2}, phase1Keys(second).Data())
+	require.Equal(t, [][]byte{encodeTraceIDPayload("trace-b")}, phase1Payloads(second).Data())
+
+	done, err := source.NextBatch(context.Background())
+	require.NoError(t, err)
+	require.Nil(t, done)
+	require.NoError(t, source.Close())
+}

--- a/pkg/query/vectorized/trace/trace_id_decode.go
+++ b/pkg/query/vectorized/trace/trace_id_decode.go
@@ -1,0 +1,81 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trace
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/apache/skywalking-banyandb/pkg/query/vectorized"
+)
+
+const idFormatV1 byte = 0x01
+
+// IDDecode decodes idFormatV1 trace-ID payloads into the traceID column.
+type IDDecode struct {
+	schema *vectorized.BatchSchema
+	closed bool
+}
+
+// NewIDDecode constructs a trace-ID decode fusible.
+func NewIDDecode(schema *vectorized.BatchSchema) *IDDecode {
+	return &IDDecode{schema: schema}
+}
+
+// Init is a no-op.
+func (d *IDDecode) Init(context.Context) error {
+	return nil
+}
+
+// OutputSchema returns the unchanged input schema.
+func (d *IDDecode) OutputSchema() *vectorized.BatchSchema {
+	return d.schema
+}
+
+// Process decodes every active row's payload into traceID.
+func (d *IDDecode) Process(_ context.Context, batch *vectorized.RecordBatch) error {
+	payloads := phase1Payloads(batch).Data()
+	traceIDs := phase1TraceIDs(batch)
+	for _, rowIdx := range activeIndices(batch) {
+		traceID, decodeErr := decodeTraceIDPayload(payloads[rowIdx])
+		if decodeErr != nil {
+			return fmt.Errorf("decode trace id at row %d: %w", rowIdx, decodeErr)
+		}
+		traceIDs.SetAt(int(rowIdx), traceID)
+	}
+	return nil
+}
+
+// Close is idempotent and a no-op.
+func (d *IDDecode) Close() error {
+	if d.closed {
+		return nil
+	}
+	d.closed = true
+	return nil
+}
+
+func decodeTraceIDPayload(data []byte) (string, error) {
+	if len(data) == 0 {
+		return "", fmt.Errorf("empty trace id payload")
+	}
+	if data[0] != idFormatV1 {
+		return "", fmt.Errorf("invalid trace id format: %x", data[0])
+	}
+	return string(data[1:]), nil
+}

--- a/pkg/query/vectorized/trace/trace_project.go
+++ b/pkg/query/vectorized/trace/trace_project.go
@@ -1,0 +1,91 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trace
+
+import (
+	"context"
+
+	"github.com/apache/skywalking-banyandb/pkg/query/model"
+	"github.com/apache/skywalking-banyandb/pkg/query/vectorized"
+)
+
+// Project is a no-op FusibleOperator documenting the Phase-2 projection contract.
+// Tag values are already decoded *modelv1.TagValue by the source; empty-projection
+// batches have no tag columns so r.Tags will naturally be nil.
+type Project struct {
+	schema *vectorized.BatchSchema
+}
+
+// NewProject constructs the Phase-2 projection operator.
+func NewProject(schema *vectorized.BatchSchema) *Project {
+	return &Project{schema: schema}
+}
+
+// Init is a no-op.
+func (p *Project) Init(context.Context) error { return nil }
+
+// OutputSchema returns the Phase-2 schema.
+func (p *Project) OutputSchema() *vectorized.BatchSchema { return p.schema }
+
+// Process is a no-op; tag values are already in final form.
+func (p *Project) Process(context.Context, *vectorized.RecordBatch) error { return nil }
+
+// Close is a no-op.
+func (p *Project) Close() error { return nil }
+
+// BatchToTraceResult converts a Phase-2 RecordBatch into a model.TraceResult.
+// schema is required to read tag column names for populating r.Tags.
+// Returns nil when batch is nil or empty.
+func BatchToTraceResult(batch *vectorized.RecordBatch, schema *vectorized.BatchSchema) *model.TraceResult {
+	if batch == nil || batch.Len == 0 {
+		return nil
+	}
+	tidCol := Phase2TraceIDs(batch)
+	keyCol := Phase2Keys(batch)
+	spanCol := Phase2Spans(batch)
+	spanIDCol := Phase2SpanIDs(batch)
+
+	tids := tidCol.Data()
+	keys := keyCol.Data()
+	spans := spanCol.Data()
+	spanIDs := spanIDCol.Data()
+
+	if len(tids) == 0 {
+		return nil
+	}
+
+	r := &model.TraceResult{
+		TID: tids[0],
+		Key: keys[0],
+	}
+	r.Spans = append(r.Spans, spans...)
+	r.SpanIDs = append(r.SpanIDs, spanIDs...)
+
+	numTagCols := len(schema.Columns) - phase2FixedColumnCount
+	if numTagCols > 0 {
+		r.Tags = make([]model.Tag, numTagCols)
+		for tagIdx := range numTagCols {
+			colDef := schema.Columns[phase2FixedColumnCount+tagIdx]
+			r.Tags[tagIdx] = model.Tag{Name: colDef.Name}
+			tagCol := Phase2TagCol(batch, tagIdx)
+			tagData := tagCol.Data()
+			r.Tags[tagIdx].Values = append(r.Tags[tagIdx].Values, tagData...)
+		}
+	}
+	return r
+}

--- a/pkg/query/vectorized/trace/trace_project_test.go
+++ b/pkg/query/vectorized/trace/trace_project_test.go
@@ -1,0 +1,87 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trace
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	modelv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/model/v1"
+	pbv1 "github.com/apache/skywalking-banyandb/pkg/pb/v1"
+	"github.com/apache/skywalking-banyandb/pkg/query/vectorized"
+)
+
+func TestProject_EmptyProjection(t *testing.T) {
+	schema := NewPhase2Schema(nil)
+	op := NewProject(schema)
+	ctx := context.Background()
+
+	require.NoError(t, op.Init(ctx))
+	require.Equal(t, schema, op.OutputSchema())
+
+	batch := vectorized.NewRecordBatch(schema, 2)
+	Phase2TraceIDs(batch).Append("trace-a")
+	Phase2TraceIDs(batch).Append("trace-a")
+	Phase2Keys(batch).Append(int64(1))
+	Phase2Keys(batch).Append(int64(1))
+	Phase2Spans(batch).Append([]byte("span1"))
+	Phase2Spans(batch).Append([]byte("span2"))
+	Phase2SpanIDs(batch).Append("s1")
+	Phase2SpanIDs(batch).Append("s2")
+	batch.Len = 2
+
+	// Process is a no-op; must return nil
+	processErr := op.Process(ctx, batch)
+	require.NoError(t, processErr)
+
+	// Batch should be unchanged
+	require.Equal(t, 2, batch.Len)
+	require.Equal(t, []string{"trace-a", "trace-a"}, Phase2TraceIDs(batch).Data())
+
+	require.NoError(t, op.Close())
+	// Idempotent close
+	require.NoError(t, op.Close())
+}
+
+func TestProject_WithTags(t *testing.T) {
+	schema := NewPhase2Schema([]string{"http.method", "status_code"})
+	op := NewProject(schema)
+	ctx := context.Background()
+
+	require.NoError(t, op.Init(ctx))
+
+	batch := vectorized.NewRecordBatch(schema, 1)
+	Phase2TraceIDs(batch).Append("trace-b")
+	Phase2Keys(batch).Append(int64(42))
+	Phase2Spans(batch).Append([]byte("spanData"))
+	Phase2SpanIDs(batch).Append("sp1")
+	Phase2TagCol(batch, 0).Append(pbv1.NullTagValue)
+	Phase2TagCol(batch, 1).Append(&modelv1.TagValue{})
+	batch.Len = 1
+
+	processErr := op.Process(ctx, batch)
+	require.NoError(t, processErr)
+
+	// Batch unchanged — 2 tag columns still present
+	require.Equal(t, 6, len(batch.Columns))
+	require.Equal(t, 1, batch.Len)
+
+	require.NoError(t, op.Close())
+}

--- a/pkg/query/vectorized/trace/util.go
+++ b/pkg/query/vectorized/trace/util.go
@@ -1,0 +1,31 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trace
+
+import "github.com/apache/skywalking-banyandb/pkg/query/vectorized"
+
+func activeIndices(batch *vectorized.RecordBatch) []uint16 {
+	if batch.Selection != nil {
+		return batch.Selection
+	}
+	out := make([]uint16, batch.Len)
+	for rowIdx := range out {
+		out[rowIdx] = uint16(rowIdx)
+	}
+	return out
+}

--- a/test/e2e-v2/cases/cluster/docker-compose.yml
+++ b/test/e2e-v2/cases/cluster/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     extends:
       file: ../../script/docker-compose/base-compose.yml
       service: data
-    command: data --node-discovery-mode=file --node-discovery-file-path=/etc/banyandb/nodes.yaml ${BANYANDB_MEASURE_VECTORIZED_FLAGS:---measure-vectorized-enabled=false}
+    command: data --node-discovery-mode=file --node-discovery-file-path=/etc/banyandb/nodes.yaml ${BANYANDB_MEASURE_VECTORIZED_FLAGS:---measure-vectorized-enabled=false} ${BANYANDB_TRACE_VECTORIZED_FLAGS:---trace-vectorized-enabled=false}
     volumes:
       - ./nodes.yaml:/etc/banyandb/nodes.yaml
     networks:
@@ -30,7 +30,7 @@ services:
     extends:
       file: ../../script/docker-compose/base-compose.yml
       service: liaison
-    command: liaison --node-discovery-mode=file --node-discovery-file-path=/etc/banyandb/nodes.yaml ${BANYANDB_MEASURE_VECTORIZED_FLAGS:---measure-vectorized-enabled=false}
+    command: liaison --node-discovery-mode=file --node-discovery-file-path=/etc/banyandb/nodes.yaml ${BANYANDB_MEASURE_VECTORIZED_FLAGS:---measure-vectorized-enabled=false} ${BANYANDB_TRACE_VECTORIZED_FLAGS:---trace-vectorized-enabled=false}
     volumes:
       - ./nodes.yaml:/etc/banyandb/nodes.yaml
     networks:

--- a/test/e2e-v2/cases/event/banyandb/docker-compose.yml
+++ b/test/e2e-v2/cases/event/banyandb/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     extends:
       file: ../../../script/docker-compose/base-compose.yml
       service: banyandb
-    command: standalone ${BANYANDB_MEASURE_VECTORIZED_FLAGS:---measure-vectorized-enabled=false}
+    command: standalone ${BANYANDB_MEASURE_VECTORIZED_FLAGS:---measure-vectorized-enabled=false} ${BANYANDB_TRACE_VECTORIZED_FLAGS:---trace-vectorized-enabled=false}
     networks:
       - e2e
 

--- a/test/e2e-v2/cases/lifecycle/data-generator/docker-compose.yml
+++ b/test/e2e-v2/cases/lifecycle/data-generator/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     ports:
       - 17912:17912
       - 17913:17913
-    command: standalone --measure-metadata-cache-wait-duration 1m --stream-metadata-cache-wait-duration 1m ${BANYANDB_MEASURE_VECTORIZED_FLAGS:---measure-vectorized-enabled=false}
+    command: standalone --measure-metadata-cache-wait-duration 1m --stream-metadata-cache-wait-duration 1m ${BANYANDB_MEASURE_VECTORIZED_FLAGS:---measure-vectorized-enabled=false} ${BANYANDB_TRACE_VECTORIZED_FLAGS:---trace-vectorized-enabled=false}
     networks:
       - e2e
 

--- a/test/e2e-v2/cases/lifecycle/docker-compose.yml
+++ b/test/e2e-v2/cases/lifecycle/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       file: ../../script/docker-compose/base-compose.yml
       service: data
     hostname: data-hot1
-    command: data --node-discovery-mode=file --node-discovery-file-path=/etc/banyandb/nodes.yaml --node-labels type=hot ${BANYANDB_MEASURE_VECTORIZED_FLAGS:---measure-vectorized-enabled=false}
+    command: data --node-discovery-mode=file --node-discovery-file-path=/etc/banyandb/nodes.yaml --node-labels type=hot ${BANYANDB_MEASURE_VECTORIZED_FLAGS:---measure-vectorized-enabled=false} ${BANYANDB_TRACE_VECTORIZED_FLAGS:---trace-vectorized-enabled=false}
     volumes:
       - ./data-generator/tmp/metadata:/tmp/measure/data/sw_metadata
       - ./nodes.yaml:/etc/banyandb/nodes.yaml
@@ -31,7 +31,7 @@ services:
       file: ../../script/docker-compose/base-compose.yml
       service: data
     hostname: data-warm1
-    command: data --node-discovery-mode=file --node-discovery-file-path=/etc/banyandb/nodes.yaml --node-labels type=warm ${BANYANDB_MEASURE_VECTORIZED_FLAGS:---measure-vectorized-enabled=false}
+    command: data --node-discovery-mode=file --node-discovery-file-path=/etc/banyandb/nodes.yaml --node-labels type=warm ${BANYANDB_MEASURE_VECTORIZED_FLAGS:---measure-vectorized-enabled=false} ${BANYANDB_TRACE_VECTORIZED_FLAGS:---trace-vectorized-enabled=false}
     volumes:
       - ./nodes.yaml:/etc/banyandb/nodes.yaml
     networks:
@@ -42,7 +42,7 @@ services:
       file: ../../script/docker-compose/base-compose.yml
       service: data
     hostname: data-cold1
-    command: data --node-discovery-mode=file --node-discovery-file-path=/etc/banyandb/nodes.yaml --node-labels type=cold ${BANYANDB_MEASURE_VECTORIZED_FLAGS:---measure-vectorized-enabled=false}
+    command: data --node-discovery-mode=file --node-discovery-file-path=/etc/banyandb/nodes.yaml --node-labels type=cold ${BANYANDB_MEASURE_VECTORIZED_FLAGS:---measure-vectorized-enabled=false} ${BANYANDB_TRACE_VECTORIZED_FLAGS:---trace-vectorized-enabled=false}
     volumes:
       - ./data-generator/tmp/measure:/tmp/measure
       - ./data-generator/tmp/stream:/tmp/stream
@@ -56,7 +56,7 @@ services:
     extends:
       file: ../../script/docker-compose/base-compose.yml
       service: liaison
-    command: liaison --node-discovery-mode=file --node-discovery-file-path=/etc/banyandb/nodes.yaml --data-node-selector type=hot ${BANYANDB_MEASURE_VECTORIZED_FLAGS:---measure-vectorized-enabled=false}
+    command: liaison --node-discovery-mode=file --node-discovery-file-path=/etc/banyandb/nodes.yaml --data-node-selector type=hot ${BANYANDB_MEASURE_VECTORIZED_FLAGS:---measure-vectorized-enabled=false} ${BANYANDB_TRACE_VECTORIZED_FLAGS:---trace-vectorized-enabled=false}
     volumes:
       - ./nodes.yaml:/etc/banyandb/nodes.yaml
     networks:

--- a/test/e2e-v2/cases/log/banyandb/docker-compose.yml
+++ b/test/e2e-v2/cases/log/banyandb/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     extends:
       file: ../../../script/docker-compose/base-compose.yml
       service: banyandb
-    command: standalone ${BANYANDB_MEASURE_VECTORIZED_FLAGS:---measure-vectorized-enabled=false}
+    command: standalone ${BANYANDB_MEASURE_VECTORIZED_FLAGS:---measure-vectorized-enabled=false} ${BANYANDB_TRACE_VECTORIZED_FLAGS:---trace-vectorized-enabled=false}
     networks:
       - e2e
 

--- a/test/e2e-v2/cases/profiling/trace/banyandb/docker-compose.yml
+++ b/test/e2e-v2/cases/profiling/trace/banyandb/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     extends:
       file: ../../../../script/docker-compose/base-compose.yml
       service: banyandb
-    command: standalone ${BANYANDB_MEASURE_VECTORIZED_FLAGS:---measure-vectorized-enabled=false}
+    command: standalone ${BANYANDB_MEASURE_VECTORIZED_FLAGS:---measure-vectorized-enabled=false} ${BANYANDB_TRACE_VECTORIZED_FLAGS:---trace-vectorized-enabled=false}
     networks:
       - e2e
 

--- a/test/e2e-v2/cases/rover/process/istio/banyandb/banyandb-deployment-vec.yaml
+++ b/test/e2e-v2/cases/rover/process/istio/banyandb/banyandb-deployment-vec.yaml
@@ -37,6 +37,7 @@ spec:
           args:
             - standalone
             - --measure-vectorized-enabled=true
+            - --trace-vectorized-enabled=true
           ports:
             - name: grpc
               containerPort: 17912

--- a/test/e2e-v2/cases/rover/process/istio/banyandb/banyandb-deployment.yaml
+++ b/test/e2e-v2/cases/rover/process/istio/banyandb/banyandb-deployment.yaml
@@ -37,6 +37,7 @@ spec:
           args:
             - standalone
             - --measure-vectorized-enabled=false
+            - --trace-vectorized-enabled=false
           ports:
             - name: grpc
               containerPort: 17912

--- a/test/e2e-v2/cases/storage/banyandb/docker-compose.yml
+++ b/test/e2e-v2/cases/storage/banyandb/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     extends:
       file: ../../../script/docker-compose/base-compose.yml
       service: banyandb
-    command: standalone ${BANYANDB_MEASURE_VECTORIZED_FLAGS:---measure-vectorized-enabled=false}
+    command: standalone ${BANYANDB_MEASURE_VECTORIZED_FLAGS:---measure-vectorized-enabled=false} ${BANYANDB_TRACE_VECTORIZED_FLAGS:---trace-vectorized-enabled=false}
     networks:
       - e2e
 

--- a/test/e2e-v2/cases/zipkin/banyandb/docker-compose.yml
+++ b/test/e2e-v2/cases/zipkin/banyandb/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     extends:
       file: ../../../script/docker-compose/base-compose.yml
       service: banyandb
-    command: standalone ${BANYANDB_MEASURE_VECTORIZED_FLAGS:---measure-vectorized-enabled=false}
+    command: standalone ${BANYANDB_MEASURE_VECTORIZED_FLAGS:---measure-vectorized-enabled=false} ${BANYANDB_TRACE_VECTORIZED_FLAGS:---trace-vectorized-enabled=false}
     networks:
       - e2e
 

--- a/test/integration/distributed/query/vectorized_trace_test.go
+++ b/test/integration/distributed/query/vectorized_trace_test.go
@@ -1,0 +1,114 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package query
+
+import (
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/apache/skywalking-banyandb/banyand/metadata/schema"
+	"github.com/apache/skywalking-banyandb/pkg/grpchelper"
+	vtrace "github.com/apache/skywalking-banyandb/pkg/query/vectorized/trace"
+	"github.com/apache/skywalking-banyandb/pkg/test"
+	"github.com/apache/skywalking-banyandb/pkg/test/helpers"
+	test_measure "github.com/apache/skywalking-banyandb/pkg/test/measure"
+	test_property "github.com/apache/skywalking-banyandb/pkg/test/property"
+	"github.com/apache/skywalking-banyandb/pkg/test/setup"
+	test_stream "github.com/apache/skywalking-banyandb/pkg/test/stream"
+	test_trace "github.com/apache/skywalking-banyandb/pkg/test/trace"
+	"github.com/apache/skywalking-banyandb/pkg/timestamp"
+	test_cases "github.com/apache/skywalking-banyandb/test/cases"
+	casestrace "github.com/apache/skywalking-banyandb/test/cases/trace"
+)
+
+// Vec trace independent verification on a distributed cluster.
+//
+// Boots a *separate* distributed cluster — 2 data nodes + 1 liaison, all
+// launched with --trace-vectorized-enabled=true — and replays the same
+// Trace test entries the row-based distributed suite already covers in
+// common.go. Each case asserts the row-path's expected output; every
+// greenness here is an INDEPENDENT verification that the vectorized trace
+// path produces the same results on the cluster wire.
+//
+// This is the distributed twin of test/integration/standalone/query/
+// vectorized_trace_test.go. Together they satisfy the directive that
+// integration standalone and distributed verify row and vec independently.
+var _ = ginkgo.Describe("vec trace independent verification (distributed)", ginkgo.Ordered, func() {
+	var (
+		vectorizedConn  *grpc.ClientConn
+		stopFn          func()
+		startQueryCount int64
+		savedTraceCtx   helpers.SharedContext
+	)
+	ginkgo.BeforeAll(func() {
+		savedTraceCtx = casestrace.SharedContext
+		startQueryCount = vtrace.QueryCount()
+
+		tmpDir, tmpDirCleanup, tmpErr := test.NewSpace()
+		gomega.Expect(tmpErr).NotTo(gomega.HaveOccurred())
+		dfWriter := setup.NewDiscoveryFileWriter(tmpDir)
+		config := setup.PropertyClusterConfig(dfWriter)
+		closeDataNode0 := setup.DataNode(config, "--trace-vectorized-enabled=true")
+		closeDataNode1 := setup.DataNode(config, "--trace-vectorized-enabled=true")
+		setup.PreloadSchemaViaProperty(config, test_stream.PreloadSchema, test_measure.PreloadSchema, test_trace.PreloadSchema, test_property.PreloadSchema)
+		config.AddLoadedKinds(schema.KindStream, schema.KindMeasure, schema.KindTrace)
+		liaisonAddr, closerLiaisonNode := setup.LiaisonNode(config, "--trace-vectorized-enabled=true")
+		stopFn = func() {
+			closerLiaisonNode()
+			closeDataNode0()
+			closeDataNode1()
+			tmpDirCleanup()
+		}
+		var connErr error
+		vectorizedConn, connErr = grpchelper.Conn(liaisonAddr, 10*time.Second,
+			grpc.WithTransportCredentials(insecure.NewCredentials()))
+		gomega.Expect(connErr).NotTo(gomega.HaveOccurred())
+		ns := timestamp.NowMilli().UnixNano()
+		now := time.Unix(0, ns-ns%int64(time.Minute))
+		test_cases.Initialize(liaisonAddr, now)
+		casestrace.SharedContext = helpers.SharedContext{
+			Connection: vectorizedConn,
+			BaseTime:   now,
+		}
+	})
+	ginkgo.AfterAll(func() {
+		// Restore the saved SharedContext before tearing down so any sibling
+		// Describe that runs after this one sees the original live connection.
+		casestrace.SharedContext = savedTraceCtx
+		queryCountDelta := vtrace.QueryCount() - startQueryCount
+		ginkgo.GinkgoWriter.Printf(
+			"vec trace dispatch (distributed): query_count=%d (delta across vec-trace-distributed table)\n",
+			queryCountDelta,
+		)
+		gomega.Expect(queryCountDelta).To(gomega.BeNumerically(">", int64(0)),
+			"vec trace dispatch did not fire for any case on the distributed cluster; "+
+				"--trace-vectorized-enabled=true may not have taken effect")
+		if vectorizedConn != nil {
+			gomega.Expect(vectorizedConn.Close()).To(gomega.Succeed())
+		}
+		if stopFn != nil {
+			stopFn()
+		}
+	})
+
+	casestrace.RegisterTable("Vec (distributed): Scanning Traces")
+})

--- a/test/integration/standalone/query/vectorized_trace_test.go
+++ b/test/integration/standalone/query/vectorized_trace_test.go
@@ -1,0 +1,109 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package query_test
+
+import (
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/apache/skywalking-banyandb/pkg/grpchelper"
+	vtrace "github.com/apache/skywalking-banyandb/pkg/query/vectorized/trace"
+	"github.com/apache/skywalking-banyandb/pkg/test"
+	"github.com/apache/skywalking-banyandb/pkg/test/helpers"
+	"github.com/apache/skywalking-banyandb/pkg/test/setup"
+	"github.com/apache/skywalking-banyandb/pkg/timestamp"
+	test_cases "github.com/apache/skywalking-banyandb/test/cases"
+	casestrace "github.com/apache/skywalking-banyandb/test/cases/trace"
+)
+
+// Vec trace independent verification on a standalone process.
+//
+// Boots a *separate* standalone with --trace-vectorized-enabled=true and
+// replays the same Trace test entries the row-based integration suite
+// already covers. Each case asserts the row-path's expected output, so
+// every greenness here is an INDEPENDENT verification that the vectorized
+// trace path produces the same results on its own merits.
+//
+// The cluster is fresh and isolated so neither side observes the other's
+// state. This is the standalone twin of test/integration/distributed/query/
+// vectorized_trace_test.go.
+var _ = ginkgo.Describe("vec trace independent verification (standalone)", ginkgo.Ordered, func() {
+	var (
+		vectorizedConn  *grpc.ClientConn
+		stopFn          func()
+		startQueryCount int64
+		savedTraceCtx   helpers.SharedContext
+	)
+	ginkgo.BeforeAll(func() {
+		savedTraceCtx = casestrace.SharedContext
+		startQueryCount = vtrace.QueryCount()
+
+		path, diskCleanupFn, pathErr := test.NewSpace()
+		gomega.Expect(pathErr).NotTo(gomega.HaveOccurred())
+		ports, portsErr := test.AllocateFreePorts(5)
+		gomega.Expect(portsErr).NotTo(gomega.HaveOccurred())
+		tmpDir, tmpDirCleanup, tmpErr := test.NewSpace()
+		gomega.Expect(tmpErr).NotTo(gomega.HaveOccurred())
+		dfWriter := setup.NewDiscoveryFileWriter(tmpDir)
+		config := setup.PropertyClusterConfig(dfWriter)
+		addr, _, closeFn := setup.ClosableStandalone(config, path, ports,
+			"--trace-vectorized-enabled=true",
+		)
+		stopFn = func() {
+			closeFn()
+			diskCleanupFn()
+			tmpDirCleanup()
+		}
+		var connErr error
+		vectorizedConn, connErr = grpchelper.Conn(addr, 10*time.Second,
+			grpc.WithTransportCredentials(insecure.NewCredentials()))
+		gomega.Expect(connErr).NotTo(gomega.HaveOccurred())
+		ns := timestamp.NowMilli().UnixNano()
+		now := time.Unix(0, ns-ns%int64(time.Minute))
+		test_cases.Initialize(addr, now)
+		casestrace.SharedContext = helpers.SharedContext{
+			Connection: vectorizedConn,
+			BaseTime:   now,
+		}
+	})
+	ginkgo.AfterAll(func() {
+		// Restore the saved SharedContext before tearing down so any sibling
+		// Describe that runs after this one sees the original live connection.
+		casestrace.SharedContext = savedTraceCtx
+		queryCountDelta := vtrace.QueryCount() - startQueryCount
+		ginkgo.GinkgoWriter.Printf(
+			"vec trace dispatch (standalone): query_count=%d (delta across vec-trace-standalone table)\n",
+			queryCountDelta,
+		)
+		gomega.Expect(queryCountDelta).To(gomega.BeNumerically(">", int64(0)),
+			"vec trace dispatch did not fire for any case in the vec-trace-standalone table; "+
+				"--trace-vectorized-enabled=true may not have taken effect")
+		if vectorizedConn != nil {
+			gomega.Expect(vectorizedConn.Close()).To(gomega.Succeed())
+		}
+		if stopFn != nil {
+			stopFn()
+		}
+	})
+
+	casestrace.RegisterTable("Vec (standalone): Scanning Traces")
+})

--- a/test/soak/docker-compose.soak.yaml
+++ b/test/soak/docker-compose.soak.yaml
@@ -23,7 +23,7 @@
 #
 # Key differences from the quick-start compose:
 #  - BanyanDB is built from local source (multi-stage Go build) instead of pulling a hub image.
-#  - The --measure-vectorized-enabled flag is controlled by BANYANDB_VEC_ENABLED (default: false).
+#  - The --measure-vectorized-enabled and --trace-vectorized-enabled flags are controlled by BANYANDB_VEC_ENABLED (default: false).
 #  - Every container has explicit memory and CPU limits so a 31 GB no-swap host cannot OOM-kill silently.
 #  - SOAK_DATA_DIR (default ./data) is bind-mounted so snapshots can be copied between phases.
 
@@ -40,6 +40,7 @@ services:
     command:
       - standalone
       - --measure-vectorized-enabled=${BANYANDB_VEC_ENABLED:-false}
+      - --trace-vectorized-enabled=${BANYANDB_VEC_ENABLED:-false}
       - --measure-root-path=/data
       - --stream-root-path=/data
       - --property-root-path=/data


### PR DESCRIPTION
## Summary

This PR introduces a vectorized pull-mode query pipeline for the trace engine, complementing the existing push-mode path. The implementation spans milestones M1–M7:

- **M1–M4, M6 (core pipeline)**: Two-phase synchronous pull architecture
  - Phase 1: `SortedMerge` / `StaticSource` → `LimitedDistinctTraceID` (dedup + limit + carry)
  - Phase 2: `loadedCursorSource` → `GroupByTraceID` → `TraceProject` → `TraceResult`
  - `loadTraceCursorsSync` with two-gate memory budget enforcement: hard-stop gate (cumulative ≥ budget) and metadata preflight gate (using `uncompressedSpanSizeBytes` before `loadData` to avoid post-peak overshoot); first-cursor exception to guarantee non-empty results
  - `QueryMemoryMiB` documented and enforced as a soft span-loading threshold (not an end-to-end cap)
- **M5**: SIDX-backed ordered query path with `sidxInstancesToVectorizedIterators`
- **M7**: Integration into the trace `Query` dispatcher with feature-flag gating (`--trace-vectorized-enabled`)

- **Bug fixes**:
  - `LimitedDistinctTraceID` max=0 path now deduplicates via `carry.keys` seen-check
  - `GroupByTraceID` deletes bucket after emit to prevent double-emission
  - Ordered SIDX path passes `maxRows=0` to `BuildMergePhase1` so `MaxTraceSize` acts as batch granularity (matching push-path semantics) rather than a total cap

- **Tests**:
  - Parity tests: vectorized vs push path for static, SIDX lookup, SIDX ordered, TTL, memory-quota, and over-scan cases
  - Unit regression tests for each bug fix: budget preflight, dedup in max=0 path, ordered MaxTraceSize parity, duplicate-order GroupBy emission
  - E2E and soak docker-compose configs extended with `--trace-vectorized-enabled`

## Test plan

- [ ] `go test ./banyand/trace/... ./pkg/query/vectorized/trace/...` — unit + parity tests
- [ ] `make lint` — lint clean
- [ ] `make build` — build clean
- [ ] E2E / soak: enable `--trace-vectorized-enabled` flag in docker-compose configs