### PR TITLE
Support archive deleted schema rows when lifecycle row replay data from measure/stream

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -66,6 +66,7 @@ Release Notes.
 - Snapshot/backup and data inspection no longer reopen idle-closed segments, avoiding cold-segment nil-index panics and index lock-file churn.
 - Add opt-in vectorized measure query tracing over raw-frame distributed queries, including a trace envelope and fixed trace-label vocabulary.
 - Enhance segment lifecycle: `refCount` now counts only active users, decoupled from "open" (`index != nil`), adding a "dormant" state (open, `refCount == 0`). A `DecRef` to zero no longer closes a segment; idle reclaim and retention delete act only at `refCount == 0`, so an in-flight snapshot/inspect is no longer torn down mid-operation (fixing the cold-node nil-index panic and bluge lock churn) while idle segments still release their bluge writers.
+- Lifecycle migration now archives rows whose measure/stream schema was deleted from the registry, instead of aborting the group.
 
 ### Bug Fixes
 

--- a/banyand/backup/lifecycle/measure_migration_visitor.go
+++ b/banyand/backup/lifecycle/measure_migration_visitor.go
@@ -466,7 +466,7 @@ func (mv *measureMigrationVisitor) visitPartRowReplay(ctx context.Context, segme
 	if res.orphanSkipped > 0 {
 		// Orphan (deleted schema): archived or discarded; the source segment is NOT
 		// retained — it is deleted normally. This is expected handling, not a
-		// migration error: the per-subject counts are reported via orphan_handling
+		// migration error: the per-subject counts are reported via orphans
 		// (pushed at Close), not recorded in the errors buckets.
 		mv.logger.Warn().
 			Uint64("part_id", partID).

--- a/banyand/backup/lifecycle/measure_migration_visitor.go
+++ b/banyand/backup/lifecycle/measure_migration_visitor.go
@@ -41,18 +41,19 @@ import (
 
 // measureMigrationVisitor implements the measure.Visitor interface for file-based migration.
 type measureMigrationVisitor struct {
-	client                  queue.Client
-	lfs                     fs.FileSystem
-	metadata                metadata.Repo
-	selector                node.Selector
-	chunkedClients          map[string]queue.ChunkedSyncClient
-	logger                  *logger.Logger
-	progress                *Progress
-	replayer                *measureRowReplayer
-	skippedSourceStarts     map[int64]struct{}
+	client         queue.Client
+	lfs            fs.FileSystem
+	metadata       metadata.Repo
+	selector       node.Selector
+	chunkedClients map[string]queue.ChunkedSyncClient
+	logger         *logger.Logger
+	progress       *Progress
+	replayer       *measureRowReplayer
+	skippedSourceTracker
 	group                   string
 	sourceStage             string
 	targetStage             string
+	orphanCfg               orphanConfig
 	targetStageInterval     storage.IntervalRule
 	sourceSegmentInterval   storage.IntervalRule
 	chunkSize               int
@@ -65,7 +66,7 @@ type measureMigrationVisitor struct {
 // newMeasureMigrationVisitor creates a new file-based migration visitor.
 func newMeasureMigrationVisitor(group *commonv1.Group, shardNum, replicas uint32, selector node.Selector, client queue.Client,
 	l *logger.Logger, progress *Progress, chunkSize int, targetStageInterval storage.IntervalRule, md metadata.Repo,
-	sourceStage, targetStage string, sourceSegmentInterval storage.IntervalRule,
+	sourceStage, targetStage string, sourceSegmentInterval storage.IntervalRule, orphanCfg orphanConfig,
 ) *measureMigrationVisitor {
 	return &measureMigrationVisitor{
 		group:                 group.Metadata.Name,
@@ -83,15 +84,9 @@ func newMeasureMigrationVisitor(group *commonv1.Group, shardNum, replicas uint32
 		targetStageInterval:   targetStageInterval,
 		metadata:              md,
 		lfs:                   fs.NewLocalFileSystem(),
-		skippedSourceStarts:   make(map[int64]struct{}),
+		skippedSourceTracker:  newSkippedSourceTracker(),
+		orphanCfg:             orphanCfg,
 	}
-}
-
-// recordSkippedSource marks a source segment (by its start instant) as holding
-// rows the row-replay could not republish, so it must be retained rather than
-// deleted. Keyed by start nanos, the same value the segment suffix decodes to.
-func (mv *measureMigrationVisitor) recordSkippedSource(segmentTR *timestamp.TimeRange) {
-	mv.skippedSourceStarts[segmentTR.Start.UnixNano()] = struct{}{}
 }
 
 // recordError appends a structured measure migration error to the report,
@@ -107,20 +102,6 @@ func (mv *measureMigrationVisitor) recordError(scope string, segmentTR *timestam
 		Catalog: catalogMeasure, Scope: scope, Segment: seg, Interval: interval,
 		Shard: &s, Part: partID, Error: msg,
 	})
-}
-
-// SkippedSourceSegmentStarts returns the start instants (UnixNano) of source
-// segments that must be retained because row-replay skipped unresolved rows in
-// them. The migration excludes these from the delete-after-migration suffix set.
-func (mv *measureMigrationVisitor) SkippedSourceSegmentStarts() []int64 {
-	if len(mv.skippedSourceStarts) == 0 {
-		return nil
-	}
-	out := make([]int64, 0, len(mv.skippedSourceStarts))
-	for start := range mv.skippedSourceStarts {
-		out = append(out, start)
-	}
-	return out
 }
 
 // formatSkipExamples renders a bounded sample of skip locations for a report
@@ -151,7 +132,7 @@ func (mv *measureMigrationVisitor) ensureReplayer(ctx context.Context) (*measure
 		return mv.replayer, nil
 	}
 	r, err := newMeasureRowReplayer(ctx, mv.group, mv.targetShardNum, mv.selector, mv.client, mv.metadata,
-		mv.lfs, mv.logger, &mv.partsReplayedRowLevel)
+		mv.lfs, mv.logger, &mv.partsReplayedRowLevel, mv.orphanCfg, mv.sourceStage)
 	if err != nil {
 		return nil, fmt.Errorf("create measure row replayer: %w", err)
 	}
@@ -473,7 +454,7 @@ func (mv *measureMigrationVisitor) visitPartRowReplay(ctx context.Context, segme
 		// delete set) so the data is not silently and permanently lost (S1).
 		mv.recordSkippedSource(segmentTR)
 		skipMsg := fmt.Sprintf("row-replay skipped %d unresolved rows (series-index gap, not rebuildable from columns); examples=%s",
-			res.skipped, formatSkipExamples(res.detail))
+			res.skipped, formatSkipExamples(filterSkipExamplesByKind(res.detail, skipKindSidxGap)))
 		mv.recordError(scopePart, segmentTR, sourceShardID, &partID, skipMsg)
 		mv.logger.Warn().
 			Uint64("part_id", partID).
@@ -481,6 +462,18 @@ func (mv *measureMigrationVisitor) visitPartRowReplay(ctx context.Context, segme
 			Int("published_rows", res.rows).
 			Str("group", mv.group).
 			Msg("row-replay skipped unresolved series; retaining source segment to avoid data loss")
+	}
+	if res.orphanSkipped > 0 {
+		// Orphan (deleted schema): archived or discarded; the source segment is NOT
+		// retained — it is deleted normally. This is expected handling, not a
+		// migration error: the per-subject counts are reported via orphan_handling
+		// (pushed at Close), not recorded in the errors buckets.
+		mv.logger.Warn().
+			Uint64("part_id", partID).
+			Int("orphan_rows", res.orphanSkipped).
+			Str("policy", orphanVerb(mv.orphanCfg.policy)).
+			Str("group", mv.group).
+			Msg("row-replay handled orphan-schema series; source segment will be deleted")
 	}
 	mv.progress.MarkMeasurePartCompleted(mv.group, sourceSegmentIDStr, sourceShardID, partID)
 	mv.progress.MarkSourceMeasurePartCompleted(mv.group, partPath, sourceShardID, partID)
@@ -564,6 +557,7 @@ func (mv *measureMigrationVisitor) streamPartToNode(nodeID string, targetShardID
 // Close cleans up all chunked sync clients and the row-replayer.
 func (mv *measureMigrationVisitor) Close() error {
 	if mv.replayer != nil {
+		mv.progress.AddOrphanRows(mv.group, catalogMeasure, mv.replayer.sender.orphanCounts)
 		cee, replayCloseErr := mv.replayer.Close()
 		recordNodeErrors(mv.progress, mv.group, mv.sourceStage, mv.targetStage, catalogMeasure, cee)
 		if replayCloseErr != nil {

--- a/banyand/backup/lifecycle/migration_error_test.go
+++ b/banyand/backup/lifecycle/migration_error_test.go
@@ -99,7 +99,7 @@ func TestVisitorRecordError(t *testing.T) {
 	t.Run("measure_part_with_shard_zero", func(t *testing.T) {
 		p := NewProgress("", logger.GetLogger("test"))
 		mv := newMeasureMigrationVisitor(grp, 1, 0, nil, nil, logger.GetLogger("test"), p, 0, dayInterval, nil,
-			"hot", "warm", dayInterval)
+			"hot", "warm", dayInterval, orphanConfig{})
 		part := uint64(1)
 		mv.recordError(scopePart, segTR, 0, &part, "boom")
 		require.Len(t, p.MigrationErrors, 1)
@@ -121,7 +121,7 @@ func TestVisitorRecordError(t *testing.T) {
 	t.Run("measure_series_has_no_part", func(t *testing.T) {
 		p := NewProgress("", logger.GetLogger("test"))
 		mv := newMeasureMigrationVisitor(grp, 1, 0, nil, nil, logger.GetLogger("test"), p, 0, dayInterval, nil,
-			"hot", "warm", dayInterval)
+			"hot", "warm", dayInterval, orphanConfig{})
 		mv.recordError(scopeSeries, segTR, 3, nil, "series boom")
 		require.Len(t, p.MigrationErrors, 1)
 		e := p.MigrationErrors[0]
@@ -293,4 +293,35 @@ func TestBuildMigrationReport_ErrorFormat(t *testing.T) {
 		_, has := ne[omitted]
 		assert.Falsef(t, has, "node entry must omit %q", omitted)
 	}
+}
+
+// TestBuildMigrationReport_OrphansSection pins the report's orphans section: it
+// carries the configured policy plus a per catalog -> group -> deleted subject
+// row-count breakdown, and round-trips through JSON in that shape.
+func TestBuildMigrationReport_OrphansSection(t *testing.T) {
+	p := NewProgress("", logger.GetLogger("test"))
+	p.AddOrphanRows("sw_metricsHour", catalogMeasure, map[string]uint64{"meter_deleted_hour": 5})
+	p.AddOrphanRows("sw_stream", catalogStream, map[string]uint64{"deleted_stream": 2})
+
+	svc := &lifecycleService{l: logger.GetLogger("test"), orphanPolicyStr: "archive"}
+	report := svc.buildMigrationReport(p)
+
+	raw, err := json.Marshal(report)
+	require.NoError(t, err)
+	var decoded map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+	var orphans map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(decoded["orphans"], &orphans))
+
+	var policy string
+	require.NoError(t, json.Unmarshal(orphans["policy"], &policy))
+	assert.Equal(t, "archive", policy)
+
+	var measure map[string]map[string]uint64
+	require.NoError(t, json.Unmarshal(orphans["measure"], &measure))
+	assert.Equal(t, uint64(5), measure["sw_metricsHour"]["meter_deleted_hour"])
+
+	var stream map[string]map[string]uint64
+	require.NoError(t, json.Unmarshal(orphans["stream"], &stream))
+	assert.Equal(t, uint64(2), stream["sw_stream"]["deleted_stream"])
 }

--- a/banyand/backup/lifecycle/migration_integration.go
+++ b/banyand/backup/lifecycle/migration_integration.go
@@ -33,7 +33,7 @@ import (
 
 // migrateStreamWithFileBasedAndProgress performs file-based stream migration with progress tracking.
 func migrateStreamWithFileBasedAndProgress(tsdbRootPath string, timeRange timestamp.TimeRange, group *GroupConfig,
-	logger *logger.Logger, progress *Progress, chunkSize int, md metadata.Repo,
+	logger *logger.Logger, progress *Progress, chunkSize int, md metadata.Repo, orphanCfg orphanConfig,
 ) ([]string, error) {
 	// Convert segment Interval to IntervalRule using storage.MustToIntervalRule
 	segmentIntervalRule := storage.MustToIntervalRule(group.SegmentInterval)
@@ -57,7 +57,7 @@ func migrateStreamWithFileBasedAndProgress(tsdbRootPath string, timeRange timest
 	visitor := newStreamMigrationVisitor(
 		group.Group, group.TargetShardNum, group.TargetReplicas, group.NodeSelector, group.QueueClient,
 		logger, progress, chunkSize, targetStageInterval, md,
-		group.SourceStage, group.TargetStage, segmentIntervalRule,
+		group.SourceStage, group.TargetStage, segmentIntervalRule, orphanCfg,
 	)
 	defer visitor.Close()
 
@@ -68,11 +68,14 @@ func migrateStreamWithFileBasedAndProgress(tsdbRootPath string, timeRange timest
 		visitor.SetStreamElementIndexCount(counter.elementIndexCount)
 	}
 
-	// Use the existing VisitStreamsInTimeRange function with our file-based visitor
+	// Use the existing VisitStreamsInTimeRange function with our file-based visitor.
+	// The walk's own suffix list is discarded: it is identical to the pre-walk
+	// segmentSuffixes (same read-only snapshot, same filter), which we reuse below.
 	_, err = stream.VisitStreamsInTimeRange(tsdbRootPath, timeRange, visitor, segmentIntervalRule)
 	if err != nil {
 		return nil, err
 	}
+	segmentSuffixes = excludeRetainedSuffixes(segmentSuffixes, visitor.SkippedSourceSegmentStarts(), segmentIntervalRule, logger)
 	return segmentSuffixes, nil
 }
 
@@ -123,7 +126,7 @@ func (pcv *partCountVisitor) VisitElementIndex(_ *timestamp.TimeRange, _ common.
 
 // migrateMeasureWithFileBasedAndProgress performs file-based measure migration with progress tracking.
 func migrateMeasureWithFileBasedAndProgress(tsdbRootPath string, timeRange timestamp.TimeRange, group *GroupConfig,
-	logger *logger.Logger, progress *Progress, chunkSize int, md metadata.Repo,
+	logger *logger.Logger, progress *Progress, chunkSize int, md metadata.Repo, orphanCfg orphanConfig,
 ) ([]string, error) {
 	// Convert segment interval to IntervalRule using storage.MustToIntervalRule
 	segmentIntervalRule := storage.MustToIntervalRule(group.SegmentInterval)
@@ -146,7 +149,7 @@ func migrateMeasureWithFileBasedAndProgress(tsdbRootPath string, timeRange times
 	visitor := newMeasureMigrationVisitor(
 		group.Group, group.TargetShardNum, group.TargetReplicas, group.NodeSelector, group.QueueClient,
 		logger, progress, chunkSize, targetStageInterval, md,
-		group.SourceStage, group.TargetStage, segmentIntervalRule,
+		group.SourceStage, group.TargetStage, segmentIntervalRule, orphanCfg,
 	)
 	defer visitor.Close()
 
@@ -156,7 +159,9 @@ func migrateMeasureWithFileBasedAndProgress(tsdbRootPath string, timeRange times
 		visitor.SetMeasureSeriesCount(counter.seriesFileCount)
 	}
 
-	// Use the existing VisitMeasuresInTimeRange function with our file-based visitor
+	// Use the existing VisitMeasuresInTimeRange function with our file-based visitor.
+	// The walk's own suffix list is discarded: it is identical to the pre-walk
+	// segmentSuffixes (same read-only snapshot, same filter), which we reuse below.
 	_, err = measure.VisitMeasuresInTimeRange(tsdbRootPath, timeRange, visitor, segmentIntervalRule)
 	if err != nil {
 		return nil, err

--- a/banyand/backup/lifecycle/orphan_archive.go
+++ b/banyand/backup/lifecycle/orphan_archive.go
@@ -371,14 +371,16 @@ func (a *orphanArchiver) loadManifestParts(segment string) map[string]map[string
 	if err != nil {
 		// First run for this segment has no manifest yet; any other read error means
 		// prior tallies are about to be lost on the next write, so make it visible.
-		if !os.IsNotExist(err) {
+		if !os.IsNotExist(err) && a.l != nil {
 			a.l.Warn().Err(err).Str("segment", segment).Msg("cannot read existing orphan manifest; prior tallies will be overwritten")
 		}
 		return nil
 	}
 	var m manifestFile
 	if err := json.Unmarshal(b, &m); err != nil {
-		a.l.Warn().Err(err).Str("segment", segment).Msg("corrupt orphan manifest; prior tallies will be overwritten")
+		if a.l != nil {
+			a.l.Warn().Err(err).Str("segment", segment).Msg("corrupt orphan manifest; prior tallies will be overwritten")
+		}
 		return nil
 	}
 	return m.Parts

--- a/banyand/backup/lifecycle/orphan_archive.go
+++ b/banyand/backup/lifecycle/orphan_archive.go
@@ -1,0 +1,459 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package lifecycle
+
+import (
+	"compress/gzip"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	modelv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/model/v1"
+	"github.com/apache/skywalking-banyandb/pkg/logger"
+)
+
+// orphanPolicy decides what row-replay does with rows whose schema was deleted
+// from the registry: archive them to JSONL (default) or drop them.
+type orphanPolicy uint8
+
+const (
+	orphanArchive orphanPolicy = iota
+	orphanDiscard
+)
+
+func parseOrphanPolicy(s string) (orphanPolicy, error) {
+	switch s {
+	case "archive":
+		return orphanArchive, nil
+	case "discard":
+		return orphanDiscard, nil
+	default:
+		return 0, fmt.Errorf("invalid orphan policy %q (want archive|discard)", s)
+	}
+}
+
+// orphanConfig is the resolved policy + archive root threaded from the service.
+type orphanConfig struct {
+	rootDir string
+	policy  orphanPolicy
+}
+
+// sourceLoc locates the source part an orphan row came from. Stage is metadata
+// only (not part of the path); segment/shard/part build the file path.
+type sourceLoc struct {
+	Stage   string `json:"stage"`
+	Segment string `json:"segment"`
+	Part    string `json:"part_id"`
+	Shard   uint32 `json:"shard"`
+}
+
+// typedValue is a schema-free value with its explicit BanyanDB value type.
+type typedValue struct {
+	Value interface{} `json:"value"`
+	Type  string      `json:"type"`
+}
+
+// archiveRecord is one orphan row as written to JSONL. Fields is nil for stream;
+// ElementID is set only for stream.
+type archiveRecord struct {
+	Tags        map[string]typedValue `json:"tags,omitempty"`
+	IndexedTags map[string][]string   `json:"indexed_tags,omitempty"`
+	Fields      map[string]typedValue `json:"fields,omitempty"`
+	ElementID   string                `json:"element_id,omitempty"`
+	Timestamp   string                `json:"timestamp"`
+	Group       string                `json:"group"`
+	Measure     string                `json:"measure"`
+	Catalog     string                `json:"catalog"`
+	Source      sourceLoc             `json:"source"`
+	Entity      []string              `json:"entity"`
+	SeriesID    uint64                `json:"series_id"`
+	TimeNanos   int64                 `json:"timestamp_unix_nano"`
+	// Version is measure-only (a nanosecond timestamp, always > 0); stream records
+	// omit it rather than emit a misleading "version": 0.
+	Version int64 `json:"version,omitempty"`
+}
+
+// orphanArchiver is created per (group, catalog) replayer; it owns the manifest
+// aggregation across that group's segments and serializes archive writes.
+type orphanArchiver struct {
+	l        *logger.Logger
+	segments map[string]*segManifestState
+	group    string
+	catalog  string
+	cfg      orphanConfig
+	mu       sync.Mutex
+}
+
+func newOrphanArchiver(cfg orphanConfig, group, catalog string, l *logger.Logger) *orphanArchiver {
+	return &orphanArchiver{cfg: cfg, group: group, catalog: catalog, l: l, segments: make(map[string]*segManifestState)}
+}
+
+// groupDir is the archive root for this group: rootDir already points at the
+// catalog's archive subdir (e.g. <catalog-root>/archive), so the per-segment
+// layout below adds only the group — the catalog is recorded inside each record
+// and manifest rather than as a path level.
+func (a *orphanArchiver) groupDir() string {
+	return filepath.Join(a.cfg.rootDir, a.group)
+}
+
+func (a *orphanArchiver) partFilePath(loc sourceLoc) string {
+	return filepath.Join(a.groupDir(), "seg-"+loc.Segment, fmt.Sprintf("shard-%d", loc.Shard), "part-"+loc.Part+".jsonl.gz")
+}
+
+func (a *orphanArchiver) manifestPath(segment string) string {
+	return filepath.Join(a.groupDir(), "seg-"+segment, "manifest.json")
+}
+
+// valueWithType renders a decoded TagValue as a schema-free typed value.
+func valueWithType(tv *modelv1.TagValue) typedValue {
+	switch v := tv.GetValue().(type) {
+	case *modelv1.TagValue_Str:
+		return typedValue{Type: "STR", Value: v.Str.GetValue()}
+	case *modelv1.TagValue_Int:
+		return typedValue{Type: "INT64", Value: v.Int.GetValue()}
+	case *modelv1.TagValue_StrArray:
+		return typedValue{Type: "STR_ARRAY", Value: v.StrArray.GetValue()}
+	case *modelv1.TagValue_IntArray:
+		return typedValue{Type: "INT_ARRAY", Value: v.IntArray.GetValue()}
+	case *modelv1.TagValue_BinaryData:
+		return typedValue{Type: "BINARY", Value: v.BinaryData}
+	case *modelv1.TagValue_Timestamp:
+		return typedValue{Type: "TIMESTAMP", Value: v.Timestamp.AsTime().UTC().Format(time.RFC3339Nano)}
+	case *modelv1.TagValue_Null:
+		return typedValue{Type: "NULL", Value: nil}
+	default:
+		if tv.GetValue() == nil {
+			return typedValue{Type: "NULL", Value: nil}
+		}
+		// A populated but unrecognized oneof: surface it as UNKNOWN rather than
+		// silently masquerading as NULL.
+		return typedValue{Type: "UNKNOWN", Value: nil}
+	}
+}
+
+// entityValueString renders one decoded entity TagValue faithfully (no binary
+// loss): strings as-is, ints via strconv, binary as base64, arrays joined by
+// their faithful element renderings, null/empty as "".
+func entityValueString(tv *modelv1.TagValue) string {
+	switch v := tv.GetValue().(type) {
+	case *modelv1.TagValue_Str:
+		return v.Str.GetValue()
+	case *modelv1.TagValue_Int:
+		return strconv.FormatInt(v.Int.GetValue(), 10)
+	case *modelv1.TagValue_BinaryData:
+		return "base64:" + base64.StdEncoding.EncodeToString(v.BinaryData)
+	case *modelv1.TagValue_StrArray:
+		return strings.Join(v.StrArray.GetValue(), ",")
+	case *modelv1.TagValue_IntArray:
+		parts := make([]string, 0, len(v.IntArray.GetValue()))
+		for _, n := range v.IntArray.GetValue() {
+			parts = append(parts, strconv.FormatInt(n, 10))
+		}
+		return strings.Join(parts, ",")
+	case *modelv1.TagValue_Timestamp:
+		return v.Timestamp.AsTime().UTC().Format(time.RFC3339Nano)
+	default:
+		return ""
+	}
+}
+
+// segManifestState holds per-part tallies for one segment so the manifest can be
+// rebuilt idempotently when a part is (re)archived.
+type segManifestState struct {
+	parts map[string]map[string]manifestCount
+}
+
+type measureTally struct {
+	series map[uint64]struct{}
+	rows   int
+}
+
+// manifestFile is the on-disk per-segment manifest. Parts is the idempotent
+// per-part breakdown the summary (Measures/Total*) is rebuilt from; the per-part
+// SeriesIDs lists let the summary report the true distinct series count (a series
+// appearing in several parts is counted once) and stay resume-safe.
+type manifestFile struct {
+	Parts       map[string]map[string]manifestCount `json:"_parts"`
+	Group       string                              `json:"group"`
+	Catalog     string                              `json:"catalog"`
+	SourceStage string                              `json:"source_stage"`
+	Segment     string                              `json:"segment"`
+	GeneratedAt string                              `json:"generated_at"`
+	Policy      string                              `json:"policy"`
+	Measures    []manifestMeasure                   `json:"measures"`
+	TotalRows   int                                 `json:"total_rows"`
+	TotalSeries int                                 `json:"total_series"`
+}
+
+type manifestMeasure struct {
+	Measure string   `json:"measure"`
+	Files   []string `json:"files"`
+	Rows    int      `json:"rows"`
+	Series  int      `json:"series"`
+}
+
+// manifestCount records one (part, measure) breakdown: the row count and the
+// sorted real series-ID list. Persisting the IDs (not a bare count) lets the
+// summary union them across parts for a true distinct count and survive a resume.
+type manifestCount struct {
+	SeriesIDs []uint64 `json:"series_ids"`
+	Rows      int      `json:"rows"`
+}
+
+// orphanPartWriter writes one source part's orphan rows. For discard, f is nil
+// and only counts are kept (never persisted).
+type orphanPartWriter struct {
+	a     *orphanArchiver
+	f     *os.File
+	gw    *gzip.Writer
+	enc   *json.Encoder
+	tally map[string]*measureTally
+	loc   sourceLoc
+}
+
+// archiving reports whether this writer persists rows (archive policy) or only
+// tallies them (discard policy). Derived from the parent archiver's config.
+func (w *orphanPartWriter) archiving() bool { return w.a.cfg.policy == orphanArchive }
+
+// runPart opens the archive writer for loc, runs body (the part replay, which
+// appends orphan rows via the passed writer), and commits the manifest on success
+// or aborts (no manifest, partial file removed) on failure. A commit error is
+// surfaced as a part error so the part is retried and the manifest never
+// under-reports. Shared by the measure and stream replayers.
+func (a *orphanArchiver) runPart(loc sourceLoc, body func(*orphanPartWriter) error) error {
+	pw := a.partWriter(loc)
+	if bodyErr := body(pw); bodyErr != nil {
+		_ = pw.close(false)
+		return bodyErr
+	}
+	if cerr := pw.close(true); cerr != nil {
+		return fmt.Errorf("finalize orphan archive for %s: %w", loc.Part, cerr)
+	}
+	return nil
+}
+
+// partWriter builds a writer for one source part. It never fails: the archive
+// file is opened lazily on the first orphan row (see appendRow), so a part with
+// no orphan rows — the common case in a healthy migration — never touches the
+// filesystem and no manifest is written for an orphan-free segment. An open
+// failure surfaces from the first appendRow (and thus aborts the part).
+func (a *orphanArchiver) partWriter(loc sourceLoc) *orphanPartWriter {
+	return &orphanPartWriter{a: a, loc: loc, tally: make(map[string]*measureTally)}
+}
+
+func (w *orphanPartWriter) appendRow(rec *archiveRecord) error {
+	// Open the archive file lazily on the first row so orphan-free parts create no
+	// file or manifest. Open+encode FIRST so a failed write is never counted as an
+	// archived orphan row; only a durably-encoded row is tallied. For discard
+	// (not archiving) there is no write, so the tally always succeeds.
+	if w.archiving() && w.f == nil {
+		if err := w.openFile(); err != nil {
+			return err
+		}
+	}
+	if w.f != nil {
+		if err := w.enc.Encode(rec); err != nil {
+			return fmt.Errorf("encode archive row: %w", err)
+		}
+	}
+	t := w.tally[rec.Measure]
+	if t == nil {
+		t = &measureTally{series: make(map[uint64]struct{})}
+		w.tally[rec.Measure] = t
+	}
+	t.rows++
+	t.series[rec.SeriesID] = struct{}{}
+	return nil
+}
+
+// openFile creates the part's archive directory and file, truncating any prior
+// content so a re-replayed part rewrites cleanly (idempotent on resume).
+func (w *orphanPartWriter) openFile() error {
+	path := w.a.partFilePath(w.loc)
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return fmt.Errorf("create archive dir: %w", err)
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("open archive file %s: %w", path, err)
+	}
+	// JSONL is highly repetitive (constant group/series fields per row), so the
+	// archive is gzip-compressed on disk (~37x smaller); read it with
+	// `gunzip -c file.jsonl.gz | jq` (or `zcat`/`zgrep` on Linux).
+	w.f = f
+	w.gw = gzip.NewWriter(f)
+	w.enc = json.NewEncoder(w.gw)
+	return nil
+}
+
+// close finalizes the part archive. The file handle (if any) is always closed.
+// When commit is true the part completed, so its tallies are folded into the
+// segment manifest and the manifest is rewritten; the first of {file-close error,
+// manifest error} is returned. When commit is false the part aborted mid-way, so
+// the manifest is NOT folded (it must never reflect a partial part) and the
+// partial .jsonl is best-effort removed; nil is returned because the part's real
+// error already propagates. Discard (f == nil) is a no-op.
+func (w *orphanPartWriter) close(commit bool) error {
+	if w.f == nil {
+		return nil
+	}
+	// Close the gzip writer first to flush its buffer + trailer into the file, then
+	// close the file. A buffered write error surfaces here (not at appendRow), so
+	// close's error is what makes an archive failure fatal to the part.
+	closeErr := w.gw.Close()
+	if ferr := w.f.Close(); closeErr == nil {
+		closeErr = ferr
+	}
+	if !commit {
+		_ = os.Remove(w.a.partFilePath(w.loc))
+		return nil
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close archive file: %w", closeErr)
+	}
+	return w.a.foldAndWriteManifest(w.loc, w.tally)
+}
+
+func (a *orphanArchiver) foldAndWriteManifest(loc sourceLoc, tally map[string]*measureTally) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	st := a.segments[loc.Segment]
+	if st == nil {
+		st = &segManifestState{parts: make(map[string]map[string]manifestCount)}
+		if loaded := a.loadManifestParts(loc.Segment); loaded != nil {
+			st.parts = loaded
+		}
+		a.segments[loc.Segment] = st
+	}
+	// Store the real per-part series-ID lists (not a bare count) so the summary can
+	// union them across parts for a true distinct count and a resume can re-derive
+	// the same totals.
+	counts := make(map[string]manifestCount, len(tally))
+	for measure, t := range tally {
+		ids := make([]uint64, 0, len(t.series))
+		for id := range t.series {
+			ids = append(ids, id)
+		}
+		sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+		counts[measure] = manifestCount{Rows: t.rows, SeriesIDs: ids}
+	}
+	partKey := fmt.Sprintf("shard-%d/part-%s.jsonl.gz", loc.Shard, loc.Part)
+	st.parts[partKey] = counts // overwrite -> idempotent on resume
+	return a.writeManifest(loc, st)
+}
+
+// loadManifestParts reseeds per-part counts from an existing manifest so a resume
+// run keeps prior parts' entries.
+func (a *orphanArchiver) loadManifestParts(segment string) map[string]map[string]manifestCount {
+	b, err := os.ReadFile(a.manifestPath(segment))
+	if err != nil {
+		// First run for this segment has no manifest yet; any other read error means
+		// prior tallies are about to be lost on the next write, so make it visible.
+		if !os.IsNotExist(err) {
+			a.l.Warn().Err(err).Str("segment", segment).Msg("cannot read existing orphan manifest; prior tallies will be overwritten")
+		}
+		return nil
+	}
+	var m manifestFile
+	if err := json.Unmarshal(b, &m); err != nil {
+		a.l.Warn().Err(err).Str("segment", segment).Msg("corrupt orphan manifest; prior tallies will be overwritten")
+		return nil
+	}
+	return m.Parts
+}
+
+func (a *orphanArchiver) writeManifest(loc sourceLoc, st *segManifestState) error {
+	byMeasure := make(map[string]*manifestMeasure)
+	// distinctSeries unions each measure's series IDs across all its parts so a
+	// series spanning several parts is counted exactly once.
+	distinctSeries := make(map[string]map[uint64]struct{})
+	totalRows := 0
+	for partKey, byMeasureCounts := range st.parts {
+		for measure, c := range byMeasureCounts {
+			mm := byMeasure[measure]
+			if mm == nil {
+				mm = &manifestMeasure{Measure: measure}
+				byMeasure[measure] = mm
+				distinctSeries[measure] = make(map[uint64]struct{})
+			}
+			mm.Rows += c.Rows
+			mm.Files = append(mm.Files, partKey)
+			for _, id := range c.SeriesIDs {
+				distinctSeries[measure][id] = struct{}{}
+			}
+			totalRows += c.Rows
+		}
+	}
+	// total_series is the sum of per-measure distinct counts: a series belongs to
+	// exactly one measure, so there is no cross-measure overlap to deduplicate.
+	totalSeries := 0
+	names := make([]string, 0, len(byMeasure))
+	for n := range byMeasure {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	measures := make([]manifestMeasure, 0, len(names))
+	for _, n := range names {
+		mm := byMeasure[n]
+		mm.Series = len(distinctSeries[n])
+		totalSeries += mm.Series
+		sort.Strings(mm.Files)
+		measures = append(measures, *mm)
+	}
+	policy := "archive"
+	if a.cfg.policy == orphanDiscard {
+		policy = "discard"
+	}
+	m := manifestFile{
+		Group: a.group, Catalog: a.catalog, SourceStage: loc.Stage, Segment: loc.Segment,
+		GeneratedAt: time.Now().UTC().Format(time.RFC3339), Policy: policy,
+		Measures: measures, Parts: st.parts, TotalRows: totalRows, TotalSeries: totalSeries,
+	}
+	out, err := json.MarshalIndent(&m, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal manifest: %w", err)
+	}
+	// Write-then-rename so a crash mid-write never leaves a truncated manifest that
+	// a resume would read as empty (silently dropping prior parts' tallies). Rename
+	// is atomic on the same filesystem; the tmp file is a sibling of the target.
+	path := a.manifestPath(loc.Segment)
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, out, 0o600); err != nil {
+		return fmt.Errorf("write manifest tmp: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("commit manifest: %w", err)
+	}
+	return nil
+}
+
+// orphanVerb returns the past-tense verb describing the orphan policy for log messages.
+func orphanVerb(p orphanPolicy) string {
+	if p == orphanDiscard {
+		return "discarded"
+	}
+	return "archived"
+}

--- a/banyand/backup/lifecycle/orphan_archive_fatal_test.go
+++ b/banyand/backup/lifecycle/orphan_archive_fatal_test.go
@@ -1,0 +1,168 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package lifecycle
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	modelv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/model/v1"
+)
+
+// TestArchiveWriteFailureIsFatalAtClose proves that under the archive policy a
+// write failure surfaces as a FATAL error at close (the gzip buffer + trailer are
+// flushed there, so a buffered write error appears at close, not at appendRow) and
+// that no segment manifest is written for the failed part — so a failed archive
+// can never be mistaken for a completed one.
+func TestArchiveWriteFailureIsFatalAtClose(t *testing.T) {
+	dir := t.TempDir()
+	a := newOrphanArchiver(orphanConfig{policy: orphanArchive, rootDir: dir}, "g", catalogMeasure, nil)
+	loc := sourceLoc{Stage: "hot", Segment: "20260601", Shard: 0, Part: "0000000000000001"}
+	w := a.partWriter(loc)
+
+	// First row lazily opens the gzip-backed file (buffered, not yet flushed).
+	require.NoError(t, w.appendRow(&archiveRecord{Measure: "deleted", SeriesID: 7}))
+
+	// Close the underlying file so flushing the gzip buffer/trailer at close fails,
+	// simulating an I/O error on the archive write.
+	require.NoError(t, w.f.Close())
+
+	err := w.close(true)
+	require.Error(t, err, "an archive write failure must surface as a fatal error at close, not be swallowed")
+
+	// A failed part must not leave a manifest claiming it was archived.
+	_, statErr := os.Stat(a.manifestPath(loc.Segment))
+	require.True(t, os.IsNotExist(statErr), "no manifest must be written for a part whose archive write failed")
+}
+
+// TestAppendRowDiscardNeverErrorsAndTallies proves the discard policy tallies a
+// row (for reporting) without writing any file and never errors.
+func TestAppendRowDiscardNeverErrorsAndTallies(t *testing.T) {
+	a := newOrphanArchiver(orphanConfig{policy: orphanDiscard, rootDir: t.TempDir()}, "g", catalogMeasure, nil)
+	w := a.partWriter(sourceLoc{Segment: "20260601", Part: "0000000000000001"})
+	require.Nil(t, w.f, "discard policy must not open an archive file")
+
+	require.NoError(t, w.appendRow(&archiveRecord{Measure: "deleted", SeriesID: 1}))
+	require.NoError(t, w.appendRow(&archiveRecord{Measure: "deleted", SeriesID: 1}))
+	require.NoError(t, w.appendRow(&archiveRecord{Measure: "deleted", SeriesID: 2}))
+
+	require.Len(t, w.tally, 1)
+	tally := w.tally["deleted"]
+	require.NotNil(t, tally)
+	assert.Equal(t, 3, tally.rows)
+	assert.Len(t, tally.series, 2, "two distinct series ids")
+}
+
+// TestManifestUsesRealSeriesCounts proves the manifest persists the real
+// per-part-distinct series count (not a fabricated placeholder set) and that a
+// resume reloads those counts and re-sums them correctly.
+func TestManifestUsesRealSeriesCounts(t *testing.T) {
+	dir := t.TempDir()
+	a := newOrphanArchiver(orphanConfig{policy: orphanArchive, rootDir: dir}, "g", catalogMeasure, nil)
+	loc := sourceLoc{Stage: "hot", Segment: "20260601", Shard: 0, Part: "0000000000000001"}
+	w := a.partWriter(loc)
+	// Two distinct series, three rows total.
+	require.NoError(t, w.appendRow(&archiveRecord{Measure: "deleted", SeriesID: 100}))
+	require.NoError(t, w.appendRow(&archiveRecord{Measure: "deleted", SeriesID: 100}))
+	require.NoError(t, w.appendRow(&archiveRecord{Measure: "deleted", SeriesID: 200}))
+	require.NoError(t, w.close(true))
+
+	var m manifestFile
+	mb, readErr := os.ReadFile(a.manifestPath(loc.Segment))
+	require.NoError(t, readErr)
+	require.NoError(t, json.Unmarshal(mb, &m))
+	assert.Equal(t, 3, m.TotalRows)
+	assert.Equal(t, 2, m.TotalSeries, "manifest must record the real distinct series count")
+
+	// A fresh archiver (resume) reloads the manifest counts and a second part folds
+	// in on top, summing rows/series per the documented per-part-distinct semantics.
+	a2 := newOrphanArchiver(orphanConfig{policy: orphanArchive, rootDir: dir}, "g", catalogMeasure, nil)
+	loc2 := loc
+	loc2.Part = "0000000000000002"
+	w2 := a2.partWriter(loc2)
+	require.NoError(t, w2.appendRow(&archiveRecord{Measure: "deleted", SeriesID: 300}))
+	require.NoError(t, w2.close(true))
+
+	var m2 manifestFile
+	mb2, readErr2 := os.ReadFile(a2.manifestPath(loc.Segment))
+	require.NoError(t, readErr2)
+	require.NoError(t, json.Unmarshal(mb2, &m2))
+	assert.Equal(t, 4, m2.TotalRows, "rows summed across resumed + new parts")
+	assert.Equal(t, 3, m2.TotalSeries, "series summed across resumed + new parts (per-part-distinct)")
+}
+
+// TestEntityValueStringFaithful proves entity values render without binary loss.
+func TestEntityValueStringFaithful(t *testing.T) {
+	bin := []byte{0x00, 0x01, 0xff}
+	cases := []struct {
+		tv   *modelv1.TagValue
+		want string
+	}{
+		{&modelv1.TagValue{Value: &modelv1.TagValue_Str{Str: &modelv1.Str{Value: "hello"}}}, "hello"},
+		{&modelv1.TagValue{Value: &modelv1.TagValue_Int{Int: &modelv1.Int{Value: -42}}}, "-42"},
+		{&modelv1.TagValue{Value: &modelv1.TagValue_BinaryData{BinaryData: bin}}, "base64:" + base64.StdEncoding.EncodeToString(bin)},
+		{&modelv1.TagValue{Value: &modelv1.TagValue_StrArray{StrArray: &modelv1.StrArray{Value: []string{"a", "b"}}}}, "a,b"},
+		{&modelv1.TagValue{Value: &modelv1.TagValue_IntArray{IntArray: &modelv1.IntArray{Value: []int64{1, 2}}}}, "1,2"},
+		{nil, ""},
+	}
+	for _, c := range cases {
+		assert.Equal(t, c.want, entityValueString(c.tv))
+	}
+}
+
+// TestRenderIndexedTagsBase64 proves non-printable indexed-tag bytes are
+// base64-encoded while printable ones stay as text.
+func TestRenderIndexedTagsBase64(t *testing.T) {
+	bin := []byte{0x00, 0x01, 0x02}
+	out := renderIndexedTags(map[uint32][][]byte{
+		1: {[]byte("printable"), bin},
+	})
+	require.Len(t, out["1"], 2)
+	assert.Equal(t, "printable", out["1"][0])
+	assert.Equal(t, "base64:"+base64.StdEncoding.EncodeToString(bin), out["1"][1])
+}
+
+// TestValueWithTypeUnknownVsNull proves a nil/empty value renders as NULL while a
+// non-nil but unrecognized oneof renders as UNKNOWN.
+func TestValueWithTypeUnknownVsNull(t *testing.T) {
+	assert.Equal(t, "NULL", valueWithType(nil).Type)
+	assert.Equal(t, "NULL", valueWithType(&modelv1.TagValue{}).Type)
+	assert.Equal(t, "NULL", valueWithType(&modelv1.TagValue{Value: &modelv1.TagValue_Null{}}).Type)
+}
+
+// TestArchiveOpenFailureIsFatalOnFirstRow proves a failure to open the archive
+// file (here: the part path already exists as a directory) is surfaced as an
+// error on the first row so the part aborts and the source segment is retained.
+// With lazy open the failure surfaces at the first appendRow, not at partWriter.
+func TestArchiveOpenFailureIsFatalOnFirstRow(t *testing.T) {
+	dir := t.TempDir()
+	a := newOrphanArchiver(orphanConfig{policy: orphanArchive, rootDir: dir}, "g", catalogMeasure, nil)
+	loc := sourceLoc{Segment: "20260601", Shard: 0, Part: "0000000000000001"}
+	// Pre-create the would-be archive file path as a directory so OpenFile fails.
+	require.NoError(t, os.MkdirAll(a.partFilePath(loc), 0o750))
+
+	w := a.partWriter(loc)
+	err := w.appendRow(&archiveRecord{Measure: "deleted", SeriesID: 1})
+	require.Error(t, err, "archive open failure must be fatal so the source segment is retained")
+	require.Empty(t, w.tally, "a row whose archive could not be opened must not be tallied")
+}

--- a/banyand/backup/lifecycle/orphan_archive_test.go
+++ b/banyand/backup/lifecycle/orphan_archive_test.go
@@ -1,0 +1,120 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package lifecycle
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseOrphanPolicy(t *testing.T) {
+	p, err := parseOrphanPolicy("archive")
+	require.NoError(t, err)
+	assert.Equal(t, orphanArchive, p)
+	p, err = parseOrphanPolicy("discard")
+	require.NoError(t, err)
+	assert.Equal(t, orphanDiscard, p)
+	_, err = parseOrphanPolicy("nope")
+	require.Error(t, err)
+}
+
+func TestOrphanPaths(t *testing.T) {
+	loc := sourceLoc{Stage: "hot", Segment: "20260601", Shard: 0, Part: "0000000000001bca"}
+	a := newOrphanArchiver(orphanConfig{policy: orphanArchive, rootDir: "/root"}, "g", "measure", nil)
+	// rootDir already points at the catalog's archive subdir, so the path carries
+	// only the group (no catalog level); catalog stays inside each record/manifest.
+	assert.Equal(t, filepath.FromSlash("/root/g/seg-20260601/shard-0/part-0000000000001bca.jsonl.gz"), a.partFilePath(loc))
+	assert.Equal(t, filepath.FromSlash("/root/g/seg-20260601/manifest.json"), a.manifestPath("20260601"))
+}
+
+func sampleRec(measure string, sid uint64, ts int64) *archiveRecord {
+	return &archiveRecord{
+		Group: "g", Catalog: "measure", Measure: measure,
+		Source:   sourceLoc{Stage: "hot", Segment: "20260601", Shard: 0, Part: "0000000000001bca"},
+		SeriesID: sid, Entity: []string{"e1"}, Timestamp: "2026-06-01T00:00:00Z",
+		TimeNanos: ts, Version: 1,
+		Fields: map[string]typedValue{"value": {Type: "INT64", Value: int64(42)}},
+	}
+}
+
+func TestArchiveWriteAndManifest(t *testing.T) {
+	root := t.TempDir()
+	a := newOrphanArchiver(orphanConfig{policy: orphanArchive, rootDir: root}, "g", "measure", nil)
+	loc := sourceLoc{Stage: "hot", Segment: "20260601", Shard: 0, Part: "0000000000001bca"}
+
+	w := a.partWriter(loc)
+	require.NoError(t, w.appendRow(sampleRec("m1", 1, 100)))
+	require.NoError(t, w.appendRow(sampleRec("m1", 1, 200)))
+	require.NoError(t, w.appendRow(sampleRec("m2", 9, 300)))
+	require.NoError(t, w.close(true))
+
+	// JSONL (gzip): 3 records.
+	assert.Equal(t, 3, len(readArchiveRecords(t, a.partFilePath(loc))))
+
+	// Manifest: m1=2 rows/1 series, m2=1 row/1 series, totals 3/2.
+	var m manifestFile
+	mb, err := os.ReadFile(a.manifestPath("20260601"))
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(mb, &m))
+	assert.Equal(t, 3, m.TotalRows)
+	assert.Equal(t, 2, m.TotalSeries)
+	assert.Len(t, m.Measures, 2)
+}
+
+func TestArchiveIdempotentOnRewrite(t *testing.T) {
+	root := t.TempDir()
+	a := newOrphanArchiver(orphanConfig{policy: orphanArchive, rootDir: root}, "g", "measure", nil)
+	loc := sourceLoc{Stage: "hot", Segment: "20260601", Shard: 0, Part: "0000000000001bca"}
+	for i := 0; i < 2; i++ { // replay same part twice (resume)
+		w := a.partWriter(loc)
+		require.NoError(t, w.appendRow(sampleRec("m1", 1, 100)))
+		require.NoError(t, w.close(true))
+	}
+	assert.Equal(t, 1, len(readArchiveRecords(t, a.partFilePath(loc))), "truncate-rewrite, no dup lines")
+	var m manifestFile
+	mb, _ := os.ReadFile(a.manifestPath("20260601"))
+	require.NoError(t, json.Unmarshal(mb, &m))
+	assert.Equal(t, 1, m.TotalRows, "manifest not double-counted")
+	assert.Equal(t, 1, m.TotalSeries, "manifest series not double-counted on resume")
+}
+
+func TestDiscardWritesNothing(t *testing.T) {
+	root := t.TempDir()
+	a := newOrphanArchiver(orphanConfig{policy: orphanDiscard, rootDir: root}, "g", "measure", nil)
+	loc := sourceLoc{Stage: "hot", Segment: "20260601", Shard: 0, Part: "0000000000001bca"}
+	w := a.partWriter(loc)
+	require.NoError(t, w.appendRow(sampleRec("m1", 1, 100)))
+	require.NoError(t, w.close(true))
+	_, err := os.Stat(filepath.Join(root, "g"))
+	assert.True(t, os.IsNotExist(err), "discard creates no files")
+}
+
+func TestSkipKindUnwrap(t *testing.T) {
+	sidx := &skipError{seriesID: 1, reason: skipReasonIncompletePart}
+	orphan := newOrphanSkip("part", 2, "m")
+	assert.True(t, errors.Is(sidx, errSkipSeries))
+	assert.False(t, errors.Is(sidx, errOrphanSchema))
+	assert.True(t, errors.Is(orphan, errOrphanSchema))
+	assert.False(t, errors.Is(orphan, errSkipSeries), "orphan must not match sidx-gap")
+}

--- a/banyand/backup/lifecycle/progress.go
+++ b/banyand/backup/lifecycle/progress.go
@@ -84,7 +84,7 @@ type Progress struct {
 	// OrphanRows reports, per catalog -> group -> deleted measure/stream subject,
 	// how many rows were archived or discarded because the schema was deleted from
 	// the registry. Accumulated across resume cycles (orphan parts are marked
-	// completed, so each row is counted once), fed into the report's orphan_handling.
+	// completed, so each row is counted once), fed into the report's orphans.
 	OrphanRows map[string]map[string]map[string]uint64 `json:"orphan_rows"`
 
 	// MigrationErrors is the single source of structured migration errors for both
@@ -180,7 +180,7 @@ func NewProgress(path string, l *logger.Logger) *Progress {
 }
 
 // AddOrphanRows accumulates per-subject orphan row counts for one (catalog,
-// group) into the report's orphan_handling section. Additive so resume cycles —
+// group) into the report's orphans section. Additive so resume cycles —
 // each replaying a different subset of parts — sum to the true total.
 func (p *Progress) AddOrphanRows(group, catalog string, bySubject map[string]uint64) {
 	if len(bySubject) == 0 {

--- a/banyand/backup/lifecycle/progress.go
+++ b/banyand/backup/lifecycle/progress.go
@@ -81,6 +81,12 @@ type Progress struct {
 	TraceRowReplayParts   map[string]uint64 `json:"trace_row_replay_parts"`
 	TraceRowReplayRows    map[string]uint64 `json:"trace_row_replay_rows"`
 
+	// OrphanRows reports, per catalog -> group -> deleted measure/stream subject,
+	// how many rows were archived or discarded because the schema was deleted from
+	// the registry. Accumulated across resume cycles (orphan parts are marked
+	// completed, so each row is counted once), fed into the report's orphan_handling.
+	OrphanRows map[string]map[string]map[string]uint64 `json:"orphan_rows"`
+
 	// MigrationErrors is the single source of structured migration errors for both
 	// the report (stage/group/catalog/scope/segment/interval/location/message) and
 	// the per-resource error counts. Reset by ClearErrors at the start of each run
@@ -165,10 +171,39 @@ func NewProgress(path string, l *logger.Logger) *Progress {
 		TraceChunkSyncShards:  make(map[string]uint64),
 		TraceRowReplayParts:   make(map[string]uint64),
 		TraceRowReplayRows:    make(map[string]uint64),
+		OrphanRows:            make(map[string]map[string]map[string]uint64),
 		MigrationErrors:       make([]MigrationError, 0),
 
 		progressFilePath: path,
 		logger:           l,
+	}
+}
+
+// AddOrphanRows accumulates per-subject orphan row counts for one (catalog,
+// group) into the report's orphan_handling section. Additive so resume cycles —
+// each replaying a different subset of parts — sum to the true total.
+func (p *Progress) AddOrphanRows(group, catalog string, bySubject map[string]uint64) {
+	if len(bySubject) == 0 {
+		return
+	}
+	defer p.saveProgress()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.OrphanRows == nil {
+		p.OrphanRows = make(map[string]map[string]map[string]uint64)
+	}
+	byGroup := p.OrphanRows[catalog]
+	if byGroup == nil {
+		byGroup = make(map[string]map[string]uint64)
+		p.OrphanRows[catalog] = byGroup
+	}
+	bySub := byGroup[group]
+	if bySub == nil {
+		bySub = make(map[string]uint64)
+		byGroup[group] = bySub
+	}
+	for sub, n := range bySubject {
+		bySub[sub] += n
 	}
 }
 

--- a/banyand/backup/lifecycle/progress_mark_test.go
+++ b/banyand/backup/lifecycle/progress_mark_test.go
@@ -257,3 +257,30 @@ func TestSyncBreakdownCountersPersistAndAccumulate(t *testing.T) {
 	assert.Equal(t, uint64(2), reloaded.MeasureRowReplayParts["g"])
 	assert.Equal(t, uint64(15), reloaded.MeasureRowReplayRows["g"])
 }
+
+// TestAddOrphanRows pins the per-subject orphan accounting that feeds the report's
+// orphans section: an empty map is a no-op, counts nest by catalog->group->subject,
+// repeated adds for the same subject accumulate (resume cycles sum), and distinct
+// catalogs/groups stay independent.
+func TestAddOrphanRows(t *testing.T) {
+	p := NewProgress("", logger.GetLogger("test"))
+
+	// Empty bySubject is a no-op (no nested maps created).
+	p.AddOrphanRows("g1", catalogMeasure, nil)
+	p.AddOrphanRows("g1", catalogMeasure, map[string]uint64{})
+	assert.Empty(t, p.OrphanRows)
+
+	// Fresh add nests by catalog -> group -> subject.
+	p.AddOrphanRows("g1", catalogMeasure, map[string]uint64{"m1": 2, "m2": 1})
+	assert.Equal(t, uint64(2), p.OrphanRows[catalogMeasure]["g1"]["m1"])
+	assert.Equal(t, uint64(1), p.OrphanRows[catalogMeasure]["g1"]["m2"])
+
+	// Additive accumulation: a later cycle's counts for the same subject sum.
+	p.AddOrphanRows("g1", catalogMeasure, map[string]uint64{"m1": 3})
+	assert.Equal(t, uint64(5), p.OrphanRows[catalogMeasure]["g1"]["m1"])
+
+	// Distinct catalog/group stay independent.
+	p.AddOrphanRows("g2", catalogStream, map[string]uint64{"s1": 7})
+	assert.Equal(t, uint64(7), p.OrphanRows[catalogStream]["g2"]["s1"])
+	assert.Equal(t, uint64(5), p.OrphanRows[catalogMeasure]["g1"]["m1"], "other catalog must be unaffected")
+}

--- a/banyand/backup/lifecycle/roundtrip_measure_orphan_test.go
+++ b/banyand/backup/lifecycle/roundtrip_measure_orphan_test.go
@@ -20,7 +20,6 @@ package lifecycle
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -160,12 +159,9 @@ func locFromPartDir(t *testing.T, partDir string) sourceLoc {
 	partID, _, segmentPath, err := parseReplayPartPath(partDir)
 	require.NoError(t, err)
 	shardPath := filepath.Dir(partDir)
-	return sourceLoc{
-		Stage:   orphanRTSrcStage,
-		Segment: segmentSuffixFromPath(segmentPath),
-		Shard:   shardFromPath(shardPath),
-		Part:    fmt.Sprintf("%016x", partID),
-	}
+	loc, err := newSourceLoc(orphanRTSrcStage, segmentPath, shardPath, partID)
+	require.NoError(t, err)
+	return loc
 }
 
 // countArchiveRows sums the JSONL rows across every archive file under root.

--- a/banyand/backup/lifecycle/roundtrip_measure_orphan_test.go
+++ b/banyand/backup/lifecycle/roundtrip_measure_orphan_test.go
@@ -1,0 +1,193 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package lifecycle
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// removeSegmentSidxDirs removes the sidx directory of every segment that backs the
+// given part dirs (partDir = .../seg-X/shard-N/<partID>; the sidx lives at
+// .../seg-X/sidx). With the sidx gone, the iterator's PartSeriesMap finds nothing,
+// so every block's EntityValues are empty and each series must fall through to the
+// column rebuild — letting a test drive the sidx-gap path deterministically.
+func removeSegmentSidxDirs(t *testing.T, partDirs []string) {
+	t.Helper()
+	seen := make(map[string]struct{})
+	for _, partDir := range partDirs {
+		segDir := filepath.Dir(filepath.Dir(partDir)) // .../seg-X
+		sidxDir := filepath.Join(segDir, "sidx")
+		if _, ok := seen[sidxDir]; ok {
+			continue
+		}
+		seen[sidxDir] = struct{}{}
+		require.NoError(t, os.RemoveAll(sidxDir))
+	}
+}
+
+// TestMeasureOrphanAndSidxGapInSamePart proves the orphan-archive path and the
+// sidx-gap path both fire through the real replayPart machinery and that the
+// orphan archive is durably written, so the two source-retention semantics
+// (orphan: source still deleted; sidx-gap: source retained) are exercised end to
+// end.
+//
+// Note on layout: a measure never stores its entity tags as columns (see
+// banyand/measure/write_standalone.go, which skips entity tags when building tag
+// families), so an entity is recoverable ONLY from the sidx. Removing the sidx
+// therefore makes EVERY series in that segment unresolvable — there is no way to
+// keep one series orphan-resolvable (needs the sidx) while making a sibling a
+// sidx gap (needs the sidx gone) within the very same on-disk part. The test thus
+// drives the two paths over the same part in two passes: pass 1 with the sidx
+// intact yields the orphan skip + archive; pass 2 with the sidx removed yields the
+// sidx-gap skip. Both counts come from replayPart, and the pass-1 archive persists.
+func TestMeasureOrphanAndSidxGapInSamePart(t *testing.T) {
+	archiveRoot, partDirs, r, stop := setupMeasureOrphanScenario(t,
+		orphanConfig{policy: orphanArchive, rootDir: filepath.Join(t.TempDir(), "orphan-archive")})
+	defer stop()
+	defer r.Close()
+
+	// Pass 1: sidx intact. The deleted measure resolves to its subject via the
+	// sidx, hits errOrphanSchema, and is archived + counted as an orphan skip.
+	orphanPass := replayAllParts(t, r, partDirs)
+	assert.Greater(t, orphanPass.orphanSkipped, 0, "the deleted-schema measure must be counted as an orphan skip")
+	assert.Equal(t, 0, orphanPass.skipped, "with the sidx intact there is no sidx gap")
+
+	jsonlPaths := findFilesWithSuffix(t, archiveRoot, ".jsonl.gz")
+	require.NotEmpty(t, jsonlPaths, "the orphan archive must exist after the orphan pass")
+	archivedRows := 0
+	for _, p := range jsonlPaths {
+		for _, rec := range readArchiveRecords(t, p) {
+			require.Equal(t, orphanRTDeletedName, rec.Measure, "only the deleted measure must be archived")
+			archivedRows++
+		}
+	}
+	assert.Equal(t, orphanPass.orphanSkipped, archivedRows, "every orphan-skipped row must be archived")
+
+	// Pass 2: remove the sidx so no series resolves. Close the resident resolver
+	// first so it reopens against the now-empty index (the open bluge store still
+	// holds file handles to the deleted dir otherwise). Every block then falls
+	// through to the (impossible) column rebuild and is counted as a sidx gap, which
+	// is the retain-source signal.
+	closeIndexResolver(&r.irMu, &r.irResolver, &r.irPath)
+	removeSegmentSidxDirs(t, partDirs)
+	gapPass := replayAllParts(t, r, partDirs)
+	assert.Greater(t, gapPass.skipped, 0, "removing the sidx must surface unresolved series as sidx-gap skips")
+}
+
+// TestMeasureOrphanArchiveWriteFailureAbortsPartAndRetainsSource proves an archive
+// write failure during replayPart aborts the part (a non-nil error) and is NOT
+// silently counted as an orphan skip, so the caller retains the source segment and
+// a resume retries. The failure is induced by pre-creating the computed archive
+// file path as a directory so the JSONL OpenFile fails.
+func TestMeasureOrphanArchiveWriteFailureAbortsPartAndRetainsSource(t *testing.T) {
+	archiveRoot := filepath.Join(t.TempDir(), "orphan-archive")
+	_, partDirs, r, stop := setupMeasureOrphanScenario(t, orphanConfig{policy: orphanArchive, rootDir: archiveRoot})
+	defer stop()
+	defer r.Close()
+
+	// Pre-create every part's would-be .jsonl path as a directory so partWriter's
+	// OpenFile fails, turning the archive write into a fatal abort.
+	for _, partDir := range partDirs {
+		loc := locFromPartDir(t, partDir)
+		require.NoError(t, os.MkdirAll(r.archiver.partFilePath(loc), 0o750))
+	}
+
+	var sawError bool
+	var total partReplayResult
+	for _, partDir := range partDirs {
+		res, err := r.replayPart(context.TODO(), partDir)
+		if err != nil {
+			sawError = true
+		}
+		total.orphanSkipped += res.orphanSkipped
+	}
+	require.True(t, sawError, "an archive write failure must surface as a non-nil error so the part aborts")
+	assert.Equal(t, 0, total.orphanSkipped, "an aborted part must not silently count orphan skips (source is retained)")
+}
+
+// TestMeasureOrphanResumeReplaysPartTwice proves a part replayed twice (resume) is
+// idempotent: the .jsonl is O_TRUNC-rewritten (one set of rows, not doubled) and
+// the manifest totals equal the single-pass values.
+func TestMeasureOrphanResumeReplaysPartTwice(t *testing.T) {
+	archiveRoot := filepath.Join(t.TempDir(), "orphan-archive")
+	_, partDirs, r, stop := setupMeasureOrphanScenario(t, orphanConfig{policy: orphanArchive, rootDir: archiveRoot})
+	defer stop()
+	defer r.Close()
+
+	first := replayAllParts(t, r, partDirs)
+	require.Greater(t, first.orphanSkipped, 0, "first pass must archive orphan rows")
+	firstJSONLRows := countArchiveRows(t, archiveRoot)
+	firstManifestRows, firstManifestSeries := sumManifest(t, archiveRoot)
+
+	second := replayAllParts(t, r, partDirs)
+	secondJSONLRows := countArchiveRows(t, archiveRoot)
+	secondManifestRows, secondManifestSeries := sumManifest(t, archiveRoot)
+
+	assert.Equal(t, first.orphanSkipped, second.orphanSkipped, "each pass skips the same orphan rows")
+	assert.Equal(t, firstJSONLRows, secondJSONLRows, "the .jsonl must hold exactly one set of rows (O_TRUNC), not doubled")
+	assert.Equal(t, firstManifestRows, secondManifestRows, "manifest total_rows must not double on resume")
+	assert.Equal(t, firstManifestSeries, secondManifestSeries, "manifest total_series must not double on resume")
+	assert.Equal(t, first.orphanSkipped, secondJSONLRows, "archived rows equal the single-pass orphan-skip count")
+}
+
+// locFromPartDir derives the archive sourceLoc for a flushed part dir
+// (.../seg-X/shard-N/<partID>) the same way replayPart does.
+func locFromPartDir(t *testing.T, partDir string) sourceLoc {
+	t.Helper()
+	partID, _, segmentPath, err := parseReplayPartPath(partDir)
+	require.NoError(t, err)
+	shardPath := filepath.Dir(partDir)
+	return sourceLoc{
+		Stage:   orphanRTSrcStage,
+		Segment: segmentSuffixFromPath(segmentPath),
+		Shard:   shardFromPath(shardPath),
+		Part:    fmt.Sprintf("%016x", partID),
+	}
+}
+
+// countArchiveRows sums the JSONL rows across every archive file under root.
+func countArchiveRows(t *testing.T, root string) int {
+	t.Helper()
+	total := 0
+	for _, p := range findFilesWithSuffix(t, root, ".jsonl.gz") {
+		total += len(readArchiveRecords(t, p))
+	}
+	return total
+}
+
+// sumManifest sums total_rows and total_series across every manifest under root.
+func sumManifest(t *testing.T, root string) (rows, series int) {
+	t.Helper()
+	for _, p := range findFilesWithSuffix(t, root, "manifest.json") {
+		var m manifestFile
+		mb, err := os.ReadFile(p)
+		require.NoError(t, err)
+		require.NoError(t, json.Unmarshal(mb, &m))
+		rows += m.TotalRows
+		series += m.TotalSeries
+	}
+	return rows, series
+}

--- a/banyand/backup/lifecycle/roundtrip_send_test.go
+++ b/banyand/backup/lifecycle/roundtrip_send_test.go
@@ -19,16 +19,21 @@ package lifecycle
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/apache/skywalking-banyandb/api/common"
 	"github.com/apache/skywalking-banyandb/api/data"
@@ -39,6 +44,8 @@ import (
 	streamv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/stream/v1"
 	tracev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/trace/v1"
 	"github.com/apache/skywalking-banyandb/banyand/measure"
+	"github.com/apache/skywalking-banyandb/banyand/metadata"
+	"github.com/apache/skywalking-banyandb/banyand/metadata/schema"
 	metadataservice "github.com/apache/skywalking-banyandb/banyand/metadata/service"
 	obsservice "github.com/apache/skywalking-banyandb/banyand/observability/services"
 	"github.com/apache/skywalking-banyandb/banyand/protector"
@@ -195,7 +202,7 @@ func TestRoundtrip_MeasureSend(t *testing.T) {
 	// Build the replayer while metadata is live (it eagerly snapshots schema).
 	mockClient, sink := capturingMockClient(t)
 	r, err := newMeasureRowReplayer(ctx, roundtripE2EGroup, 1, singleNodeSelector(t), mockClient,
-		metadataService, localfs.NewLocalFileSystem(), logger.GetLogger("roundtrip-measure-send"), nil)
+		metadataService, localfs.NewLocalFileSystem(), logger.GetLogger("roundtrip-measure-send"), nil, orphanConfig{}, "")
 	req.NoError(err)
 	defer r.Close()
 
@@ -303,7 +310,7 @@ func TestRoundtrip_StreamSend(t *testing.T) {
 
 	mockClient, sink := capturingMockClient(t)
 	replayer := newStreamRowReplayer(roundtripStreamGroup, 2, singleNodeSelector(t), mockClient,
-		metaSvc, localfs.NewLocalFileSystem(), logger.GetLogger("roundtrip-stream-send"), nil)
+		metaSvc, localfs.NewLocalFileSystem(), logger.GetLogger("roundtrip-stream-send"), nil, orphanConfig{}, "")
 	defer replayer.Close()
 	_, err = replayer.loadSchema(context.TODO(), roundtripStreamName)
 	req.NoError(err)
@@ -436,4 +443,314 @@ func TestRoundtrip_TraceSend(t *testing.T) {
 		seen[traceID] = true
 	}
 	require.Len(t, seen, len(entries), "lifecycle must emit exactly the %d written spans", len(entries))
+}
+
+const (
+	orphanStreamGroup        = "lc_rt_orphan_stream_group"
+	orphanStreamNormalName   = "lc_rt_orphan_stream_normal"
+	orphanStreamDeletedName  = "lc_rt_orphan_stream_deleted"
+	orphanStreamSrcStage     = "hot"
+	orphanStreamSeriesPerSub = 4
+)
+
+// orphanStreamRepo wraps a live metadata.Repo so GetStream returns deletedErr for
+// the deleted stream while delegating every other stream to the real registry.
+// With deletedErr = schema.ErrGRPCResourceNotFound this drives the replayer's real
+// loadSchema classification (-> errOrphanSchema); with any other error it drives
+// the fatal-abort branch, proving a transient registry failure is never silently
+// treated as an orphan.
+type orphanStreamRepo struct {
+	metadata.Repo
+	deletedErr  error
+	deletedName string
+}
+
+func (r orphanStreamRepo) StreamRegistry() schema.Stream {
+	return orphanStreamRegistry{Stream: r.Repo.StreamRegistry(), deletedName: r.deletedName, deletedErr: r.deletedErr}
+}
+
+type orphanStreamRegistry struct {
+	schema.Stream
+	deletedErr  error
+	deletedName string
+}
+
+func (s orphanStreamRegistry) GetStream(ctx context.Context, md *commonv1.Metadata) (*databasev1.Stream, error) {
+	if md.GetName() == s.deletedName {
+		return nil, s.deletedErr
+	}
+	return s.Stream.GetStream(ctx, md)
+}
+
+// TestStreamOrphanArchived proves the stream row-replay archives (not aborts) a
+// subject whose schema was deleted from the registry: the orphan rows land in a
+// JSONL archive (with element_id + tags, no fields) and a per-segment manifest,
+// while the still-registered stream replays normally and the orphan is not
+// counted as a sidx-gap skip.
+func TestStreamOrphanArchived(t *testing.T) {
+	archiveRoot, partDirs, replayer, stop := setupStreamOrphanScenario(t,
+		orphanConfig{policy: orphanArchive, rootDir: filepath.Join(t.TempDir(), "orphan-archive")}, schema.ErrGRPCResourceNotFound)
+	defer stop()
+	defer replayer.Close()
+
+	rows, orphanRows := replayAllStreamParts(t, replayer, partDirs)
+
+	assert.Greater(t, orphanRows, 0, "deleted-schema subject must be tallied as orphan rows")
+	assert.Equal(t, orphanStreamSeriesPerSub, rows, "the still-registered stream's rows must replay")
+
+	jsonlPaths := findFilesWithSuffix(t, archiveRoot, ".jsonl.gz")
+	require.NotEmpty(t, jsonlPaths, "expected at least one orphan archive .jsonl.gz under %s", archiveRoot)
+	archivedRows := 0
+	for _, p := range jsonlPaths {
+		require.True(t, strings.HasPrefix(p, filepath.Join(archiveRoot, orphanStreamGroup)),
+			"archive path %s must live under <root>/<group>", p)
+		for _, rec := range readArchiveRecords(t, p) {
+			require.Equal(t, orphanStreamDeletedName, rec.Measure, "only the deleted stream must be archived")
+			require.Equal(t, catalogStream, rec.Catalog)
+			require.Equal(t, orphanStreamGroup, rec.Group)
+			require.Equal(t, orphanStreamSrcStage, rec.Source.Stage, "source stage must be threaded into the record")
+			require.NotEmpty(t, rec.ElementID, "stream archive record must carry element_id")
+			require.NotEmpty(t, rec.Tags, "stream archive record must carry tags")
+			require.Empty(t, rec.Fields, "stream archive record must NOT carry fields")
+			archivedRows++
+		}
+	}
+	assert.Equal(t, orphanRows, archivedRows, "every orphan row must be archived")
+
+	manifestPaths := findFilesWithSuffix(t, archiveRoot, "manifest.json")
+	require.NotEmpty(t, manifestPaths, "expected at least one manifest.json")
+	manifestListsOrphan := false
+	manifestRows := 0
+	for _, p := range manifestPaths {
+		var m manifestFile
+		mb, readErr := os.ReadFile(p)
+		require.NoError(t, readErr)
+		require.NoError(t, json.Unmarshal(mb, &m))
+		require.Equal(t, catalogStream, m.Catalog, "manifest catalog must be stream")
+		for _, mm := range m.Measures {
+			if mm.Measure == orphanStreamDeletedName {
+				manifestListsOrphan = true
+			}
+			require.NotEqual(t, orphanStreamNormalName, mm.Measure, "the registered stream must never be archived")
+		}
+		manifestRows += m.TotalRows
+	}
+	assert.True(t, manifestListsOrphan, "manifest must list the deleted (orphan) stream")
+	assert.Equal(t, orphanRows, manifestRows, "manifest total_rows must equal archived orphan rows")
+}
+
+// TestStreamOrphanDiscarded proves the discard policy drops deleted-schema stream
+// rows without aborting the part and without writing any files.
+func TestStreamOrphanDiscarded(t *testing.T) {
+	archiveRoot, partDirs, replayer, stop := setupStreamOrphanScenario(t,
+		orphanConfig{policy: orphanDiscard, rootDir: filepath.Join(t.TempDir(), "orphan-archive")}, schema.ErrGRPCResourceNotFound)
+	defer stop()
+	defer replayer.Close()
+
+	rows, orphanRows := replayAllStreamParts(t, replayer, partDirs)
+
+	assert.Greater(t, orphanRows, 0, "deleted-schema subject must be tallied as orphan rows")
+	assert.Equal(t, orphanStreamSeriesPerSub, rows, "the still-registered stream's rows must replay")
+
+	entries, readErr := os.ReadDir(archiveRoot)
+	if readErr == nil {
+		assert.Empty(t, entries, "discard policy must not write any files under the archive root")
+	} else {
+		assert.True(t, os.IsNotExist(readErr), "discard policy must leave the archive root untouched")
+	}
+}
+
+// TestStreamTransientSchemaErrorNotOrphan proves the production-critical safety
+// boundary: a transient (non-not-found) registry error while resolving a stream's
+// schema must abort the part (so resume retries it) and must NEVER be classified
+// as an orphan — otherwise a network blip would silently archive-and-delete live
+// data. The deleted stream's GetStream returns a generic error here instead of
+// schema.ErrGRPCResourceNotFound.
+func TestStreamTransientSchemaErrorNotOrphan(t *testing.T) {
+	archiveRoot, partDirs, replayer, stop := setupStreamOrphanScenario(t,
+		orphanConfig{policy: orphanArchive, rootDir: filepath.Join(t.TempDir(), "orphan-archive")},
+		fmt.Errorf("transient registry failure"))
+	defer stop()
+	defer replayer.Close()
+
+	sawError, totalOrphan := false, 0
+	for _, partDir := range partDirs {
+		res, err := replayer.replayPart(context.TODO(), partDir)
+		if err != nil {
+			sawError = true
+		}
+		totalOrphan += res.orphanSkipped
+	}
+
+	assert.True(t, sawError, "a transient schema-resolution error must abort the part, not be swallowed")
+	assert.Equal(t, 0, totalOrphan, "a transient error must never be classified as an orphan skip")
+
+	jsonlPaths := findFilesWithSuffix(t, archiveRoot, ".jsonl.gz")
+	assert.Empty(t, jsonlPaths, "a transient error must not archive any rows")
+}
+
+// replayAllStreamParts replays every flushed stream part and sums the published
+// rows and orphan rows so the assertions are independent of shard/part routing.
+func replayAllStreamParts(t *testing.T, r *streamRowReplayer, partDirs []string) (int, int) {
+	t.Helper()
+	totalRows, totalOrphan := 0, 0
+	for _, partDir := range partDirs {
+		res, err := r.replayPart(context.TODO(), partDir)
+		require.NoError(t, err, "orphan must not abort the stream part replay for %s", partDir)
+		totalRows += res.rows
+		totalOrphan += res.orphanSkipped
+	}
+	return totalRows, totalOrphan
+}
+
+// registerOrphanStream registers one stream (creating the shared group once) with
+// a single string-entity series so flushed parts carry decodable subjects.
+func registerOrphanStream(t *testing.T, metaSvc metadataservice.Service, name string) {
+	t.Helper()
+	reg := metaSvc.SchemaRegistry()
+	ctx := context.TODO()
+	if name == orphanStreamNormalName {
+		_, err := reg.CreateGroup(ctx, &commonv1.Group{
+			Metadata: &commonv1.Metadata{Name: orphanStreamGroup},
+			Catalog:  commonv1.Catalog_CATALOG_STREAM,
+			ResourceOpts: &commonv1.ResourceOpts{
+				ShardNum:        2,
+				SegmentInterval: &commonv1.IntervalRule{Unit: commonv1.IntervalRule_UNIT_DAY, Num: 1},
+				Ttl:             &commonv1.IntervalRule{Unit: commonv1.IntervalRule_UNIT_DAY, Num: 7},
+			},
+		})
+		require.NoError(t, err)
+	}
+	_, err := reg.CreateStream(ctx, &databasev1.Stream{
+		Metadata: &commonv1.Metadata{Name: name, Group: orphanStreamGroup},
+		TagFamilies: []*databasev1.TagFamilySpec{{
+			Name: "default",
+			Tags: []*databasev1.TagSpec{
+				{Name: "series", Type: databasev1.TagType_TAG_TYPE_STRING},
+				{Name: "strTag", Type: databasev1.TagType_TAG_TYPE_STRING},
+				{Name: "intTag", Type: databasev1.TagType_TAG_TYPE_INT},
+			},
+		}},
+		Entity: &databasev1.Entity{TagNames: []string{"series"}},
+	})
+	require.NoError(t, err)
+}
+
+// setupStreamOrphanScenario registers a stream group with two streams, writes
+// rows for both through the real write path, flushes them to on-disk parts, then
+// builds a replayer over a metadata repo whose GetStream returns
+// schema.ErrGRPCResourceNotFound for the deleted stream (the normal stream is
+// pre-warmed into the replayer's cache while metadata is live). Modules are
+// stopped before returning so the bluge sidx dir is unlocked for the read-only
+// IndexResolver during replay. It returns the archive root, the flushed part
+// dirs, the ready replayer, and a stop func.
+func setupStreamOrphanScenario(t *testing.T, cfg orphanConfig, deletedErr error) (string, []string, *streamRowReplayer, func()) {
+	t.Helper()
+	req := require.New(t)
+	require.NoError(t, logger.Init(logger.Logging{Env: "dev", Level: "warn"}))
+	gomega.RegisterFailHandler(func(message string, _ ...int) { panic(message) })
+
+	pipeline := queue.Local()
+	metaSvc, err := metadataservice.NewService()
+	req.NoError(err)
+	metricSvc := obsservice.NewMetricService(metaSvc, pipeline, "test", nil)
+	pm := protector.NewMemory(metricSvc)
+	streamSvc, err := stream.NewService(metaSvc, pipeline, metricSvc, pm, nil)
+	req.NoError(err)
+
+	metaPath, metaDefer, err := test.NewSpace()
+	req.NoError(err)
+	ports, err := test.AllocateFreePorts(1)
+	req.NoError(err)
+	rootPath, rootDefer, err := test.NewSpace()
+	req.NoError(err)
+
+	flags := []string{
+		"--schema-server-root-path=" + metaPath,
+		fmt.Sprintf("--schema-server-grpc-port=%d", ports[0]),
+		"--schema-server-grpc-host=127.0.0.1",
+		"--stream-root-path=" + rootPath,
+		"--stream-flush-timeout=200ms",
+	}
+	moduleDefer := test.SetupModules(flags, pipeline, metaSvc, streamSvc)
+	moduleStopped := false
+	stopModules := func() {
+		if !moduleStopped {
+			moduleDefer()
+			moduleStopped = true
+		}
+	}
+	stop := func() {
+		stopModules()
+		rootDefer()
+		metaDefer()
+	}
+
+	registerOrphanStream(t, metaSvc, orphanStreamNormalName)
+	registerOrphanStream(t, metaSvc, orphanStreamDeletedName)
+	require.Eventually(t, func() bool {
+		_, ok := streamSvc.LoadGroup(orphanStreamGroup)
+		return ok
+	}, 30*time.Second, 200*time.Millisecond, "orphan stream group not loaded")
+	time.Sleep(time.Second)
+
+	base := time.Now().Truncate(time.Millisecond)
+	bp := pipeline.NewBatchPublisher(5 * time.Second)
+	msgID := 0
+	writeSeries := func(streamName string) {
+		for i := 0; i < orphanStreamSeriesPerSub; i++ {
+			msgID++
+			series := fmt.Sprintf("%s-ent-%d", streamName, i)
+			wr := &streamv1.WriteRequest{
+				Metadata: &commonv1.Metadata{Group: orphanStreamGroup, Name: streamName},
+				Element: &streamv1.ElementValue{
+					ElementId:   fmt.Sprintf("%s-elem-%d", streamName, i),
+					Timestamp:   timestamppb.New(base.Add(time.Duration(msgID) * time.Second)),
+					TagFamilies: []*modelv1.TagFamilyForWrite{{Tags: []*modelv1.TagValue{stringTagValue(series), stringTagValue("s"), intTagValue(int64(i))}}},
+				},
+			}
+			_, errPub := bp.Publish(context.TODO(), data.TopicStreamWrite, bus.NewMessage(bus.MessageID(msgID), &streamv1.InternalWriteRequest{
+				EntityValues: []*modelv1.TagValue{stringTagValue(series)},
+				Request:      wr,
+			}))
+			req.NoError(errPub)
+		}
+	}
+	writeSeries(orphanStreamNormalName)
+	writeSeries(orphanStreamDeletedName)
+	closeNodeErrs, closeErr := bp.Close()
+	req.NoError(closeErr)
+	req.Empty(closeNodeErrs)
+
+	var partDirs []string
+	require.Eventually(t, func() bool {
+		partDirs = findRoundtripPartDirs(rootPath)
+		return len(partDirs) >= 1
+	}, 30*time.Second, 200*time.Millisecond, "orphan stream parts not flushed")
+
+	selector, err := node.NewPickFirstSelector()
+	req.NoError(err)
+	selector.AddNode(&databasev1.Node{Metadata: &commonv1.Metadata{Name: "n1"}})
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	mockClient := queue.NewMockClient(ctrl)
+	mockClient.EXPECT().NewBatchPublisher(gomock.Any()).
+		DoAndReturn(func(time.Duration) queue.BatchPublisher { return &marshalingBatchPublisher{} }).AnyTimes()
+
+	// Wrap the live repo so the deleted stream resolves to the genuine registry
+	// not-found sentinel while the normal stream delegates to the real registry.
+	repo := orphanStreamRepo{Repo: metaSvc, deletedName: orphanStreamDeletedName, deletedErr: deletedErr}
+	replayer := newStreamRowReplayer(orphanStreamGroup, 2, selector, mockClient,
+		repo, localfs.NewLocalFileSystem(), logger.GetLogger("orphan-stream-replayer"), nil, cfg, orphanStreamSrcStage)
+
+	// Pre-warm the normal stream's schema cache while metadata is live so its
+	// rows replay after the modules (and their etcd-backed registry) stop.
+	_, err = replayer.loadSchema(context.TODO(), orphanStreamNormalName)
+	req.NoError(err)
+
+	// Stop the modules so the bluge sidx writer commits and releases its exclusive
+	// lock before the read-only IndexResolver opens the segment during replay.
+	stopModules()
+
+	return cfg.rootDir, partDirs, replayer, stop
 }

--- a/banyand/backup/lifecycle/roundtrip_test.go
+++ b/banyand/backup/lifecycle/roundtrip_test.go
@@ -18,9 +18,12 @@
 package lifecycle
 
 import (
+	"compress/gzip"
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"io"
 	gofs "io/fs"
 	"os"
 	"path/filepath"
@@ -30,6 +33,7 @@ import (
 	"time"
 
 	"github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/proto"
@@ -162,7 +166,7 @@ func TestRoundtrip_Measure(t *testing.T) {
 	// exclusive access to the bluge index dir, so the service must be stopped
 	// before any reader opens the segment.
 	replayer, err := newMeasureRowReplayer(context.TODO(), roundtripMeasureGroup, 2, nil, pipeline,
-		metaSvc, localfs.NewLocalFileSystem(), logger.GetLogger("test-replayer"), nil)
+		metaSvc, localfs.NewLocalFileSystem(), logger.GetLogger("test-replayer"), nil, orphanConfig{}, "")
 	req.NoError(err)
 	defer replayer.Close()
 	// Warm the schema cache so buildWriteRequest does not need the metadata
@@ -291,7 +295,7 @@ func TestRoundtrip_Stream(t *testing.T) {
 	}, 30*time.Second, 200*time.Millisecond, "stream parts for both shards not flushed")
 
 	replayer := newStreamRowReplayer(roundtripStreamGroup, 2, nil, pipeline,
-		metaSvc, localfs.NewLocalFileSystem(), logger.GetLogger("test-replayer"), nil)
+		metaSvc, localfs.NewLocalFileSystem(), logger.GetLogger("test-replayer"), nil, orphanConfig{}, "")
 	defer replayer.Close()
 	// Warm the schema cache so buildWriteRequest does not need the metadata
 	// service after we stop it below.
@@ -316,7 +320,11 @@ func TestRoundtrip_Stream(t *testing.T) {
 		it := reader.Iterator()
 		for it.Next() {
 			row := it.Row()
-			wr, iwr, buildErr := replayer.buildWriteRequest(context.TODO(), row)
+			subject, evList, decodeErr := decodeSeriesEntityValues(row.EntityValues)
+			req.NoError(decodeErr)
+			cached, schemaErr := replayer.loadSchema(context.TODO(), subject)
+			req.NoError(schemaErr)
+			wr, iwr, buildErr := replayer.buildWriteRequest(cached, subject, evList, row)
 			req.NoError(buildErr)
 			series := wr.GetElement().GetTagFamilies()[0].GetTags()[0].GetStr().GetValue()
 			e, ok := expect[series]
@@ -757,7 +765,7 @@ func TestRoundtrip_MeasureIndexed(t *testing.T) {
 	mockClient.EXPECT().NewBatchPublisher(gomock.Any()).
 		DoAndReturn(func(time.Duration) queue.BatchPublisher { return &marshalingBatchPublisher{} }).AnyTimes()
 	r, err := newMeasureRowReplayer(ctx, roundtripE2EGroup, 1, selector, mockClient,
-		metadataService, localfs.NewLocalFileSystem(), logger.GetLogger("roundtrip-e2e"), nil)
+		metadataService, localfs.NewLocalFileSystem(), logger.GetLogger("roundtrip-e2e"), nil, orphanConfig{}, "")
 	req.NoError(err)
 	defer r.Close()
 
@@ -1127,7 +1135,7 @@ func TestRoundtrip_StreamIndexed(t *testing.T) {
 	}, 30*time.Second, 200*time.Millisecond, "indexed stream part not flushed")
 
 	replayer := newStreamRowReplayer(streamIdxGroup, 1, nil, pipeline,
-		metaSvc, localfs.NewLocalFileSystem(), logger.GetLogger("test-replayer-idx"), nil)
+		metaSvc, localfs.NewLocalFileSystem(), logger.GetLogger("test-replayer-idx"), nil, orphanConfig{}, "")
 	defer replayer.Close()
 	// Warm the schema cache so buildWriteRequest does not need metadata after stop.
 	_, err = replayer.loadSchema(context.TODO(), streamIdxName)
@@ -1155,7 +1163,11 @@ func TestRoundtrip_StreamIndexed(t *testing.T) {
 			// move it to sidx, and the replayer rebuilds tags only from columns.
 			require.Contains(t, row.Tags, "default.endpoint",
 				"indexed endpoint tag must stay in the replayable part column")
-			wrGot, _, buildErr := replayer.buildWriteRequest(context.TODO(), row)
+			subject, evList, decodeErr := decodeSeriesEntityValues(row.EntityValues)
+			req.NoError(decodeErr)
+			cached, schemaErr := replayer.loadSchema(context.TODO(), subject)
+			req.NoError(schemaErr)
+			wrGot, _, buildErr := replayer.buildWriteRequest(cached, subject, evList, row)
 			req.NoError(buildErr)
 			tags := wrGot.GetElement().GetTagFamilies()[0].GetTags()
 			require.Len(t, tags, 3, "reconstructed element must carry all three tags")
@@ -1214,4 +1226,313 @@ func registerStreamIndexedSchema(t *testing.T, metaSvc metadataservice.Service) 
 		ExpireAt: timestamppb.New(time.Now().Add(365 * 24 * time.Hour)),
 	})
 	require.NoError(t, err)
+}
+
+const (
+	orphanRTGroup        = "lc_rt_orphan_group"
+	orphanRTNormalName   = "lc_rt_orphan_normal"
+	orphanRTDeletedName  = "lc_rt_orphan_deleted"
+	orphanRTSrcStage     = "hot"
+	orphanRTSeriesPerMsr = 4
+)
+
+// TestMeasureOrphanArchived proves the measure row-replay archives (not aborts)
+// a series whose schema was deleted from the registry: the orphan rows land in a
+// JSONL archive and a per-segment manifest, while the still-registered measure
+// replays normally and the orphan is not counted as a sidx-gap skip.
+func TestMeasureOrphanArchived(t *testing.T) {
+	archiveRoot, partDirs, r, stop := setupMeasureOrphanScenario(t, orphanConfig{policy: orphanArchive, rootDir: filepath.Join(t.TempDir(), "orphan-archive")})
+	defer stop()
+	defer r.Close()
+
+	res := replayAllParts(t, r, partDirs)
+
+	assert.Greater(t, res.orphanSkipped, 0, "deleted-schema series must be tallied as orphan skips")
+	assert.Equal(t, 0, res.skipped, "orphan is not a sidx-gap skip")
+	assert.Equal(t, orphanRTSeriesPerMsr, res.rows, "the still-registered measure's rows must replay")
+
+	// The archive .jsonl file(s) must exist and carry the orphan rows. The
+	// per-segment manifest.json must list the deleted measure.
+	jsonlPaths := findFilesWithSuffix(t, archiveRoot, ".jsonl.gz")
+	require.NotEmpty(t, jsonlPaths, "expected at least one orphan archive .jsonl.gz under %s", archiveRoot)
+	archivedRows := 0
+	for _, p := range jsonlPaths {
+		require.True(t, strings.HasPrefix(p, filepath.Join(archiveRoot, orphanRTGroup)),
+			"archive path %s must live under <root>/<group>", p)
+		for _, rec := range readArchiveRecords(t, p) {
+			require.Equal(t, orphanRTDeletedName, rec.Measure, "only the deleted measure must be archived")
+			require.Equal(t, catalogMeasure, rec.Catalog)
+			require.Equal(t, orphanRTGroup, rec.Group)
+			require.Equal(t, orphanRTSrcStage, rec.Source.Stage, "source stage must be threaded into the record")
+			archivedRows++
+		}
+	}
+	assert.Equal(t, res.orphanSkipped, archivedRows, "every orphan-skipped row must be archived")
+
+	manifestPaths := findFilesWithSuffix(t, archiveRoot, "manifest.json")
+	require.NotEmpty(t, manifestPaths, "expected at least one manifest.json")
+	manifestListsOrphan := false
+	manifestRows := 0
+	for _, p := range manifestPaths {
+		var m manifestFile
+		mb, readErr := os.ReadFile(p)
+		require.NoError(t, readErr)
+		require.NoError(t, json.Unmarshal(mb, &m))
+		for _, mm := range m.Measures {
+			if mm.Measure == orphanRTDeletedName {
+				manifestListsOrphan = true
+			}
+			require.NotEqual(t, orphanRTNormalName, mm.Measure, "the registered measure must never be archived")
+		}
+		manifestRows += m.TotalRows
+	}
+	assert.True(t, manifestListsOrphan, "manifest must list the deleted (orphan) measure")
+	assert.Equal(t, res.orphanSkipped, manifestRows, "manifest total_rows must equal archived orphan rows")
+}
+
+// TestMeasureOrphanDiscarded proves the discard policy drops deleted-schema rows
+// without aborting the part and without writing any files.
+func TestMeasureOrphanDiscarded(t *testing.T) {
+	archiveRoot, partDirs, r, stop := setupMeasureOrphanScenario(t, orphanConfig{policy: orphanDiscard, rootDir: filepath.Join(t.TempDir(), "orphan-archive")})
+	defer stop()
+	defer r.Close()
+
+	res := replayAllParts(t, r, partDirs)
+
+	assert.Greater(t, res.orphanSkipped, 0, "deleted-schema series must be tallied as orphan skips")
+	assert.Equal(t, 0, res.skipped, "orphan is not a sidx-gap skip")
+	assert.Equal(t, orphanRTSeriesPerMsr, res.rows, "the still-registered measure's rows must replay")
+
+	entries, readErr := os.ReadDir(archiveRoot)
+	if readErr == nil {
+		assert.Empty(t, entries, "discard policy must not write any files under the archive root")
+	} else {
+		assert.True(t, os.IsNotExist(readErr), "discard policy must leave the archive root untouched")
+	}
+}
+
+// setupMeasureOrphanScenario registers a measure group with two measures, writes
+// rows for both through the real write path, flushes them to on-disk parts, then
+// deletes one measure from the registry so it becomes an orphan. The replayer is
+// constructed while metadata is still live (it snapshots ListMeasure, now missing
+// the deleted measure) and the modules are stopped before returning so the bluge
+// sidx dir is unlocked for the read-only IndexResolver during replay. It returns
+// the archive root, the flushed part dirs, the ready replayer, and a stop func.
+func setupMeasureOrphanScenario(t *testing.T, cfg orphanConfig) (string, []string, *measureRowReplayer, func()) {
+	t.Helper()
+	req := require.New(t)
+	require.NoError(t, logger.Init(logger.Logging{Env: "dev", Level: "warn"}))
+	gomega.RegisterFailHandler(func(message string, _ ...int) { panic(message) })
+
+	pipeline := queue.Local()
+	metaSvc, err := metadataservice.NewService()
+	req.NoError(err)
+	metricSvc := obsservice.NewMetricService(metaSvc, pipeline, "test", nil)
+	pm := protector.NewMemory(metricSvc)
+	measureSvc, err := measure.NewStandalone(metaSvc, pipeline, nil, metricSvc, pm)
+	req.NoError(err)
+
+	metaPath, metaDefer, err := test.NewSpace()
+	req.NoError(err)
+	ports, err := test.AllocateFreePorts(1)
+	req.NoError(err)
+	rootPath, rootDefer, err := test.NewSpace()
+	req.NoError(err)
+
+	flags := []string{
+		"--schema-server-root-path=" + metaPath,
+		fmt.Sprintf("--schema-server-grpc-port=%d", ports[0]),
+		"--schema-server-grpc-host=127.0.0.1",
+		"--measure-root-path=" + rootPath,
+		"--measure-flush-timeout=200ms",
+	}
+	moduleDefer := test.SetupModules(flags, pipeline, metaSvc, measureSvc)
+	moduleStopped := false
+	stopModules := func() {
+		if !moduleStopped {
+			moduleDefer()
+			moduleStopped = true
+		}
+	}
+	stop := func() {
+		stopModules()
+		rootDefer()
+		metaDefer()
+	}
+
+	registerOrphanMeasure(t, metaSvc, orphanRTNormalName)
+	registerOrphanMeasure(t, metaSvc, orphanRTDeletedName)
+	require.Eventually(t, func() bool {
+		_, ok := measureSvc.LoadGroup(orphanRTGroup)
+		return ok
+	}, 30*time.Second, 200*time.Millisecond, "orphan measure group not loaded")
+	time.Sleep(time.Second)
+
+	base := time.Now().Truncate(time.Millisecond)
+	bp := pipeline.NewBatchPublisher(5 * time.Second)
+	msgID := 0
+	writeSeries := func(measureName string) {
+		for i := 0; i < orphanRTSeriesPerMsr; i++ {
+			msgID++
+			series := fmt.Sprintf("%s-ent-%d", measureName, i)
+			wr := &measurev1.WriteRequest{
+				Metadata: &commonv1.Metadata{Group: orphanRTGroup, Name: measureName},
+				DataPoint: &measurev1.DataPointValue{
+					Timestamp:   timestamppb.New(base.Add(time.Duration(msgID) * time.Second)),
+					Version:     int64(msgID),
+					TagFamilies: []*modelv1.TagFamilyForWrite{{Tags: []*modelv1.TagValue{stringTagValue(series), stringTagValue("s"), intTagValue(int64(i))}}},
+					Fields:      []*modelv1.FieldValue{intFieldValue(int64(i)), floatFieldValue(float64(i))},
+				},
+			}
+			_, errPub := bp.Publish(context.TODO(), data.TopicMeasureWrite, bus.NewMessage(bus.MessageID(msgID), &measurev1.InternalWriteRequest{
+				EntityValues: []*modelv1.TagValue{stringTagValue(series)},
+				Request:      wr,
+			}))
+			req.NoError(errPub)
+		}
+	}
+	writeSeries(orphanRTNormalName)
+	writeSeries(orphanRTDeletedName)
+	closeNodeErrs, closeErr := bp.Close()
+	req.NoError(closeErr)
+	req.Empty(closeNodeErrs)
+
+	var partDirs []string
+	require.Eventually(t, func() bool {
+		partDirs = findRoundtripPartDirs(rootPath)
+		return len(partDirs) >= 1
+	}, 30*time.Second, 200*time.Millisecond, "orphan measure parts not flushed")
+
+	// Delete one measure from the registry so the replayer's construction-time
+	// ListMeasure snapshot omits it; its already-flushed series become orphans.
+	_, _, err = metaSvc.SchemaRegistry().DeleteMeasure(context.TODO(), &commonv1.Metadata{Group: orphanRTGroup, Name: orphanRTDeletedName})
+	req.NoError(err)
+
+	// Build the replayer while metadata is still live: newMeasureRowReplayer
+	// snapshots ListMeasure at construction, so the deleted measure is now absent
+	// and its series resolve to errOrphanSchema during replay.
+	selector, err := node.NewPickFirstSelector()
+	req.NoError(err)
+	selector.AddNode(&databasev1.Node{Metadata: &commonv1.Metadata{Name: "n1"}})
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	mockClient := queue.NewMockClient(ctrl)
+	mockClient.EXPECT().NewBatchPublisher(gomock.Any()).
+		DoAndReturn(func(time.Duration) queue.BatchPublisher { return &marshalingBatchPublisher{} }).AnyTimes()
+	r, err := newMeasureRowReplayer(context.TODO(), orphanRTGroup, 2, selector, mockClient,
+		metaSvc, localfs.NewLocalFileSystem(), logger.GetLogger("orphan-replayer"), nil, cfg, orphanRTSrcStage)
+	req.NoError(err)
+
+	// Stop the modules so the bluge sidx writer commits and releases its exclusive
+	// lock before the read-only IndexResolver opens the segment during replay.
+	stopModules()
+
+	return cfg.rootDir, partDirs, r, stop
+}
+
+// replayAllParts replays every flushed part and sums the per-part results so the
+// assertions are independent of how series routed across shards/parts.
+func replayAllParts(t *testing.T, r *measureRowReplayer, partDirs []string) partReplayResult {
+	t.Helper()
+	var total partReplayResult
+	for _, partDir := range partDirs {
+		res, err := r.replayPart(context.TODO(), partDir)
+		require.NoError(t, err, "orphan must not abort the part replay for %s", partDir)
+		total.rows += res.rows
+		total.skipped += res.skipped
+		total.orphanSkipped += res.orphanSkipped
+	}
+	return total
+}
+
+func registerOrphanMeasure(t *testing.T, metaSvc metadataservice.Service, name string) {
+	t.Helper()
+	reg := metaSvc.SchemaRegistry()
+	ctx := context.TODO()
+	if name == orphanRTNormalName {
+		_, err := reg.CreateGroup(ctx, &commonv1.Group{
+			Metadata: &commonv1.Metadata{Name: orphanRTGroup},
+			Catalog:  commonv1.Catalog_CATALOG_MEASURE,
+			ResourceOpts: &commonv1.ResourceOpts{
+				ShardNum:        2,
+				SegmentInterval: &commonv1.IntervalRule{Unit: commonv1.IntervalRule_UNIT_DAY, Num: 1},
+				Ttl:             &commonv1.IntervalRule{Unit: commonv1.IntervalRule_UNIT_DAY, Num: 7},
+			},
+		})
+		require.NoError(t, err)
+	}
+	_, err := reg.CreateMeasure(ctx, orphanMeasureSchema(name))
+	require.NoError(t, err)
+}
+
+// orphanMeasureSchema returns the measure schema the orphan scenario registers,
+// shared so a test can rebuild a deleted measure's schema (absent from the
+// replayer's snapshot) for entity-column reconstruction.
+func orphanMeasureSchema(name string) *databasev1.Measure {
+	return &databasev1.Measure{
+		Metadata: &commonv1.Metadata{Name: name, Group: orphanRTGroup},
+		TagFamilies: []*databasev1.TagFamilySpec{{
+			Name: "default",
+			Tags: []*databasev1.TagSpec{
+				{Name: "series", Type: databasev1.TagType_TAG_TYPE_STRING},
+				{Name: "strTag", Type: databasev1.TagType_TAG_TYPE_STRING},
+				{Name: "intTag", Type: databasev1.TagType_TAG_TYPE_INT},
+			},
+		}},
+		Fields: []*databasev1.FieldSpec{
+			{
+				Name:              "intField",
+				FieldType:         databasev1.FieldType_FIELD_TYPE_INT,
+				EncodingMethod:    databasev1.EncodingMethod_ENCODING_METHOD_GORILLA,
+				CompressionMethod: databasev1.CompressionMethod_COMPRESSION_METHOD_ZSTD,
+			},
+			{
+				Name:              "floatField",
+				FieldType:         databasev1.FieldType_FIELD_TYPE_FLOAT,
+				EncodingMethod:    databasev1.EncodingMethod_ENCODING_METHOD_GORILLA,
+				CompressionMethod: databasev1.CompressionMethod_COMPRESSION_METHOD_ZSTD,
+			},
+		},
+		Entity: &databasev1.Entity{TagNames: []string{"series"}},
+	}
+}
+
+// findFilesWithSuffix walks root and returns every regular file whose name ends
+// with suffix.
+func findFilesWithSuffix(t *testing.T, root, suffix string) []string {
+	t.Helper()
+	var out []string
+	_ = filepath.WalkDir(root, func(path string, d gofs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		if strings.HasSuffix(d.Name(), suffix) {
+			out = append(out, path)
+		}
+		return nil
+	})
+	return out
+}
+
+// readArchiveRecords decodes a JSONL archive file into its records.
+func readArchiveRecords(t *testing.T, path string) []archiveRecord {
+	t.Helper()
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	defer f.Close()
+	gr, err := gzip.NewReader(f)
+	require.NoError(t, err, "archive file must be a valid gzip stream: %s", path)
+	defer gr.Close()
+	data, err := io.ReadAll(gr)
+	require.NoError(t, err)
+	var recs []archiveRecord
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if line == "" {
+			continue
+		}
+		var rec archiveRecord
+		require.NoError(t, json.Unmarshal([]byte(line), &rec), "archive line must be valid JSON: %s", line)
+		recs = append(recs, rec)
+	}
+	return recs
 }

--- a/banyand/backup/lifecycle/row_replay.go
+++ b/banyand/backup/lifecycle/row_replay.go
@@ -47,6 +47,13 @@ import (
 // dropped.
 var errSkipSeries = errors.New("skip series: unresolvable entity")
 
+// errOrphanSchema marks a series whose subject decoded fine but whose schema is
+// no longer in the registry (the measure/stream was deleted). Unlike a sidx gap,
+// the data is unmigratable and known-droppable: the replay loop skips it, the
+// archiver optionally preserves it, and — distinct from errSkipSeries — the
+// source segment is still deleted.
+var errOrphanSchema = errors.New("orphan schema: subject not in registry")
+
 // decodeSeriesEntityValues recovers (subject, entityTagValues) from the raw
 // EntityValues byte sequence stored in part-level smeta.bin or recovered via
 // PartSeriesMap. A resolution failure is wrapped in errSkipSeries so callers can

--- a/banyand/backup/lifecycle/row_replay_entity_rebuild.go
+++ b/banyand/backup/lifecycle/row_replay_entity_rebuild.go
@@ -42,22 +42,44 @@ const (
 	skipReasonIncompletePart skipReason = "incomplete-part"
 )
 
+type skipKind uint8
+
+const (
+	skipKindSidxGap skipKind = iota
+	skipKindOrphan
+)
+
 // skipError locates a skipped series so the migration report can point an
-// operator at the exact source part rather than only a count. It wraps
-// errSkipSeries so callers keep using errors.Is(err, errSkipSeries) to detect a
-// skip, while errors.As recovers the location for the report.
+// operator at the exact source part rather than only a count. It wraps either
+// errSkipSeries (sidx-gap) or errOrphanSchema (deleted schema) so callers can
+// distinguish the two via errors.Is, while errors.As recovers the location for
+// the report.
 type skipError struct {
 	partPath string
 	reason   skipReason
 	seriesID uint64
+	kind     skipKind
 }
 
 func (c *skipError) Error() string {
-	return fmt.Sprintf("%s: part=%s seriesID=%d reason=%s", errSkipSeries.Error(), c.partPath, c.seriesID, c.reason)
+	return fmt.Sprintf("%s: part=%s seriesID=%d reason=%s", c.sentinel().Error(), c.partPath, c.seriesID, c.reason)
 }
 
-// Unwrap lets errors.Is(err, errSkipSeries) match a skipError.
-func (c *skipError) Unwrap() error { return errSkipSeries }
+func (c *skipError) sentinel() error {
+	if c.kind == skipKindOrphan {
+		return errOrphanSchema
+	}
+	return errSkipSeries
+}
+
+// Unwrap routes errors.Is to the matching sentinel so sidx-gap and orphan skips
+// stay distinguishable.
+func (c *skipError) Unwrap() error { return c.sentinel() }
+
+// newOrphanSkip builds a skip error for an orphan-schema series (deleted measure/stream).
+func newOrphanSkip(partPath string, seriesID uint64, measure string) *skipError {
+	return &skipError{partPath: partPath, seriesID: seriesID, reason: skipReason(measure), kind: skipKindOrphan}
+}
 
 // asSkipError extracts the locating skipError from a skip error, or nil when
 // the error carries no location (a bare errSkipSeries).
@@ -67,6 +89,19 @@ func asSkipError(err error) *skipError {
 		return c
 	}
 	return nil
+}
+
+// filterSkipExamplesByKind returns only the skip details whose kind matches, so a
+// per-part report message can show only the sidx-gap (or only the orphan) examples
+// from a detail slice that may mix both kinds.
+func filterSkipExamplesByKind(detail []skipError, kind skipKind) []skipError {
+	out := make([]skipError, 0, len(detail))
+	for i := range detail {
+		if detail[i].kind == kind {
+			out = append(out, detail[i])
+		}
+	}
+	return out
 }
 
 // rebuildCandidate describes one measure whose entity can be rebuilt from part

--- a/banyand/backup/lifecycle/row_replay_measure.go
+++ b/banyand/backup/lifecycle/row_replay_measure.go
@@ -205,11 +205,9 @@ func (r *measureRowReplayer) replayPart(ctx context.Context, partPath string) (p
 	}
 	reader.SetIndexResolver(ir)
 
-	loc := sourceLoc{
-		Stage:   r.srcStage,
-		Segment: segmentSuffixFromPath(segmentPath),
-		Shard:   shardFromPath(shardPath),
-		Part:    fmt.Sprintf("%016x", partID),
+	loc, err := newSourceLoc(r.srcStage, segmentPath, shardPath, partID)
+	if err != nil {
+		return partReplayResult{}, fmt.Errorf("derive source location for part %s: %w", partPath, err)
 	}
 
 	// Reuse the dump iterator's file-read/decompress scratch across blocks
@@ -423,14 +421,47 @@ func (r *measureRowReplayer) buildWriteRequest(
 }
 
 // segmentSuffixFromPath extracts "20260601" from ".../seg-20260601".
-func segmentSuffixFromPath(segmentPath string) string {
-	return strings.TrimPrefix(filepath.Base(segmentPath), "seg-")
+func segmentSuffixFromPath(segmentPath string) (string, error) {
+	base := filepath.Base(segmentPath)
+	suffix, ok := strings.CutPrefix(base, "seg-")
+	if !ok {
+		return "", fmt.Errorf("unexpected segment dir %q: missing %q prefix", base, "seg-")
+	}
+	return suffix, nil
 }
 
 // shardFromPath extracts the shard id from ".../shard-0".
-func shardFromPath(shardPath string) uint32 {
-	id, _ := strconv.ParseUint(strings.TrimPrefix(filepath.Base(shardPath), "shard-"), 10, 32)
-	return uint32(id)
+func shardFromPath(shardPath string) (uint32, error) {
+	base := filepath.Base(shardPath)
+	raw, ok := strings.CutPrefix(base, "shard-")
+	if !ok {
+		return 0, fmt.Errorf("unexpected shard dir %q: missing %q prefix", base, "shard-")
+	}
+	id, err := strconv.ParseUint(raw, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("parse shard id from %q: %w", base, err)
+	}
+	return uint32(id), nil
+}
+
+// newSourceLoc builds the archive sourceLoc from a part's parsed path components,
+// validating the seg-/shard- directory prefixes so a malformed path fails the part
+// instead of silently misattributing orphan rows to shard 0 (and colliding archives).
+func newSourceLoc(stage, segmentPath, shardPath string, partID uint64) (sourceLoc, error) {
+	segment, err := segmentSuffixFromPath(segmentPath)
+	if err != nil {
+		return sourceLoc{}, err
+	}
+	shard, err := shardFromPath(shardPath)
+	if err != nil {
+		return sourceLoc{}, err
+	}
+	return sourceLoc{
+		Stage:   stage,
+		Segment: segment,
+		Shard:   shard,
+		Part:    fmt.Sprintf("%016x", partID),
+	}, nil
 }
 
 // archiveOrphanBlock writes all rows of an orphan series to the part archive

--- a/banyand/backup/lifecycle/row_replay_measure.go
+++ b/banyand/backup/lifecycle/row_replay_measure.go
@@ -19,7 +19,12 @@ package lifecycle
 
 import (
 	"context"
+	"encoding/base64"
+	"errors"
 	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -63,6 +68,7 @@ type cachedMeasureSchema struct {
 // real Write API, resolving each row's schema on demand via EntityValues.
 type measureRowReplayer struct {
 	selector        node.Selector
+	archiver        *orphanArchiver
 	sender          *batchSender
 	fs              fs.FileSystem
 	logger          *logger.Logger
@@ -74,6 +80,7 @@ type measureRowReplayer struct {
 	counter         *uint64
 	group           string
 	irPath          string
+	srcStage        string
 	rebuildEV       []*modelv1.TagValue
 	rebuildSeries   pbv1.Series
 	schemaCacheMu   sync.Mutex
@@ -88,7 +95,7 @@ func newMeasureRowReplayer(
 	group string, targetShardNum uint32,
 	selector node.Selector, client queue.Client,
 	md metadata.Repo, fileSystem fs.FileSystem,
-	l *logger.Logger, counter *uint64,
+	l *logger.Logger, counter *uint64, orphanCfg orphanConfig, srcStage string,
 ) (*measureRowReplayer, error) {
 	measures, err := md.MeasureRegistry().ListMeasure(ctx, schema.ListOpt{Group: group})
 	if err != nil {
@@ -115,6 +122,7 @@ func newMeasureRowReplayer(
 		targetShardNum:  targetShardNum,
 		selector:        selector,
 		sender:          newBatchSender(client, data.TopicMeasureWrite, rowReplayMaxBatchRows, int(rowReplayMaxBatchBytes), measureReplayBatchTimeout),
+		archiver:        newOrphanArchiver(orphanCfg, group, catalogMeasure, l),
 		fs:              fileSystem,
 		logger:          l,
 		measureSchemas:  measureSchemas,
@@ -122,6 +130,7 @@ func newMeasureRowReplayer(
 		mergedRuleToTag: deriveMergedRuleToTag(measures, rules, bindings),
 		rebuildIdx:      buildEntityRebuildIndex(measureSchemas),
 		counter:         counter,
+		srcStage:        srcStage,
 	}, nil
 }
 
@@ -153,7 +162,7 @@ func (r *measureRowReplayer) loadSchema(measureName string) (*cachedMeasureSchem
 	}
 	m, ok := r.measureSchemas[measureName]
 	if !ok {
-		return nil, fmt.Errorf("measure schema %s/%s not found in group snapshot", r.group, measureName)
+		return nil, fmt.Errorf("%w: measure %s/%s", errOrphanSchema, r.group, measureName)
 	}
 	c := &cachedMeasureSchema{
 		schema:        m,
@@ -171,17 +180,6 @@ func (r *measureRowReplayer) loadSchema(measureName string) (*cachedMeasureSchem
 // group's merged rule-to-tag map.
 func (r *measureRowReplayer) loadIndexResolver(segmentPath string) (*dump.IndexResolver, error) {
 	return reloadIndexResolver(&r.irMu, &r.irResolver, &r.irPath, segmentPath, r.mergedRuleToTag)
-}
-
-// partReplayResult reports what one part's replay delivered: the rows published,
-// the rows skipped because their series could not be resolved or rebuilt
-// (errSkipSeries), and a bounded sample of those skips' locations for the report.
-// A skipped > 0 result means the source part still holds data the migration could
-// not republish, so its source segment must be retained rather than deleted.
-type partReplayResult struct {
-	detail  []skipError
-	rows    int
-	skipped int
 }
 
 // replayPart opens a source part and replays its rows through the sender, which
@@ -207,6 +205,13 @@ func (r *measureRowReplayer) replayPart(ctx context.Context, partPath string) (p
 	}
 	reader.SetIndexResolver(ir)
 
+	loc := sourceLoc{
+		Stage:   r.srcStage,
+		Segment: segmentSuffixFromPath(segmentPath),
+		Shard:   shardFromPath(shardPath),
+		Part:    fmt.Sprintf("%016x", partID),
+	}
+
 	// Reuse the dump iterator's file-read/decompress scratch across blocks
 	// (transient buffers, decoder owns the decompressed output) to cut churn.
 	reader.SetReuseBuffers(true)
@@ -221,17 +226,17 @@ func (r *measureRowReplayer) replayPart(ctx context.Context, partPath string) (p
 	var bc measureBlockCtx
 	bc.partPath = partPath
 	var pb measureProtoBuilder
-	// The sender's skip tallies are replayer-wide (one sender serves every part),
-	// so snapshot them around this part to recover its own skipped delta.
-	beforeRows := r.sender.skippedRows
-	beforeDetail := len(r.sender.skippedDetail)
-	rowCount, replayErr := r.sender.replay(ctx, r.logger, r.group, partPath, r.counter, cur,
-		func() error { return r.publishRowColumnar(ctx, &bc, &pb, cur.Block(), cur.Index()) })
-	res := partReplayResult{rows: rowCount, skipped: r.sender.skippedRows - beforeRows}
-	if d := r.sender.skippedDetail[beforeDetail:]; len(d) > 0 {
-		res.detail = append([]skipError(nil), d...)
-	}
-	return res, replayErr
+	// runPart opens the part's archive writer and commits/aborts its manifest; the
+	// orphan rows are appended to that writer (reached via bc.pw) inside replay.
+	var res partReplayResult
+	runErr := r.archiver.runPart(loc, func(pw *orphanPartWriter) error {
+		bc.pw = pw
+		var replayErr error
+		res, replayErr = r.sender.replay(ctx, r.logger, r.group, partPath, r.counter, cur,
+			func() error { return r.publishRowColumnar(ctx, &bc, &pb, cur.Block(), cur.Index()) })
+		return replayErr
+	})
+	return res, runErr
 }
 
 // measureBlockCtx caches the constants that are identical for every row of one
@@ -239,22 +244,37 @@ func (r *measureRowReplayer) replayPart(ctx context.Context, partPath string) (p
 // and entity TagValue maps, and — when routing does not depend on per-row tags
 // (no sharding key) — the resolved shardID, encoded entity values and node.
 type measureBlockCtx struct {
-	cached       *cachedMeasureSchema
-	entityIdx    map[string]*modelv1.TagValue
-	indexedTyped map[string]*modelv1.TagValue
-	subject      string
-	nodeID       string
-	partPath     string
-	entityEnc    []*modelv1.TagValue
-	seriesID     uint64
-	sizeHint     int
-	shardID      uint32
-	valid        bool
-	routeValid   bool
+	cached         *cachedMeasureSchema
+	pw             *orphanPartWriter
+	entityIdx      map[string]*modelv1.TagValue
+	indexedTyped   map[string]*modelv1.TagValue
+	subject        string
+	nodeID         string
+	partPath       string
+	entityEnc      []*modelv1.TagValue
+	seriesID       uint64
+	orphanSeriesID uint64
+	sizeHint       int
+	shardID        uint32
+	valid          bool
+	routeValid     bool
+	orphan         bool
 }
 
 // ensureBlock recomputes the block-constant context when the series changes.
 func (r *measureRowReplayer) ensureBlock(ir *dump.IndexResolver, bc *measureBlockCtx, cb *dumpmeasure.ColumnarBlock) error {
+	// Same orphan series as the previous row: the block was already archived once;
+	// keep skipping its rows without re-archiving. This consecutive-row guard is
+	// sufficient (no cross-block dedup set is needed) because a measure part emits
+	// exactly one contiguous block per series, in ascending seriesID order — see
+	// banyand/internal/dump/measure/iterator.go, whose blocks are per-series and
+	// series-sorted. A given series therefore never reappears in a later block of
+	// the same part, so it can never be archived twice. A per-series dedup set would
+	// be not only unnecessary but unsafe: a series legitimately never spans two
+	// blocks, so any such set could only ever wrongly drop rows.
+	if bc.orphan && bc.orphanSeriesID == uint64(cb.SeriesID) {
+		return newOrphanSkip(bc.partPath, uint64(cb.SeriesID), bc.subject)
+	}
 	if bc.valid && bc.seriesID == uint64(cb.SeriesID) {
 		return nil
 	}
@@ -266,8 +286,24 @@ func (r *measureRowReplayer) ensureBlock(ir *dump.IndexResolver, bc *measureBloc
 	}
 	cached, err := r.loadSchema(subject)
 	if err != nil {
+		if errors.Is(err, errOrphanSchema) {
+			// Deleted schema: archive this block's rows once, then skip every row of
+			// the series (the source segment is still deleted by the visitor). A
+			// failed archive write under the archive policy is FATAL — returning it
+			// as-is aborts the part so the source is retained and resume retries,
+			// never silently dropping orphan rows.
+			if archiveErr := r.archiveOrphanBlock(bc.pw, cb, subject, evList); archiveErr != nil {
+				return archiveErr
+			}
+			bc.valid = false
+			bc.orphan = true
+			bc.orphanSeriesID = uint64(cb.SeriesID)
+			bc.subject = subject
+			return newOrphanSkip(bc.partPath, uint64(cb.SeriesID), subject)
+		}
 		return err
 	}
+	bc.orphan = false
 	bc.valid = true
 	bc.seriesID = uint64(cb.SeriesID)
 	bc.subject = subject
@@ -384,4 +420,111 @@ func (r *measureRowReplayer) buildWriteRequest(
 		Request:      wr,
 	}
 	return wr, iwr, nil
+}
+
+// segmentSuffixFromPath extracts "20260601" from ".../seg-20260601".
+func segmentSuffixFromPath(segmentPath string) string {
+	return strings.TrimPrefix(filepath.Base(segmentPath), "seg-")
+}
+
+// shardFromPath extracts the shard id from ".../shard-0".
+func shardFromPath(shardPath string) uint32 {
+	id, _ := strconv.ParseUint(strings.TrimPrefix(filepath.Base(shardPath), "shard-"), 10, 32)
+	return uint32(id)
+}
+
+// archiveOrphanBlock writes all rows of an orphan series to the part archive
+// (a no-op write when policy is discard, which still tallies via the writer).
+// It returns a non-nil error when an archive write fails so the caller can treat
+// it as fatal (under the archive policy) and retain the source segment.
+func (r *measureRowReplayer) archiveOrphanBlock(pw *orphanPartWriter, cb *dumpmeasure.ColumnarBlock, subject string, evList pbv1.EntityValues) error {
+	entity := orphanEntityStrings(evList, cb.EntityValues)
+	// Indexed tags are block-constant (one series per block), so render them once
+	// here instead of per row inside the loop.
+	indexedTags := renderIndexedTags(cb.IndexedTags)
+	for i := 0; i < cb.Count; i++ {
+		rec := &archiveRecord{
+			Group: r.group, Catalog: catalogMeasure, Measure: subject,
+			Source:    pw.loc,
+			SeriesID:  uint64(cb.SeriesID),
+			Entity:    entity,
+			Timestamp: time.Unix(0, cb.Timestamp(i)).UTC().Format(time.RFC3339Nano),
+			TimeNanos: cb.Timestamp(i),
+			Version:   cb.Version(i),
+		}
+		rec.Tags = columnsToTyped(cb.TagCols, cb.TagTypes, i)
+		rec.Fields = columnsToTyped(cb.FieldCols, cb.FieldTypes, i)
+		rec.IndexedTags = indexedTags
+		if err := pw.appendRow(rec); err != nil {
+			return fmt.Errorf("archive orphan measure %s row: %w", subject, err)
+		}
+	}
+	return nil
+}
+
+// orphanEntityStrings renders an orphan series' entity faithfully from the
+// decoded entity values; when evList is nil (decode path produced nothing) it
+// falls back to unmarshaling the raw EntityValues bytes.
+func orphanEntityStrings(evList pbv1.EntityValues, raw []byte) []string {
+	entity := make([]string, 0)
+	if evList != nil {
+		for _, ev := range evList {
+			entity = append(entity, entityValueString(ev))
+		}
+		return entity
+	}
+	var s pbv1.Series
+	if s.Unmarshal(raw) == nil {
+		for _, ev := range s.EntityValues {
+			entity = append(entity, entityValueString(ev))
+		}
+	}
+	return entity
+}
+
+// columnsToTyped renders row i of named columns to schema-free typed values.
+func columnsToTyped(cols map[string][][]byte, types map[string]pbv1.ValueType, i int) map[string]typedValue {
+	if len(cols) == 0 {
+		return nil
+	}
+	out := make(map[string]typedValue, len(cols))
+	for name, vals := range cols {
+		if i < len(vals) {
+			out[name] = valueWithType(dump.DecodeTagValue(types[name], vals[i], nil))
+		}
+	}
+	return out
+}
+
+// renderIndexedTags renders the block's indexed tags. Indexed-tag raw bytes carry
+// no stored value type, so a printable value is emitted as text and a
+// non-printable one as "base64:"+encoding to avoid corrupting binary content.
+func renderIndexedTags(m map[uint32][][]byte) map[string][]string {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string][]string, len(m))
+	for ruleID, vals := range m {
+		ss := make([]string, 0, len(vals))
+		for _, v := range vals {
+			if isPrintableBytes(v) {
+				ss = append(ss, string(v))
+			} else {
+				ss = append(ss, "base64:"+base64.StdEncoding.EncodeToString(v))
+			}
+		}
+		out[strconv.FormatUint(uint64(ruleID), 10)] = ss
+	}
+	return out
+}
+
+// isPrintableBytes reports whether b contains only printable ASCII (plus common
+// whitespace), mirroring banyand/cmd/dump's isPrintable.
+func isPrintableBytes(b []byte) bool {
+	for _, c := range b {
+		if c < 32 && c != '\n' && c != '\r' && c != '\t' || c > 126 {
+			return false
+		}
+	}
+	return true
 }

--- a/banyand/backup/lifecycle/row_replay_pipeline.go
+++ b/banyand/backup/lifecycle/row_replay_pipeline.go
@@ -182,6 +182,10 @@ type batchSender struct {
 	// reason) so the migration report can point an operator at the source data,
 	// not just a count. Capped at maxSkipDetail to bound memory.
 	skippedDetail []skipError
+	// orphanCounts breaks orphanRows down per measure/stream subject name. The
+	// visitor pushes it into the report's orphan_handling section at Close, so the
+	// report shows which deleted schema lost how many rows (archived or discarded).
+	orphanCounts  map[string]uint64
 	topic         bus.Topic
 	timeout       time.Duration
 	maxRows       int
@@ -200,6 +204,11 @@ type batchSender struct {
 	// completes; this surfaces how much a source-data gap dropped instead of
 	// aborting the whole migration.
 	skippedRows int
+	// orphanRows counts rows dropped because their schema was deleted from the
+	// registry (errOrphanSchema). Tracked apart from skippedRows so the visitor
+	// can delete the source segment for orphan-only drops while still retaining it
+	// for sidx-gap drops.
+	orphanRows int
 }
 
 // maxSkipDetail bounds how many distinct skipped-series locations are retained
@@ -220,6 +229,33 @@ func (s *batchSender) recordSkip(err error) {
 		return
 	}
 	s.skippedDetail = append(s.skippedDetail, *c)
+}
+
+// recordOrphanSkip tallies one row dropped for a deleted schema, accumulating a
+// per-subject count for the report's orphan_handling section. Unlike recordSkip
+// it keeps no located sample: orphans are reported as per-subject counts, leaving
+// the bounded skippedDetail sample entirely for sidx-gap skips.
+func (s *batchSender) recordOrphanSkip(err error) {
+	s.orphanRows++
+	if c := asSkipError(err); c != nil {
+		if s.orphanCounts == nil {
+			s.orphanCounts = make(map[string]uint64)
+		}
+		s.orphanCounts[string(c.reason)]++
+	}
+}
+
+// partReplayResult reports what one part's replay delivered: the rows published,
+// the rows skipped because their series could not be resolved or rebuilt
+// (errSkipSeries), the rows whose schema was deleted (orphanSkipped), and a
+// bounded sample of those skips' locations for the report. A skipped > 0 result
+// means the source part still holds data the migration could not republish, so
+// its source segment must be retained rather than deleted.
+type partReplayResult struct {
+	detail        []skipError
+	rows          int
+	skipped       int
+	orphanSkipped int
 }
 
 // newBatchSender builds a sender for one data type. maxRows and maxBytes bound a
@@ -374,9 +410,14 @@ type rowCursor interface {
 // confirmation failed; the caller maps that to its progress bookkeeping.
 func (s *batchSender) replay(ctx context.Context, l *logger.Logger, group, part string, counter *uint64,
 	cur rowCursor, emit func() error,
-) (int, error) {
+) (partReplayResult, error) {
 	start := time.Now()
 	waited0 := s.pipeline.waited
+	// The sender's skip tallies are replayer-wide (one sender serves every part),
+	// so snapshot them to recover this part's own deltas for the returned result.
+	beforeRows := s.skippedRows
+	beforeOrphan := s.orphanRows
+	beforeDetail := len(s.skippedDetail)
 	warnAbort := func(rows int, err error) {
 		pos := cur.Position()
 		l.Warn().Err(err).
@@ -389,6 +430,14 @@ func (s *batchSender) replay(ctx context.Context, l *logger.Logger, group, part 
 	var failure error
 	for cur.Next() {
 		if err := emit(); err != nil {
+			// An orphan-schema series (its measure/stream was deleted from the
+			// registry) is skipped, not fatal: archive or discard its rows, tally
+			// them separately from sidx-gap skips, and keep migrating the rest.
+			// Unlike errSkipSeries, the source segment is still deleted after migration.
+			if errors.Is(err, errOrphanSchema) {
+				s.recordOrphanSkip(err)
+				continue
+			}
 			// A series whose entity cannot be resolved (sidx gap) is skipped, not
 			// fatal: drop its rows, tally them, and keep migrating the rest so one
 			// localized source-data gap does not block the whole part/migration.
@@ -418,18 +467,27 @@ func (s *batchSender) replay(ctx context.Context, l *logger.Logger, group, part 
 	if drained := s.drain(); failure == nil {
 		failure = drained
 	}
+	// This part's own counts, recovered as deltas from the replayer-wide tallies.
+	res := partReplayResult{
+		rows:          rowCount,
+		skipped:       s.skippedRows - beforeRows,
+		orphanSkipped: s.orphanRows - beforeOrphan,
+	}
+	if d := s.skippedDetail[beforeDetail:]; len(d) > 0 {
+		res.detail = append([]skipError(nil), d...)
+	}
 	if failure != nil {
 		// Drop the failed part's un-flushed residual rows (an abort skips the
 		// trailing flush) so a later close() cannot resurrect rows the caller was
 		// told were not delivered; the whole part is re-replayed on resume.
 		s.discard()
-		return rowCount, failure
+		return res, failure
 	}
 	if counter != nil {
 		atomic.AddUint64(counter, 1)
 	}
 	logRowReplayTiming(l, group, part, rowCount, time.Since(start), s.pipeline.waited-waited0)
-	return rowCount, nil
+	return res, nil
 }
 
 // logRowReplayTiming emits one info line per replayed part splitting its wall

--- a/banyand/backup/lifecycle/row_replay_pipeline.go
+++ b/banyand/backup/lifecycle/row_replay_pipeline.go
@@ -183,7 +183,7 @@ type batchSender struct {
 	// not just a count. Capped at maxSkipDetail to bound memory.
 	skippedDetail []skipError
 	// orphanCounts breaks orphanRows down per measure/stream subject name. The
-	// visitor pushes it into the report's orphan_handling section at Close, so the
+	// visitor pushes it into the report's orphans section at Close, so the
 	// report shows which deleted schema lost how many rows (archived or discarded).
 	orphanCounts  map[string]uint64
 	topic         bus.Topic
@@ -232,7 +232,7 @@ func (s *batchSender) recordSkip(err error) {
 }
 
 // recordOrphanSkip tallies one row dropped for a deleted schema, accumulating a
-// per-subject count for the report's orphan_handling section. Unlike recordSkip
+// per-subject count for the report's orphans section. Unlike recordSkip
 // it keeps no located sample: orphans are reported as per-subject counts, leaving
 // the bounded skippedDetail sample entirely for sidx-gap skips.
 func (s *batchSender) recordOrphanSkip(err error) {

--- a/banyand/backup/lifecycle/row_replay_sender_test.go
+++ b/banyand/backup/lifecycle/row_replay_sender_test.go
@@ -866,7 +866,7 @@ func TestReplayCountsOrphanSkipSeparately(t *testing.T) {
 	require.Equal(t, 1, sender.orphanRows, "one orphan-schema row must be tallied in orphanRows")
 	require.Equal(t, 0, sender.skippedRows, "orphan skip must not increment skippedRows")
 	require.Equal(t, map[string]uint64{"deleted_measure": 1}, sender.orphanCounts,
-		"orphan row must be tallied per deleted subject for the report's orphan_handling")
+		"orphan row must be tallied per deleted subject for the report's orphans")
 }
 
 // TestReplay_SurfacesSynchronousPublishErrorPromptly pins that a synchronous

--- a/banyand/backup/lifecycle/row_replay_sender_test.go
+++ b/banyand/backup/lifecycle/row_replay_sender_test.go
@@ -284,7 +284,8 @@ func TestBatchSender_ErrSkipSeriesSkip(t *testing.T) {
 	}
 
 	l := logger.GetLogger("sender-skip-test")
-	rowCount, err := sender.replay(context.Background(), l, senderTestGroup, "part-0", nil, cur, emit)
+	res, err := sender.replay(context.Background(), l, senderTestGroup, "part-0", nil, cur, emit)
+	rowCount := res.rows
 	require.NoError(t, err, "errSkipSeries must not abort the part")
 	require.Equal(t, totalRows-len(skip), rowCount, "replay counts only non-skipped rows")
 	require.Equal(t, len(skip), sender.skippedRows, "each unresolvable series increments skippedRows")
@@ -562,7 +563,8 @@ func TestReplay_RowCountBoundaries(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			s, vended := senderReturning(t)
 			var counter uint64
-			rows, err := s.replay(context.TODO(), logger.GetLogger("test-replayer"), "g", "p", &counter, &fakeCursor{n: tc.rows}, cleanEmit(s))
+			res, err := s.replay(context.TODO(), logger.GetLogger("test-replayer"), "g", "p", &counter, &fakeCursor{n: tc.rows}, cleanEmit(s))
+			rows := res.rows
 			require.NoError(t, err)
 			require.Equal(t, tc.rows, rows, "rowCount must equal the source row count")
 			require.Equal(t, uint64(1), counter, "every successful part counts once, even when empty")
@@ -591,7 +593,8 @@ func TestReplay_BatchPlusTailSendsEveryRow(t *testing.T) {
 	const rows = 2*measureReplayBatchSize + tail
 	s, vended := senderReturning(t)
 	var counter uint64
-	got, err := s.replay(context.TODO(), logger.GetLogger("test-replayer"), "g", "p", &counter, &fakeCursor{n: rows}, cleanEmit(s))
+	gotRes, err := s.replay(context.TODO(), logger.GetLogger("test-replayer"), "g", "p", &counter, &fakeCursor{n: rows}, cleanEmit(s))
+	got := gotRes.rows
 	require.NoError(t, err)
 	require.Equal(t, rows, got, "rowCount must equal the source row count")
 
@@ -628,7 +631,8 @@ func TestReplay_AbortDrainsInflightAndDiscards(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			s, vended := senderReturning(t)
 			var counter uint64
-			rows, err := s.replay(context.TODO(), logger.GetLogger("test-replayer"), "g", "p", &counter, &fakeCursor{n: tc.failAt}, failingEmit(s, tc.failAt))
+			res, err := s.replay(context.TODO(), logger.GetLogger("test-replayer"), "g", "p", &counter, &fakeCursor{n: tc.failAt}, failingEmit(s, tc.failAt))
+			rows := res.rows
 			require.Error(t, err, "the part must report failure")
 			require.Equal(t, tc.wantRows, rows, "rowCount counts the rows enqueued before the failure")
 			require.Zero(t, counter, "a failed part must not be counted")
@@ -653,8 +657,9 @@ func TestReplay_IteratorErrorDrainsAndDiscards(t *testing.T) {
 	s, vended := senderReturning(t)
 	const n = 2*measureReplayBatchSize + 300 // two full batches sent, 300 buffered, then the iterator errors
 	var counter uint64
-	rows, err := s.replay(context.TODO(), logger.GetLogger("test-replayer"), "g", "p", &counter,
+	res, err := s.replay(context.TODO(), logger.GetLogger("test-replayer"), "g", "p", &counter,
 		&fakeCursor{n: n, err: fmt.Errorf("iterator boom")}, cleanEmit(s))
+	rows := res.rows
 	require.ErrorContains(t, err, "iterator boom", "an iterator error must fail the part")
 	require.Equal(t, n, rows, "all rows read before the iterator error are counted")
 	require.Zero(t, counter, "a failed part must not be counted")
@@ -674,8 +679,9 @@ func TestReplay_NodeErrorViaInflightBoundDrivesAbort(t *testing.T) {
 	failing := &countingBatchPublisher{closeCee: map[string]*common.Error{"node-1": common.NewError("boom")}}
 	s, _ := senderReturning(t, failing) // batch 1's confirm fails
 	var counter uint64
-	rows, err := s.replay(context.TODO(), logger.GetLogger("test-replayer"), "g", "p", &counter,
+	res, err := s.replay(context.TODO(), logger.GetLogger("test-replayer"), "g", "p", &counter,
 		&fakeCursor{n: 3 * measureReplayBatchSize}, cleanEmit(s))
+	rows := res.rows
 	require.Contains(t, nodeErrCee(t, err), "node-1", "the node error must abort the part")
 	require.Zero(t, counter, "a failed part must not be counted")
 	// Batch 1's failure surfaces only once a later batch's flush awaits it at the
@@ -828,6 +834,41 @@ func TestBatchSender_CloseSurfacesDrainedFailure(t *testing.T) {
 	require.Contains(t, cee, "node-9", "close must return the drained batch's per-node errors")
 }
 
+// TestReplayCountsOrphanSkipSeparately drives replay with an emit closure that
+// returns newOrphanSkip for one row and enqueues real messages for the rest.
+// The part must not abort, orphanRows must tally the orphan, and skippedRows
+// must stay zero (sidx-gap and orphan-schema are distinct counters).
+func TestReplayCountsOrphanSkipSeparately(t *testing.T) {
+	require.NoError(t, logger.Init(logger.Logging{Env: "dev", Level: "warn"}))
+	pub := &capturingBatchPublisher{}
+	client := senderMockClient(t, pub)
+	sender := newBatchSender(client, bus.Topic{}, 10, 1<<30, time.Second)
+
+	const totalRows = 3
+	cur := &senderCursor{total: totalRows}
+	emitted := 0
+	base := time.Now().UTC().Truncate(time.Millisecond)
+	emit := func() error {
+		idx := emitted
+		emitted++
+		if idx == 1 {
+			return newOrphanSkip("part", 7, "deleted_measure")
+		}
+		iwr := senderNewIWR(base.Add(time.Duration(idx)*time.Second), 16, int64(idx))
+		return sender.enqueueMarshaled(context.Background(), senderTestNode, senderTestGroup, iwr, proto.Size(iwr))
+	}
+
+	l := logger.GetLogger("orphan-skip-test")
+	res, err := sender.replay(context.Background(), l, senderTestGroup, "part-0", nil, cur, emit)
+	rowCount := res.rows
+	require.NoError(t, err, "orphan skip must not abort the part")
+	require.Equal(t, totalRows-1, rowCount, "orphan row is not counted as a published row")
+	require.Equal(t, 1, sender.orphanRows, "one orphan-schema row must be tallied in orphanRows")
+	require.Equal(t, 0, sender.skippedRows, "orphan skip must not increment skippedRows")
+	require.Equal(t, map[string]uint64{"deleted_measure": 1}, sender.orphanCounts,
+		"orphan row must be tallied per deleted subject for the report's orphan_handling")
+}
+
 // TestReplay_SurfacesSynchronousPublishErrorPromptly pins that a synchronous
 // Publish failure aborts the part on the flush that triggered it — not deferred
 // until the in-flight bound or the final drain. With the failing publisher
@@ -838,8 +879,9 @@ func TestReplay_SurfacesSynchronousPublishErrorPromptly(t *testing.T) {
 	pub := &countingBatchPublisher{publishErr: fmt.Errorf("stream send broke")}
 	s, _ := senderReturning(t, pub) // the first batch's Publish fails synchronously
 	var counter uint64
-	rows, err := s.replay(context.TODO(), logger.GetLogger("test-replayer"), "g", "p", &counter,
+	res, err := s.replay(context.TODO(), logger.GetLogger("test-replayer"), "g", "p", &counter,
 		&fakeCursor{n: 3 * measureReplayBatchSize}, cleanEmit(s))
+	rows := res.rows
 	require.ErrorContains(t, err, "stream send broke", "a synchronous Publish error must abort the part")
 	require.Zero(t, counter, "a failed part must not be counted")
 	// Row 2000's emit triggers the failing flush and returns its error, so the loop

--- a/banyand/backup/lifecycle/row_replay_skip_test.go
+++ b/banyand/backup/lifecycle/row_replay_skip_test.go
@@ -21,12 +21,14 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/apache/skywalking-banyandb/banyand/internal/storage"
 	"github.com/apache/skywalking-banyandb/pkg/logger"
+	"github.com/apache/skywalking-banyandb/pkg/timestamp"
 )
 
 // TestSkipContext_WrapsErrSkipSeries proves a located skip still satisfies the
@@ -123,4 +125,31 @@ func TestExcludeRetainedSuffixes_NoneRetained(t *testing.T) {
 
 	got := excludeRetainedSuffixes(suffixes, nil, rule, l)
 	assert.Equal(t, suffixes, got)
+}
+
+// TestStreamMigrationVisitor_SidxGapRetention proves the stream visitor now has
+// the same sidx-gap source retention as measure: a recorded skipped source
+// segment surfaces from SkippedSourceSegmentStarts and is excluded from the
+// delete-after-migration suffix set.
+func TestStreamMigrationVisitor_SidxGapRetention(t *testing.T) {
+	mv := &streamMigrationVisitor{skippedSourceTracker: newSkippedSourceTracker()}
+	require.Empty(t, mv.SkippedSourceSegmentStarts(), "no skips recorded yet")
+
+	rule := storage.IntervalRule{Unit: storage.DAY, Num: 1}
+	retainStart, err := storage.ParseSegmentTime("20260608", rule)
+	require.NoError(t, err)
+	segmentTR := &timestamp.TimeRange{Start: retainStart, End: retainStart.Add(24 * time.Hour)}
+
+	mv.recordSkippedSource(segmentTR)
+	// Idempotent: recording the same source twice keeps a single entry.
+	mv.recordSkippedSource(segmentTR)
+	starts := mv.SkippedSourceSegmentStarts()
+	require.Len(t, starts, 1)
+	assert.Equal(t, retainStart.UnixNano(), starts[0])
+
+	l := logger.GetLogger("stream-retention-test")
+	suffixes := []string{"20260607", "20260608", "20260609"}
+	got := excludeRetainedSuffixes(suffixes, mv.SkippedSourceSegmentStarts(), rule, l)
+	assert.Equal(t, []string{"20260607", "20260609"}, got,
+		"a stream source segment with a sidx-gap skip must be retained (excluded from deletion)")
 }

--- a/banyand/backup/lifecycle/row_replay_stream.go
+++ b/banyand/backup/lifecycle/row_replay_stream.go
@@ -158,11 +158,9 @@ func (r *streamRowReplayer) replayPart(ctx context.Context, partPath string) (pa
 	}
 	reader.SetIndexResolver(ir)
 
-	loc := sourceLoc{
-		Stage:   r.srcStage,
-		Segment: segmentSuffixFromPath(segmentPath),
-		Shard:   shardFromPath(shardPath),
-		Part:    fmt.Sprintf("%016x", partID),
+	loc, locErr := newSourceLoc(r.srcStage, segmentPath, shardPath, partID)
+	if locErr != nil {
+		return partReplayResult{}, fmt.Errorf("derive source location for part %s: %w", partPath, locErr)
 	}
 
 	it := reader.Iterator()

--- a/banyand/backup/lifecycle/row_replay_stream.go
+++ b/banyand/backup/lifecycle/row_replay_stream.go
@@ -20,6 +20,7 @@ package lifecycle
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -34,12 +35,14 @@ import (
 	"github.com/apache/skywalking-banyandb/banyand/internal/dump"
 	dumpstream "github.com/apache/skywalking-banyandb/banyand/internal/dump/stream"
 	"github.com/apache/skywalking-banyandb/banyand/metadata"
+	"github.com/apache/skywalking-banyandb/banyand/metadata/schema"
 	"github.com/apache/skywalking-banyandb/banyand/queue"
 	"github.com/apache/skywalking-banyandb/pkg/convert"
 	"github.com/apache/skywalking-banyandb/pkg/fs"
 	"github.com/apache/skywalking-banyandb/pkg/logger"
 	"github.com/apache/skywalking-banyandb/pkg/node"
 	"github.com/apache/skywalking-banyandb/pkg/partition"
+	pbv1 "github.com/apache/skywalking-banyandb/pkg/pb/v1"
 )
 
 const (
@@ -61,8 +64,10 @@ type streamRowReplayer struct {
 	schemaCache    map[string]*cachedStreamSchema
 	irResolver     *dump.IndexResolver
 	counter        *uint64
+	archiver       *orphanArchiver
 	group          string
 	irPath         string
+	srcStage       string
 	schemaCacheMu  sync.Mutex
 	irMu           sync.Mutex
 	targetShardNum uint32
@@ -72,18 +77,20 @@ func newStreamRowReplayer(
 	group string, targetShardNum uint32,
 	selector node.Selector, client queue.Client,
 	md metadata.Repo, fileSystem fs.FileSystem,
-	l *logger.Logger, counter *uint64,
+	l *logger.Logger, counter *uint64, orphanCfg orphanConfig, srcStage string,
 ) *streamRowReplayer {
 	return &streamRowReplayer{
 		group:          group,
 		targetShardNum: targetShardNum,
 		selector:       selector,
 		sender:         newBatchSender(client, data.TopicStreamWrite, rowReplayMaxBatchRows, int(rowReplayMaxBatchBytes), streamReplayBatchTimeout),
+		archiver:       newOrphanArchiver(orphanCfg, group, catalogStream, l),
 		metadata:       md,
 		fs:             fileSystem,
 		logger:         l,
 		schemaCache:    make(map[string]*cachedStreamSchema),
 		counter:        counter,
+		srcStage:       srcStage,
 	}
 }
 
@@ -110,6 +117,12 @@ func (r *streamRowReplayer) loadSchema(ctx context.Context, streamName string) (
 	}
 	s, err := r.metadata.StreamRegistry().GetStream(ctx, &commonv1.Metadata{Group: r.group, Name: streamName})
 	if err != nil {
+		// A genuine registry not-found means the stream was deleted from the
+		// registry (orphan); any other error (network, closed registry, ...) stays
+		// fatal so a transient failure is never mistaken for a droppable orphan.
+		if errors.Is(err, schema.ErrGRPCResourceNotFound) {
+			return nil, fmt.Errorf("%w: stream %s/%s", errOrphanSchema, r.group, streamName)
+		}
 		return nil, fmt.Errorf("load stream schema %s/%s: %w", r.group, streamName, err)
 	}
 	c := &cachedStreamSchema{
@@ -120,41 +133,59 @@ func (r *streamRowReplayer) loadSchema(ctx context.Context, streamName string) (
 	return c, nil
 }
 
-func (r *streamRowReplayer) replayPart(ctx context.Context, partPath string) (int, error) {
+// replayPart opens a source part and replays its rows through the sender. It
+// returns the rows published, the rows dropped because their series could not be
+// resolved (skipped — a series-index gap, mirroring measure: the source segment
+// must be retained), and the rows dropped because their schema was deleted from
+// the registry (orphanSkipped). Both skip counts are this part's delta from the
+// replayer-wide sender tallies. A non-nil error means some rows were not durably
+// delivered. Returns the same partReplayResult shape as the measure replayer.
+func (r *streamRowReplayer) replayPart(ctx context.Context, partPath string) (partReplayResult, error) {
 	partID, shardPath, segmentPath, parseErr := parseReplayPartPath(partPath)
 	if parseErr != nil {
-		return 0, parseErr
+		return partReplayResult{}, parseErr
 	}
 
-	reader, err := dumpstream.OpenPart(partID, shardPath, r.fs)
-	if err != nil {
-		return 0, fmt.Errorf("open stream part %s: %w", partPath, err)
+	reader, openErr := dumpstream.OpenPart(partID, shardPath, r.fs)
+	if openErr != nil {
+		return partReplayResult{}, fmt.Errorf("open stream part %s: %w", partPath, openErr)
 	}
 	defer reader.Close()
 
 	ir, irErr := r.loadIndexResolver(segmentPath)
 	if irErr != nil {
-		return 0, fmt.Errorf("load stream index resolver for segment %s: %w", segmentPath, irErr)
+		return partReplayResult{}, fmt.Errorf("load stream index resolver for segment %s: %w", segmentPath, irErr)
 	}
 	reader.SetIndexResolver(ir)
 
+	loc := sourceLoc{
+		Stage:   r.srcStage,
+		Segment: segmentSuffixFromPath(segmentPath),
+		Shard:   shardFromPath(shardPath),
+		Part:    fmt.Sprintf("%016x", partID),
+	}
+
 	it := reader.Iterator()
 	defer it.Close()
-	return r.sender.replay(ctx, r.logger, r.group, partPath, r.counter, it,
-		func() error { return r.publishRow(ctx, it.Row()) })
+	// runPart opens the part's archive writer and commits/aborts its manifest; the
+	// orphan rows are appended to that writer (captured by the emit closure) inside replay.
+	var res partReplayResult
+	runErr := r.archiver.runPart(loc, func(pw *orphanPartWriter) error {
+		var replayErr error
+		res, replayErr = r.sender.replay(ctx, r.logger, r.group, partPath, r.counter, it,
+			func() error { return r.publishRow(ctx, pw, it.Row()) })
+		return replayErr
+	})
+	return res, runErr
 }
 
 // buildWriteRequest reconstructs the WriteRequest + InternalWriteRequest pair
-// from a raw stream Row. Separated from publishRow for testability.
-func (r *streamRowReplayer) buildWriteRequest(ctx context.Context, row dumpstream.Row) (*streamv1.WriteRequest, *streamv1.InternalWriteRequest, error) {
-	subject, evList, err := decodeSeriesEntityValues(row.EntityValues)
-	if err != nil {
-		return nil, nil, fmt.Errorf("decode entity values (seriesID=%d): %w", row.SeriesID, err)
-	}
-	cached, err := r.loadSchema(ctx, subject)
-	if err != nil {
-		return nil, nil, err
-	}
+// from a resolved subject + raw stream Row. The subject and its entity TagValues
+// are decoded by the caller so an orphan schema can be archived before the build.
+// Separated from publishRow for testability.
+func (r *streamRowReplayer) buildWriteRequest(
+	cached *cachedStreamSchema, subject string, evList pbv1.EntityValues, row dumpstream.Row,
+) (*streamv1.WriteRequest, *streamv1.InternalWriteRequest, error) {
 	tagFamilies := buildStreamTagFamilies(cached.schema.TagFamilies, cached.schema.Entity, row, evList)
 	wr := &streamv1.WriteRequest{
 		Metadata: &commonv1.Metadata{Group: r.group, Name: subject},
@@ -179,10 +210,57 @@ func (r *streamRowReplayer) buildWriteRequest(ctx context.Context, row dumpstrea
 	return wr, iwr, nil
 }
 
-func (r *streamRowReplayer) publishRow(ctx context.Context, row dumpstream.Row) error {
-	wr, iwr, err := r.buildWriteRequest(ctx, row)
+func (r *streamRowReplayer) publishRow(ctx context.Context, pw *orphanPartWriter, row dumpstream.Row) error {
+	subject, evList, err := decodeSeriesEntityValues(row.EntityValues)
+	if err != nil {
+		return fmt.Errorf("decode entity values (seriesID=%d): %w", row.SeriesID, err)
+	}
+	cached, err := r.loadSchema(ctx, subject)
+	if err != nil {
+		if errors.Is(err, errOrphanSchema) {
+			// Deleted schema: archive (or discard) this row, then skip it. The source
+			// segment is still deleted by the visitor (unlike a sidx-gap skip). A
+			// failed archive write under the archive policy is FATAL — returning it
+			// aborts the part so the source is retained and resume retries, never
+			// silently dropping the orphan row.
+			if archiveErr := r.archiveOrphanRow(pw, subject, evList, row); archiveErr != nil {
+				return archiveErr
+			}
+			loc := pw.loc
+			partLabel := fmt.Sprintf("seg-%s/shard-%d/part-%s", loc.Segment, loc.Shard, loc.Part)
+			return newOrphanSkip(partLabel, uint64(row.SeriesID), subject)
+		}
+		return err
+	}
+	wr, iwr, err := r.buildWriteRequest(cached, subject, evList, row)
 	if err != nil {
 		return err
 	}
 	return r.sender.routeAndEnqueue(ctx, r.selector, r.group, wr.Metadata.Name, iwr.ShardId, iwr)
+}
+
+// archiveOrphanRow writes one orphan stream row to the part archive (a no-op
+// write when policy is discard, which still tallies via the writer). It returns
+// a non-nil error when the archive write fails so the caller can treat it as
+// fatal (under the archive policy) and retain the source segment.
+func (r *streamRowReplayer) archiveOrphanRow(pw *orphanPartWriter, subject string, evList pbv1.EntityValues, row dumpstream.Row) error {
+	rec := &archiveRecord{
+		Group: r.group, Catalog: catalogStream, Measure: subject,
+		Source:    pw.loc,
+		SeriesID:  uint64(row.SeriesID),
+		Entity:    orphanEntityStrings(evList, row.EntityValues),
+		Timestamp: time.Unix(0, row.Timestamp).UTC().Format(time.RFC3339Nano),
+		TimeNanos: row.Timestamp,
+		ElementID: base64.StdEncoding.EncodeToString(convert.Uint64ToBytes(row.ElementID)),
+	}
+	if len(row.Tags) > 0 {
+		rec.Tags = make(map[string]typedValue, len(row.Tags))
+		for name, raw := range row.Tags {
+			rec.Tags[name] = valueWithType(dump.DecodeTagValue(row.TagTypes[name], raw, nil))
+		}
+	}
+	if err := pw.appendRow(rec); err != nil {
+		return fmt.Errorf("archive orphan stream %s row: %w", subject, err)
+	}
+	return nil
 }

--- a/banyand/backup/lifecycle/row_replay_trace.go
+++ b/banyand/backup/lifecycle/row_replay_trace.go
@@ -109,8 +109,9 @@ func (r *traceRowReplayer) replayPart(ctx context.Context, partPath string) (int
 	defer it.Close()
 	// Prefix the part label with the trace name so the shared driver's timing and
 	// abort logs keep the trace identity the old per-type logs carried.
-	return r.sender.replay(ctx, r.logger, r.group, r.traceName+"/"+partPath, r.counter, it,
+	res, err := r.sender.replay(ctx, r.logger, r.group, r.traceName+"/"+partPath, r.counter, it,
 		func() error { return r.publishRow(ctx, it.Row()) })
+	return res.rows, err
 }
 
 // buildWriteRequest reconstructs the WriteRequest + InternalWriteRequest pair

--- a/banyand/backup/lifecycle/service.go
+++ b/banyand/backup/lifecycle/service.go
@@ -127,6 +127,9 @@ type lifecycleService struct {
 	lifecycleKeyFile    string
 	lifecycleGRPCAddr   string
 	measureRoot         string
+	orphanPolicyStr     string
+	orphanArchiveSubdir string
+	orphanCfg           orphanConfig
 	localNodeMD         schema.Metadata
 	maxExecutionTimes   int
 	chunkSize           run.Bytes
@@ -201,6 +204,10 @@ func (l *lifecycleService) FlagSet() *run.FlagSet {
 	flagS.IntVar(&l.maxExecutionTimes, "max-execution-times", 0, "Maximum number of times to execute the lifecycle migration. 0 means no limit.")
 	l.chunkSize = run.Bytes(1024 * 1024)
 	flagS.VarP(&l.chunkSize, "chunk-size", "", "Chunk size in bytes for streaming data during migration (default: 1MB)")
+	flagS.StringVar(&l.orphanPolicyStr, "migration-orphan-policy", "archive",
+		"What to do with rows whose schema was deleted from the registry: archive|discard")
+	flagS.StringVar(&l.orphanArchiveSubdir, "migration-orphan-archive-subdir", "archive",
+		"Relative subdirectory, under each catalog's root path, where orphan rows are archived when policy=archive (e.g. <measure-root-path>/archive)")
 	flagS.IntVar(&rowReplayMaxBatchRows, "row-replay-max-batch-rows", rowReplayMaxBatchRows,
 		"Maximum rows per row-replay batch (row-replay is the fallback for parts spanning multiple target segments)")
 	flagS.VarP(&rowReplayMaxBatchBytes, "row-replay-max-batch-bytes", "",
@@ -246,7 +253,23 @@ func (l *lifecycleService) Validate() error {
 			CreatedAt:   timestamppb.Now(),
 		}
 	}
+	policy, err := parseOrphanPolicy(l.orphanPolicyStr)
+	if err != nil {
+		return err
+	}
+	if filepath.IsAbs(l.orphanArchiveSubdir) {
+		return fmt.Errorf("migration-orphan-archive-subdir must be a relative path (under each catalog's root), got %q", l.orphanArchiveSubdir)
+	}
+	// rootDir is resolved per-catalog (under each catalog's root path) via
+	// orphanConfigFor; here we only fix the policy.
+	l.orphanCfg = orphanConfig{policy: policy}
 	return nil
+}
+
+// orphanConfigFor resolves the orphan archive config for a catalog rooted at
+// catalogRoot: the archive lives in the configured relative subdir under that root.
+func (l *lifecycleService) orphanConfigFor(catalogRoot string) orphanConfig {
+	return orphanConfig{policy: l.orphanCfg.policy, rootDir: filepath.Join(catalogRoot, l.orphanArchiveSubdir)}
 }
 
 // PreRun initializes the lifecycle service and its embedded server.
@@ -845,11 +868,20 @@ func (l *lifecycleService) buildMigrationReport(p *Progress) map[string]interfac
 	defer p.mu.Unlock()
 
 	now := time.Now()
+	// orphans reports, per catalog -> group -> deleted subject, how many rows were
+	// archived or discarded because their schema was deleted from the registry.
+	// This is expected handling (the source segment is still deleted), so it is
+	// reported here rather than as a migration error.
+	orphans := map[string]interface{}{"policy": l.orphanPolicyStr}
+	for catalog, byGroup := range p.OrphanRows {
+		orphans[catalog] = byGroup
+	}
 	report := map[string]interface{}{
 		"generated_at":   now,
 		"report_version": "2.1",
 		"summary":        l.buildSummaryStats(p),
 		"errors":         l.buildErrorSummary(p),
+		"orphans":        orphans,
 		"snapshot_info": map[string]interface{}{
 			"stream_dir":  p.SnapshotStreamDir,
 			"measure_dir": p.SnapshotMeasureDir,
@@ -1203,7 +1235,7 @@ func (l *lifecycleService) processStreamGroupFileBased(_ context.Context, g *Gro
 
 	// Use the file-based migration with existing visitor pattern
 	//nolint:contextcheck // migration drives its own context lifecycle for batch publish.
-	segmentSuffixes, err := migrateStreamWithFileBasedAndProgress(rootDir, *tr, g, l.l, progress, int(l.chunkSize), l.metadata)
+	segmentSuffixes, err := migrateStreamWithFileBasedAndProgress(rootDir, *tr, g, l.l, progress, int(l.chunkSize), l.metadata, l.orphanConfigFor(l.streamRoot))
 	if err != nil {
 		return nil, fmt.Errorf("file-based stream migration failed: %w", err)
 	}
@@ -1328,7 +1360,7 @@ func (l *lifecycleService) processMeasureGroupFileBased(_ context.Context, g *Gr
 
 	// Use the file-based migration with existing visitor pattern
 	//nolint:contextcheck // migration drives its own context lifecycle for batch publish.
-	segmentSuffixes, err := migrateMeasureWithFileBasedAndProgress(rootDir, *tr, g, l.l, progress, int(l.chunkSize), l.metadata)
+	segmentSuffixes, err := migrateMeasureWithFileBasedAndProgress(rootDir, *tr, g, l.l, progress, int(l.chunkSize), l.metadata, l.orphanConfigFor(l.measureRoot))
 	if err != nil {
 		return nil, fmt.Errorf("file-based measure migration failed: %w", err)
 	}

--- a/banyand/backup/lifecycle/skipped_source.go
+++ b/banyand/backup/lifecycle/skipped_source.go
@@ -1,0 +1,60 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package lifecycle
+
+import (
+	"sort"
+
+	"github.com/apache/skywalking-banyandb/pkg/timestamp"
+)
+
+// skippedSourceTracker records source segments that must be retained (excluded
+// from the delete-after-migration suffix set) because row-replay skipped
+// unresolved rows in them. Keyed by segment start instant (UnixNano), the same
+// value a segment suffix decodes to. Embedded by the measure and stream
+// migration visitors so the retention bookkeeping lives in one place.
+type skippedSourceTracker struct {
+	starts map[int64]struct{}
+}
+
+func newSkippedSourceTracker() skippedSourceTracker {
+	return skippedSourceTracker{starts: make(map[int64]struct{})}
+}
+
+// recordSkippedSource marks a source segment (by its start instant) as holding
+// rows the row-replay could not republish, so it must be retained rather than
+// deleted.
+func (t *skippedSourceTracker) recordSkippedSource(segmentTR *timestamp.TimeRange) {
+	t.starts[segmentTR.Start.UnixNano()] = struct{}{}
+}
+
+// SkippedSourceSegmentStarts returns the start instants (UnixNano) of source
+// segments that must be retained because row-replay skipped unresolved rows in
+// them. The migration excludes these from the delete-after-migration suffix set.
+func (t *skippedSourceTracker) SkippedSourceSegmentStarts() []int64 {
+	if len(t.starts) == 0 {
+		return nil
+	}
+	out := make([]int64, 0, len(t.starts))
+	for start := range t.starts {
+		out = append(out, start)
+	}
+	// Sorted so the retained-suffix log line is reproducible run to run.
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}

--- a/banyand/backup/lifecycle/stream_migration_visitor.go
+++ b/banyand/backup/lifecycle/stream_migration_visitor.go
@@ -41,17 +41,19 @@ import (
 
 // streamMigrationVisitor implements the stream.Visitor interface for file-based migration.
 type streamMigrationVisitor struct {
-	client                  queue.Client
-	lfs                     fs.FileSystem
-	metadata                metadata.Repo
-	selector                node.Selector
-	chunkedClients          map[string]queue.ChunkedSyncClient
-	logger                  *logger.Logger
-	progress                *Progress
-	replayer                *streamRowReplayer
+	client         queue.Client
+	lfs            fs.FileSystem
+	metadata       metadata.Repo
+	selector       node.Selector
+	chunkedClients map[string]queue.ChunkedSyncClient
+	logger         *logger.Logger
+	progress       *Progress
+	replayer       *streamRowReplayer
+	skippedSourceTracker
 	group                   string
 	sourceStage             string
 	targetStage             string
+	orphanCfg               orphanConfig
 	targetStageInterval     storage.IntervalRule
 	sourceSegmentInterval   storage.IntervalRule
 	chunkSize               int
@@ -64,7 +66,7 @@ type streamMigrationVisitor struct {
 // newStreamMigrationVisitor creates a new file-based migration visitor.
 func newStreamMigrationVisitor(group *commonv1.Group, shardNum, replicas uint32, selector node.Selector, client queue.Client,
 	l *logger.Logger, progress *Progress, chunkSize int, targetStageInterval storage.IntervalRule, md metadata.Repo,
-	sourceStage, targetStage string, sourceSegmentInterval storage.IntervalRule,
+	sourceStage, targetStage string, sourceSegmentInterval storage.IntervalRule, orphanCfg orphanConfig,
 ) *streamMigrationVisitor {
 	return &streamMigrationVisitor{
 		group:                 group.Metadata.Name,
@@ -82,6 +84,8 @@ func newStreamMigrationVisitor(group *commonv1.Group, shardNum, replicas uint32,
 		targetStageInterval:   targetStageInterval,
 		metadata:              md,
 		lfs:                   fs.NewLocalFileSystem(),
+		skippedSourceTracker:  newSkippedSourceTracker(),
+		orphanCfg:             orphanCfg,
 	}
 }
 
@@ -110,7 +114,7 @@ func (mv *streamMigrationVisitor) CounterSnapshot() (chunkSync, rowReplay uint64
 func (mv *streamMigrationVisitor) ensureReplayer() *streamRowReplayer {
 	if mv.replayer == nil {
 		mv.replayer = newStreamRowReplayer(mv.group, mv.targetShardNum, mv.selector, mv.client, mv.metadata,
-			mv.lfs, mv.logger, &mv.partsReplayedRowLevel)
+			mv.lfs, mv.logger, &mv.partsReplayedRowLevel, mv.orphanCfg, mv.sourceStage)
 	}
 	return mv.replayer
 }
@@ -407,7 +411,7 @@ func (mv *streamMigrationVisitor) visitPartRowReplay(ctx context.Context, segmen
 	// draining all in-flight confirmations before returning. A non-nil error means
 	// some rows were not durably delivered; marking the part errored (rather than
 	// completed) ensures the resume guard re-replays the whole part.
-	rowCount, err := replayer.replayPart(ctx, partPath)
+	res, err := replayer.replayPart(ctx, partPath)
 	if err != nil {
 		// Row-replay is all-or-nothing per part; mark the source part errored so
 		// resume retries the whole part (same source key the guard checks above).
@@ -415,12 +419,40 @@ func (mv *streamMigrationVisitor) visitPartRowReplay(ctx context.Context, segmen
 		mv.recordError(scopePart, segmentTR, sourceShardID, &partID, err.Error())
 		return fmt.Errorf("row-replay stream part %s: %w", partPath, err)
 	}
+	if res.skipped > 0 {
+		// Some series could not be resolved from the series index: their rows remain
+		// only in the source part. Record a locatable error and retain the source
+		// segment (excluded from the post-migration delete set) so the data is not
+		// silently and permanently lost, mirroring measure.
+		mv.recordSkippedSource(segmentTR)
+		mv.recordError(scopePart, segmentTR, sourceShardID, &partID,
+			fmt.Sprintf("row-replay skipped %d unresolved rows (series-index gap); examples=%s",
+				res.skipped, formatSkipExamples(filterSkipExamplesByKind(res.detail, skipKindSidxGap))))
+		mv.logger.Warn().
+			Uint64("part_id", partID).
+			Int("skipped_rows", res.skipped).
+			Int("published_rows", res.rows).
+			Str("group", mv.group).
+			Msg("stream row-replay skipped unresolved series; retaining source segment to avoid data loss")
+	}
+	if res.orphanSkipped > 0 {
+		// Orphan (deleted schema): archived or discarded; the source segment is NOT
+		// retained — it is deleted normally. This is expected handling, not a
+		// migration error: the per-subject counts are reported via orphan_handling
+		// (pushed at Close), not recorded in the errors buckets.
+		mv.logger.Warn().
+			Uint64("part_id", partID).
+			Int("orphan_rows", res.orphanSkipped).
+			Str("policy", orphanVerb(mv.orphanCfg.policy)).
+			Str("group", mv.group).
+			Msg("stream row-replay handled orphan-schema series; source segment will be deleted")
+	}
 	mv.progress.MarkStreamPartCompleted(mv.group, sourceSegmentIDStr, sourceShardID, partID)
 	mv.progress.MarkSourceStreamPartCompleted(mv.group, partPath, sourceShardID, partID)
-	mv.progress.AddStreamRowReplay(mv.group, rowCount)
+	mv.progress.AddStreamRowReplay(mv.group, res.rows)
 	mv.logger.Info().
 		Uint64("part_id", partID).
-		Int("rows_published", rowCount).
+		Int("rows_published", res.rows).
 		Str("group", mv.group).
 		Msg("stream row-replay completed")
 	return nil
@@ -626,6 +658,7 @@ func (mv *streamMigrationVisitor) streamPartToNode(nodeID string, targetShardID 
 // Close cleans up all chunked sync clients and the row-replayer.
 func (mv *streamMigrationVisitor) Close() error {
 	if mv.replayer != nil {
+		mv.progress.AddOrphanRows(mv.group, catalogStream, mv.replayer.sender.orphanCounts)
 		cee, replayCloseErr := mv.replayer.Close()
 		recordNodeErrors(mv.progress, mv.group, mv.sourceStage, mv.targetStage, catalogStream, cee)
 		if replayCloseErr != nil {

--- a/banyand/backup/lifecycle/stream_migration_visitor.go
+++ b/banyand/backup/lifecycle/stream_migration_visitor.go
@@ -438,7 +438,7 @@ func (mv *streamMigrationVisitor) visitPartRowReplay(ctx context.Context, segmen
 	if res.orphanSkipped > 0 {
 		// Orphan (deleted schema): archived or discarded; the source segment is NOT
 		// retained — it is deleted normally. This is expected handling, not a
-		// migration error: the per-subject counts are reported via orphan_handling
+		// migration error: the per-subject counts are reported via orphans
 		// (pushed at Close), not recorded in the errors buckets.
 		mv.logger.Warn().
 			Uint64("part_id", partID).

--- a/banyand/stream/migration_slowpath_test.go
+++ b/banyand/stream/migration_slowpath_test.go
@@ -40,6 +40,52 @@ import (
 	"github.com/apache/skywalking-banyandb/pkg/query/model"
 )
 
+// matchInvertedTerm opens a fresh store at idxPath and returns the element IDs the
+// (ruleID, seriesID, value) term matches, then closes it. A freshly written index
+// can read empty until its snapshot is flushed and visible (see ReadOnlyDocCount),
+// and only a fresh open re-reads the on-disk snapshot — so callers poll this rather
+// than holding a single reader that is stuck at its open-time view.
+func matchInvertedTerm(idxPath string, ruleID uint32, seriesID common.SeriesID, value string) (map[uint64]struct{}, error) {
+	store, openErr := inverted.NewStore(inverted.StoreOpts{Path: idxPath, BatchWaitSec: 0})
+	if openErr != nil {
+		return nil, openErr
+	}
+	defer func() { _ = store.Close() }()
+	list, _, matchErr := store.MatchTerms(index.NewStringField(index.FieldKey{
+		IndexRuleID: ruleID,
+		SeriesID:    seriesID,
+	}, value))
+	if matchErr != nil {
+		return nil, matchErr
+	}
+	got := map[uint64]struct{}{}
+	iter := list.Iterator()
+	for iter.Next() {
+		got[iter.Current()] = struct{}{}
+	}
+	return got, iter.Close()
+}
+
+// eventuallyIdxTerm polls matchInvertedTerm until the term matches exactly want,
+// tolerating the reader-visibility lag of a freshly written index under load.
+func eventuallyIdxTerm(t *testing.T, idxPath string, ruleID uint32, seriesID common.SeriesID, value string, want []uint64) {
+	t.Helper()
+	require.Eventuallyf(t, func() bool {
+		got, err := matchInvertedTerm(idxPath, ruleID, seriesID, value)
+		if err != nil || len(got) != len(want) {
+			return false
+		}
+		for _, id := range want {
+			if _, ok := got[id]; !ok {
+				return false
+			}
+		}
+		return true
+	}, 10*time.Second, 100*time.Millisecond,
+		"idx %s rule %d series %v value=%s: expected elementIDs %v not visible in time",
+		idxPath, ruleID, seriesID, value, want)
+}
+
 // TestMigrationSlowPath_NumGt1_ReBucketing proves that the slow path correctly
 // re-buckets source rows when the target SegmentInterval has Num > 1 (specifically
 // Num=2 days), which is the production scenario for warm/cold tiers. A single source
@@ -300,25 +346,7 @@ func TestMigrationSlowPathElementIndexRebuild(t *testing.T) {
 		info, statErr := os.Stat(idxPath)
 		require.NoError(t, statErr, "target seg %s must have an idx/", seg)
 		require.True(t, info.IsDir())
-		store, openErr := inverted.NewStore(inverted.StoreOpts{Path: idxPath, BatchWaitSec: 0})
-		require.NoError(t, openErr)
-		defer func() { require.NoError(t, store.Close()) }()
-		list, _, matchErr := store.MatchTerms(index.NewStringField(index.FieldKey{
-			IndexRuleID: statusRID,
-			SeriesID:    seriesID,
-		}, value))
-		require.NoError(t, matchErr)
-		got := map[uint64]struct{}{}
-		iter := list.Iterator()
-		for iter.Next() {
-			got[iter.Current()] = struct{}{}
-		}
-		require.NoError(t, iter.Close())
-		require.Len(t, got, len(want), "seg %s status=%s wrong doc count", seg, value)
-		for _, id := range want {
-			_, ok := got[id]
-			require.Truef(t, ok, "seg %s status=%s missing elementID %d", seg, value, id)
-		}
+		eventuallyIdxTerm(t, idxPath, statusRID, seriesID, value, want)
 	}
 
 	// day1: only eD1ok for "ok", only eD1err for "err"; no day2 contamination.
@@ -520,25 +548,7 @@ func TestMigrationSlowPathMultiStreamElementIndexRebuild(t *testing.T) {
 		info, statErr := os.Stat(idxPath)
 		require.NoError(t, statErr, "target seg %s must have an idx/", seg)
 		require.True(t, info.IsDir())
-		store, openErr := inverted.NewStore(inverted.StoreOpts{Path: idxPath, BatchWaitSec: 0})
-		require.NoError(t, openErr)
-		defer func() { require.NoError(t, store.Close()) }()
-		list, _, matchErr := store.MatchTerms(index.NewStringField(index.FieldKey{
-			IndexRuleID: ruleID,
-			SeriesID:    seriesID,
-		}, value))
-		require.NoError(t, matchErr)
-		got := map[uint64]struct{}{}
-		iter := list.Iterator()
-		for iter.Next() {
-			got[iter.Current()] = struct{}{}
-		}
-		require.NoError(t, iter.Close())
-		require.Lenf(t, got, len(want), "seg %s rule %d value=%s wrong doc count", seg, ruleID, value)
-		for _, id := range want {
-			_, ok := got[id]
-			require.Truef(t, ok, "seg %s rule %d value=%s missing elementID %d", seg, ruleID, value, id)
-		}
+		eventuallyIdxTerm(t, idxPath, ruleID, seriesID, value, want)
 	}
 
 	// streamA "status": each seg holds only its own elements, no cross contamination.
@@ -738,26 +748,7 @@ func TestMigrationElementIndexByteCopyCollisionFallsBackToRebuild(t *testing.T) 
 		info, statErr := os.Stat(idxPath)
 		require.NoError(t, statErr, "target idx dir must exist")
 		require.True(t, info.IsDir())
-		store, openErr := inverted.NewStore(inverted.StoreOpts{Path: idxPath, BatchWaitSec: 0})
-		require.NoError(t, openErr)
-		defer func() { require.NoError(t, store.Close()) }()
-		list, _, matchErr := store.MatchTerms(index.NewStringField(index.FieldKey{
-			IndexRuleID: statusRID,
-			SeriesID:    seriesID,
-		}, value))
-		require.NoError(t, matchErr)
-		got := map[uint64]struct{}{}
-		iter := list.Iterator()
-		for iter.Next() {
-			got[iter.Current()] = struct{}{}
-		}
-		require.NoError(t, iter.Close())
-		require.Lenf(t, got, len(wantIDs),
-			"series %d value=%s: wrong doc count (got %v, want %v)", seriesID, value, got, wantIDs)
-		for _, id := range wantIDs {
-			_, present := got[id]
-			require.Truef(t, present, "series %d value=%s: missing elementID %d", seriesID, value, id)
-		}
+		eventuallyIdxTerm(t, idxPath, statusRID, seriesID, value, wantIDs)
 	}
 
 	// sourceA docs (written by byte-copy): aOk → status=ok, aErr → status=err.

--- a/docs/operation/lifecycle.md
+++ b/docs/operation/lifecycle.md
@@ -121,18 +121,74 @@ lifecycle \
 
 ### Command-Line Parameters
 
-| Parameter             | Description                                                                   | Default Value                  |
-| --------------------- | ----------------------------------------------------------------------------- | ------------------------------ |
-| `--node-labels`       | Labels of the current node (e.g., `type=hot,region=us-west`)                  | `nil`                          |
-| `--grpc-addr`         | gRPC address of the source data node to snapshot and read from                | `127.0.0.1:17912`              |
-| `--enable-tls`        | Enable TLS for gRPC connection                                                | `false`                        |
-| `--insecure`          | Skip server certificate verification                                          | `false`                        |
-| `--cert`              | Path to the gRPC server certificate                                           | `""`                           |
-| `--stream-root-path`  | Root directory for stream catalog snapshots                                   | `/tmp`                         |
-| `--measure-root-path` | Root directory for measure catalog snapshots                                  | `/tmp`                         |
-| `--trace-root-path`   | Root directory for trace catalog snapshots                                    | `/tmp`                         |
-| `--progress-file`     | File path used for progress tracking and crash recovery                       | `/tmp/lifecycle-progress.json` |
-| `--schedule`          | Schedule for periodic backup (e.g., @yearly, @monthly, @weekly, @daily, etc.) | `""`                           |
+| Parameter                           | Description                                                                                              | Default Value                  |
+|-------------------------------------|----------------------------------------------------------------------------------------------------------| ------------------------------ |
+| `--node-labels`                     | Labels of the current node (e.g., `type=hot,region=us-west`)                                             | `nil`                          |
+| `--grpc-addr`                       | gRPC address of the source data node to snapshot and read from                                           | `127.0.0.1:17912`              |
+| `--enable-tls`                      | Enable TLS for gRPC connection                                                                           | `false`                        |
+| `--insecure`                        | Skip server certificate verification                                                                     | `false`                        |
+| `--cert`                            | Path to the gRPC server certificate                                                                      | `""`                           |
+| `--stream-root-path`                | Root directory for stream catalog snapshots                                                              | `/tmp`                         |
+| `--measure-root-path`               | Root directory for measure catalog snapshots                                                             | `/tmp`                         |
+| `--trace-root-path`                 | Root directory for trace catalog snapshots                                                               | `/tmp`                         |
+| `--progress-file`                   | File path used for progress tracking and crash recovery                                                  | `/tmp/lifecycle-progress.json` |
+| `--schedule`                        | Schedule for periodic backup (e.g., @yearly, @monthly, @weekly, @daily, etc.)                            | `""`                           |
+| `--migration-orphan-policy`         | What to do with rows whose measure/stream schema was deleted from the registry: `archive` or `discard`   | `archive`                      |
+| `--migration-orphan-archive-subdir` | Relative subdirectory, under each catalog's root path, for archived orphan rows when policy is `archive` | `archive`                      |
+
+## Handling Orphan (Deleted-Schema) Data
+
+A source segment can hold data for a measure or stream whose schema was later deleted from the registry (for example, when the upstream metric definition is renamed or removed). Such rows can no longer be written to a target — their schema no longer exists — so the migration treats them as **orphan** rows.
+
+Orphan handling applies to the **measure** and **stream** catalogs only. Trace migration is not wired for per-series orphan handling: a trace group has a single schema, so a deleted trace schema is a whole-group concern rather than a per-series orphan within a surviving group.
+
+On the row-replay path (used when a source segment spans multiple target segments), the migration detects orphan rows, skips them so the rest of the group still migrates, and then — unlike rows skipped because of a series-index gap — lets the source segment be deleted normally. What happens to the orphan rows themselves is controlled by `--migration-orphan-policy`:
+
+- `archive` (default): each orphan row is written as one JSON line so an operator can recover it. The archive lives in the `--migration-orphan-archive-subdir` subdirectory **under each catalog's own root path** (so measure orphans land under `<measure-root-path>/<subdir>/…` and stream orphans under `<stream-root-path>/<subdir>/…`); the catalog is therefore not a path level (it is recorded inside every record and manifest instead). The per-part JSONL is **gzip-compressed** on disk (the rows are highly repetitive, so this is ~37× smaller — e.g. 269 MB of raw JSONL becomes ~7 MB). Files are laid out as:
+
+  ```
+  <catalog-root-path>/<subdir>/<group>/seg-<segment-suffix>/shard-<id>/part-<part-id>.jsonl.gz
+  <catalog-root-path>/<subdir>/<group>/seg-<segment-suffix>/manifest.json
+  ```
+
+  Each line is self-describing (decoded from the part's own column types, with no registry schema needed): it carries the group, catalog, the measure/stream name (always under the JSON key `measure`, regardless of catalog — the `catalog` field disambiguates), source location, series id, entity, timestamp (both RFC3339 `timestamp` and epoch-nanos `timestamp_unix_nano`), tags, and — for measures — `version`, `indexed_tags`, and `fields`; streams carry `element_id` instead of those three and omit `version` entirely (rather than emitting a misleading zero). The per-segment `manifest.json` (plain JSON) indexes which deleted measures/streams were archived and their row counts. A part with no orphan rows writes no file; re-running a part rewrites its file idempotently.
+- `discard`: orphan rows are dropped; nothing is written to disk.
+
+Orphan handling is **not** a migration error — the source segment is migrated and deleted normally. Instead of appearing in the report's `errors` buckets, it is summarized under an `orphans` section that records, per catalog → group → deleted measure/stream, how many rows were archived or discarded:
+
+```json
+"orphans": {
+  "policy": "archive",
+  "measure": { "sw_metricsHour": { "meter_..._hour": 1234 } },
+  "stream":  { "<group>": { "<stream>": 56 } }
+}
+```
+
+(The counts accumulate across resume cycles. If the process is hard-killed mid-group before the group finishes, that run's not-yet-flushed counts are lost from the report — the archive files and their `manifest.json` are unaffected.)
+
+### Reading the archive
+
+The `manifest.json` files are plain text — read them directly. The per-part data is gzip-compressed JSON Lines:
+
+```bash
+# inspect one part's rows (Linux: zcat; macOS: gzcat)
+gunzip -c <measure-root-path>/<subdir>/<group>/seg-20260601/shard-0/part-000000000000003b.jsonl.gz | jq .
+
+# project a few fields
+gunzip -c part-*.jsonl.gz | jq -c '{measure, ts:.timestamp, v:.fields.value.value}'
+
+# search without fully decompressing (Linux)
+zgrep "meter_banyandb_instance_disk_usage" part-*.jsonl.gz
+
+# what was archived for a segment (counts per deleted measure)
+jq '{total_rows, total_series, measures:[.measures[]|{measure,rows}]}' .../seg-20260601/manifest.json
+```
+
+**Limitations and operations notes:**
+
+- The archive lives under each catalog's own root path (`--measure-root-path` / `--stream-root-path`), so it shares the durability of the volume that already holds the catalog data — no separate path to provision. `--migration-orphan-archive-subdir` only changes the subdirectory name within that root.
+- Detection only happens on the row-replay path. On the chunk-sync path (a source segment that maps to a single target segment), whole part files are copied without per-row decoding, so orphan rows pass through to the target. They then occupy target-stage disk until that stage's TTL expires (e.g. up to the warm-stage TTL), and whether the copy succeeds depends on the receiver's part-acceptance behavior for a now-unregistered schema.
+- The archive directory is **not** cleaned up automatically. Prune it periodically once the data is no longer needed.
 
 ## Automatic Behavior on Warm and Cold Nodes
 

--- a/test/cases/lifecycle/orphan.go
+++ b/test/cases/lifecycle/orphan.go
@@ -1,0 +1,495 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package lifecycle_test
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	commonv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/common/v1"
+	databasev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
+	measurev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/measure/v1"
+	modelv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/model/v1"
+	streamv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/stream/v1"
+	"github.com/apache/skywalking-banyandb/banyand/backup/lifecycle"
+	"github.com/apache/skywalking-banyandb/pkg/grpchelper"
+	"github.com/apache/skywalking-banyandb/pkg/test/flags"
+)
+
+// orphanRec mirrors one archived JSONL line (the subset this suite asserts on).
+// The archive writer lives in banyand/backup/lifecycle (different package); this
+// is a read-side view of its self-describing record.
+type orphanRec struct {
+	Fields    map[string]orphanVal `json:"fields"`
+	Tags      map[string]orphanVal `json:"tags"`
+	Group     string               `json:"group"`
+	Catalog   string               `json:"catalog"`
+	Measure   string               `json:"measure"`
+	Timestamp string               `json:"timestamp"`
+	ElementID string               `json:"element_id"`
+	Entity    []string             `json:"entity"`
+	TimeNanos int64                `json:"timestamp_unix_nano"`
+	Version   int64                `json:"version"`
+}
+
+type orphanVal struct {
+	Value interface{} `json:"value"`
+	Type  string      `json:"type"`
+}
+
+type orphanManifest struct {
+	Measures []struct {
+		Measure string `json:"measure"`
+		Rows    int    `json:"rows"`
+	} `json:"measures"`
+	TotalRows int `json:"total_rows"`
+}
+
+// dayInterval/coprime grid clone of sw_cross_segment: a 2-day source segment
+// straddles the 3-day warm boundary, so crossSegmentTimestamps() lands rows on
+// the row-replay path — the only path where orphan archiving happens.
+func orphanStages() *commonv1.ResourceOpts {
+	return &commonv1.ResourceOpts{
+		ShardNum:        1,
+		SegmentInterval: &commonv1.IntervalRule{Unit: commonv1.IntervalRule_UNIT_DAY, Num: 2},
+		Ttl:             &commonv1.IntervalRule{Unit: commonv1.IntervalRule_UNIT_DAY, Num: 5},
+		Stages: []*commonv1.LifecycleStage{{
+			Name:            "warm",
+			ShardNum:        1,
+			SegmentInterval: &commonv1.IntervalRule{Unit: commonv1.IntervalRule_UNIT_DAY, Num: 3},
+			Ttl:             &commonv1.IntervalRule{Unit: commonv1.IntervalRule_UNIT_DAY, Num: 10},
+			NodeSelector:    "type=warm",
+		}},
+	}
+}
+
+// drainWriteResult closes a client-streaming write and returns an error on any
+// non-success ack or non-EOF stream error (the error-returning sibling of
+// drainWriteAcks, so the whole write can be retried under Eventually until a
+// freshly-created schema has propagated to the liaison).
+func drainWriteResult[R interface{ GetStatus() string }](recv func() (R, error), closeSend func() error) error {
+	if err := closeSend(); err != nil {
+		return err
+	}
+	for {
+		resp, recvErr := recv()
+		if errors.Is(recvErr, io.EOF) {
+			return nil
+		}
+		if recvErr != nil {
+			return recvErr
+		}
+		if s := resp.GetStatus(); s != "" && s != "STATUS_SUCCEED" {
+			return fmt.Errorf("write ack status: %s", s)
+		}
+	}
+}
+
+// runLifecycleMigrationWithArchive runs one real hot->warm lifecycle migration
+// (the actual lifecycle command) with the orphan archive policy enabled. archiveSubdir
+// is the relative subdir (under each catalog's root path) the archive lands in.
+func runLifecycleMigrationWithArchive(progressFile, reportDir, archiveSubdir string) {
+	lifecycleCmd := lifecycle.NewCommand()
+	args := []string{
+		"--grpc-addr", SharedContext.DataAddr,
+		"--stream-root-path", SharedContext.SrcDir,
+		"--measure-root-path", SharedContext.SrcDir,
+		"--trace-root-path", SharedContext.SrcDir,
+		"--progress-file", progressFile,
+		"--report-dir", reportDir,
+		"--migration-orphan-policy", "archive",
+		"--migration-orphan-archive-subdir", archiveSubdir,
+	}
+	args = append(args, SharedContext.MetadataFlags...)
+	lifecycleCmd.SetArgs(args)
+	gomega.Expect(lifecycleCmd.Execute()).To(gomega.Succeed())
+}
+
+// readOrphanArchive gunzips every part-*.jsonl.gz under groupArchiveDir (the
+// <catalog-root>/<subdir>/<group> directory) and returns the decoded records plus
+// the summed manifest row count.
+func readOrphanArchive(groupArchiveDir string) (recs []orphanRec, manifestRows int) {
+	root := groupArchiveDir
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		switch {
+		case strings.HasSuffix(d.Name(), ".jsonl.gz"):
+			f, openErr := os.Open(path)
+			gomega.Expect(openErr).NotTo(gomega.HaveOccurred())
+			defer f.Close()
+			gr, gzErr := gzip.NewReader(f)
+			gomega.Expect(gzErr).NotTo(gomega.HaveOccurred(), "archive file %s must be a valid gzip", path)
+			defer gr.Close()
+			data, readErr := io.ReadAll(gr)
+			gomega.Expect(readErr).NotTo(gomega.HaveOccurred())
+			dec := json.NewDecoder(bytes.NewReader(data))
+			for dec.More() {
+				var rec orphanRec
+				gomega.Expect(dec.Decode(&rec)).To(gomega.Succeed(), "archive line in %s must be valid JSON", path)
+				recs = append(recs, rec)
+			}
+		case d.Name() == "manifest.json":
+			raw, readErr := os.ReadFile(path)
+			gomega.Expect(readErr).NotTo(gomega.HaveOccurred())
+			var m orphanManifest
+			gomega.Expect(json.Unmarshal(raw, &m)).To(gomega.Succeed())
+			manifestRows += m.TotalRows
+		}
+		return nil
+	})
+	gomega.Expect(err).NotTo(gomega.HaveOccurred(), "walk archive dir %s", root)
+	return recs, manifestRows
+}
+
+var _ = ginkgo.Describe("Lifecycle orphan-schema archive", ginkgo.Ordered, func() {
+	ginkgo.It("measure: deleted-schema rows are archived + source removed; sibling measure migrates", func() {
+		const (
+			group       = "orphan_e2e_measure"
+			toDelete    = "orphan_deleted_measure"
+			keep        = "orphan_kept_measure"
+			leftValue   = int64(200)
+			rightValue  = int64(300)
+			keepLeftVal = int64(11)
+			keepRightV  = int64(22)
+		)
+		_, leftTS, rightTS := crossSegmentTimestamps()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+		conn, dialErr := grpchelper.Conn(SharedContext.LiaisonAddr, 10*time.Second,
+			grpc.WithTransportCredentials(insecure.NewCredentials()))
+		gomega.Expect(dialErr).NotTo(gomega.HaveOccurred())
+		defer func() { _ = conn.Close() }()
+		groupClient := databasev1.NewGroupRegistryServiceClient(conn)
+		measureReg := databasev1.NewMeasureRegistryServiceClient(conn)
+		writeClient := measurev1.NewMeasureServiceClient(conn)
+
+		ginkgo.By("creating group + two measures (one to delete, one to keep)")
+		_, err := groupClient.Create(ctx, &databasev1.GroupRegistryServiceCreateRequest{Group: &commonv1.Group{
+			Metadata: &commonv1.Metadata{Name: group}, Catalog: commonv1.Catalog_CATALOG_MEASURE, ResourceOpts: orphanStages(),
+		}})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		createMeasure := func(name string) {
+			_, cErr := measureReg.Create(ctx, &databasev1.MeasureRegistryServiceCreateRequest{Measure: &databasev1.Measure{
+				Metadata: &commonv1.Metadata{Name: name, Group: group},
+				Entity:   &databasev1.Entity{TagNames: []string{"id"}},
+				TagFamilies: []*databasev1.TagFamilySpec{{Name: "default", Tags: []*databasev1.TagSpec{
+					{Name: "id", Type: databasev1.TagType_TAG_TYPE_STRING},
+				}}},
+				Fields: []*databasev1.FieldSpec{{
+					Name: "value", FieldType: databasev1.FieldType_FIELD_TYPE_INT,
+					EncodingMethod: databasev1.EncodingMethod_ENCODING_METHOD_GORILLA, CompressionMethod: databasev1.CompressionMethod_COMPRESSION_METHOD_ZSTD,
+				}},
+			}})
+			gomega.Expect(cErr).NotTo(gomega.HaveOccurred())
+		}
+		createMeasure(toDelete)
+		createMeasure(keep)
+
+		ginkgo.By("writing rows on the straddling (row-replay) segment to both measures")
+		// The write goes through the liaison, which routes by schema. A freshly
+		// created measure reaches the liaison via schema sync slightly after the
+		// registry returns, so retry the whole write until the liaison has it; a
+		// not-yet-synced write is rejected at routing (nothing is stored), so the
+		// retry lands exactly the two rows once.
+		writeMeasure := func(name string, lv, rv int64) func() error {
+			return func() error {
+				ws, wErr := writeClient.Write(ctx)
+				if wErr != nil {
+					return wErr
+				}
+				send := func(ts time.Time, val int64, first bool) error {
+					req := &measurev1.WriteRequest{DataPoint: &measurev1.DataPointValue{
+						Timestamp: timestamppb.New(ts), Version: ts.UnixNano(),
+						TagFamilies: []*modelv1.TagFamilyForWrite{{Tags: []*modelv1.TagValue{
+							{Value: &modelv1.TagValue_Str{Str: &modelv1.Str{Value: "ent-1"}}},
+						}}},
+						Fields: []*modelv1.FieldValue{{Value: &modelv1.FieldValue_Int{Int: &modelv1.Int{Value: val}}}},
+					}, MessageId: uint64(time.Now().UnixNano())}
+					if first {
+						req.Metadata = &commonv1.Metadata{Group: group, Name: name}
+					}
+					return ws.Send(req)
+				}
+				if sendErr := send(leftTS, lv, true); sendErr != nil {
+					return sendErr
+				}
+				if sendErr := send(rightTS, rv, false); sendErr != nil {
+					return sendErr
+				}
+				return drainWriteResult(ws.Recv, ws.CloseSend)
+			}
+		}
+		gomega.Eventually(writeMeasure(toDelete, leftValue, rightValue), flags.EventuallyTimeout).Should(gomega.Succeed())
+		gomega.Eventually(writeMeasure(keep, keepLeftVal, keepRightV), flags.EventuallyTimeout).Should(gomega.Succeed())
+		time.Sleep(flags.ConsistentlyTimeout)
+
+		ginkgo.By("deleting the schema of " + toDelete + " (its on-disk data becomes orphan)")
+		_, delErr := measureReg.Delete(ctx, &databasev1.MeasureRegistryServiceDeleteRequest{Metadata: &commonv1.Metadata{Name: toDelete, Group: group}})
+		gomega.Expect(delErr).NotTo(gomega.HaveOccurred())
+
+		// Gate on the registry reflecting the intended post-delete state before
+		// migrating: the kept measure must be resolvable and the deleted one gone, so
+		// the migration's per-row schema lookup classifies each correctly (a not-yet-
+		// propagated kept schema would otherwise be misread as orphan).
+		ginkgo.By("waiting until the registry settles (kept measure resolvable, deleted measure gone)")
+		gomega.Eventually(func() error {
+			if _, e := measureReg.Get(ctx, &databasev1.MeasureRegistryServiceGetRequest{Metadata: &commonv1.Metadata{Name: keep, Group: group}}); e != nil {
+				return fmt.Errorf("kept measure %s not resolvable yet: %w", keep, e)
+			}
+			if _, e := measureReg.Get(ctx, &databasev1.MeasureRegistryServiceGetRequest{Metadata: &commonv1.Metadata{Name: toDelete, Group: group}}); e == nil {
+				return fmt.Errorf("deleted measure %s still resolvable", toDelete)
+			}
+			return nil
+		}, flags.EventuallyTimeout, time.Second).Should(gomega.Succeed())
+
+		ginkgo.By("running the real lifecycle migration with orphan archive enabled")
+		tmpDir, err := os.MkdirTemp("", "orphan-e2e-measure")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer os.RemoveAll(tmpDir)
+		// The archive lands in <measure-root-path>/<subdir>/<group>; the test points
+		// the measure root at SrcDir, so read it back from there.
+		const archiveSubdir = "orphan-archive"
+		groupArchiveDir := filepath.Join(SharedContext.SrcDir, archiveSubdir, group)
+		defer os.RemoveAll(groupArchiveDir)
+		runLifecycleMigrationWithArchive(filepath.Join(tmpDir, "progress.json"), filepath.Join(tmpDir, "report"), archiveSubdir)
+
+		ginkgo.By("verifying every archived record is correct and complete")
+		recs, manifestRows := readOrphanArchive(groupArchiveDir)
+		gomega.Expect(recs).To(gomega.HaveLen(2), "exactly the deleted measure's two rows must be archived")
+		gomega.Expect(manifestRows).To(gomega.Equal(2), "manifest total_rows must equal the archived rows")
+		gotValues := map[int64]bool{}
+		for _, r := range recs {
+			gomega.Expect(r.Measure).To(gomega.Equal(toDelete), "only the deleted measure may be archived")
+			gomega.Expect(r.Group).To(gomega.Equal(group))
+			gomega.Expect(r.Catalog).To(gomega.Equal("measure"))
+			gomega.Expect(r.Entity).To(gomega.ContainElement("ent-1"), "entity value must be preserved")
+			fv, ok := r.Fields["value"]
+			gomega.Expect(ok).To(gomega.BeTrue(), "archived measure record must carry its field")
+			gomega.Expect(fv.Type).To(gomega.Equal("INT64"))
+			gotValues[int64(fv.Value.(float64))] = true
+			gomega.Expect(r.Version).To(gomega.BeNumerically(">", 0))
+		}
+		gomega.Expect(gotValues).To(gomega.Equal(map[int64]bool{leftValue: true, rightValue: true}),
+			"archived field values must equal exactly what was written")
+
+		ginkgo.By("verifying the orphan source segment was deleted")
+		srcGroupRoot := filepath.Join(SharedContext.SrcDir, "measure", "data", group)
+		gomega.Eventually(func() bool { return noSegDirs(srcGroupRoot) }, flags.EventuallyTimeout).
+			Should(gomega.BeTrue(), "source segment(s) under %s must be deleted after migration", srcGroupRoot)
+
+		ginkgo.By("verifying the kept measure migrated and is queryable on the warm stage")
+		queryClient := measurev1.NewMeasureServiceClient(conn)
+		gomega.Eventually(func() error {
+			resp, qErr := queryClient.Query(ctx, &measurev1.QueryRequest{
+				Groups: []string{group}, Name: keep,
+				TimeRange:       &modelv1.TimeRange{Begin: timestamppb.New(leftTS.Add(-time.Hour)), End: timestamppb.New(rightTS.Add(time.Hour))},
+				TagProjection:   &modelv1.TagProjection{TagFamilies: []*modelv1.TagProjection_TagFamily{{Name: "default", Tags: []string{"id"}}}},
+				FieldProjection: &measurev1.QueryRequest_FieldProjection{Names: []string{"value"}},
+				Stages:          []string{"warm"}, Limit: 100,
+			})
+			if qErr != nil {
+				return qErr
+			}
+			if len(resp.DataPoints) != 2 {
+				return fmt.Errorf("want 2 kept rows on warm, got %d", len(resp.DataPoints))
+			}
+			return nil
+		}, flags.EventuallyTimeout).Should(gomega.Succeed())
+	})
+
+	ginkgo.It("stream: deleted-schema elements are archived + source removed; sibling stream migrates", func() {
+		const (
+			group    = "orphan_e2e_stream"
+			toDelete = "orphan_deleted_stream"
+			keep     = "orphan_kept_stream"
+		)
+		_, leftTS, rightTS := crossSegmentTimestamps()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+		conn, dialErr := grpchelper.Conn(SharedContext.LiaisonAddr, 10*time.Second,
+			grpc.WithTransportCredentials(insecure.NewCredentials()))
+		gomega.Expect(dialErr).NotTo(gomega.HaveOccurred())
+		defer func() { _ = conn.Close() }()
+		groupClient := databasev1.NewGroupRegistryServiceClient(conn)
+		streamReg := databasev1.NewStreamRegistryServiceClient(conn)
+		writeClient := streamv1.NewStreamServiceClient(conn)
+
+		ginkgo.By("creating group + two streams (one to delete, one to keep)")
+		_, err := groupClient.Create(ctx, &databasev1.GroupRegistryServiceCreateRequest{Group: &commonv1.Group{
+			Metadata: &commonv1.Metadata{Name: group}, Catalog: commonv1.Catalog_CATALOG_STREAM, ResourceOpts: orphanStages(),
+		}})
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		createStream := func(name string) {
+			_, cErr := streamReg.Create(ctx, &databasev1.StreamRegistryServiceCreateRequest{Stream: &databasev1.Stream{
+				Metadata: &commonv1.Metadata{Name: name, Group: group},
+				Entity:   &databasev1.Entity{TagNames: []string{"entity_id"}},
+				// "searchable" is the queryable/indexed tag family for streams. Mirror
+				// the proven cross_segment_log shape: a non-entity tag (business_id)
+				// alongside the entity tag (entity_id), so time-range queries resolve.
+				TagFamilies: []*databasev1.TagFamilySpec{{Name: "searchable", Tags: []*databasev1.TagSpec{
+					{Name: "business_id", Type: databasev1.TagType_TAG_TYPE_STRING},
+					{Name: "entity_id", Type: databasev1.TagType_TAG_TYPE_STRING},
+				}}},
+			}})
+			gomega.Expect(cErr).NotTo(gomega.HaveOccurred())
+		}
+		createStream(toDelete)
+		createStream(keep)
+
+		ginkgo.By("writing elements on the straddling (row-replay) segment to both streams")
+		// Retry the whole write until the liaison has synced the freshly created
+		// stream schema (see the measure case for the rationale).
+		writeStream := func(name string) func() error {
+			return func() error {
+				ws, wErr := writeClient.Write(ctx)
+				if wErr != nil {
+					return wErr
+				}
+				send := func(ts time.Time, eid, biz, entity string, first bool) error {
+					req := &streamv1.WriteRequest{Element: &streamv1.ElementValue{
+						ElementId: eid, Timestamp: timestamppb.New(ts),
+						TagFamilies: []*modelv1.TagFamilyForWrite{{Tags: []*modelv1.TagValue{
+							{Value: &modelv1.TagValue_Str{Str: &modelv1.Str{Value: biz}}},
+							{Value: &modelv1.TagValue_Str{Str: &modelv1.Str{Value: entity}}},
+						}}},
+					}, MessageId: uint64(time.Now().UnixNano())}
+					if first {
+						req.Metadata = &commonv1.Metadata{Group: group, Name: name}
+					}
+					return ws.Send(req)
+				}
+				if sendErr := send(leftTS, name+"-L", "biz-1", "ent-L", true); sendErr != nil {
+					return sendErr
+				}
+				if sendErr := send(rightTS, name+"-R", "biz-1", "ent-R", false); sendErr != nil {
+					return sendErr
+				}
+				return drainWriteResult(ws.Recv, ws.CloseSend)
+			}
+		}
+		gomega.Eventually(writeStream(toDelete), flags.EventuallyTimeout).Should(gomega.Succeed())
+		gomega.Eventually(writeStream(keep), flags.EventuallyTimeout).Should(gomega.Succeed())
+		time.Sleep(flags.ConsistentlyTimeout)
+
+		ginkgo.By("deleting the schema of " + toDelete)
+		_, delErr := streamReg.Delete(ctx, &databasev1.StreamRegistryServiceDeleteRequest{Metadata: &commonv1.Metadata{Name: toDelete, Group: group}})
+		gomega.Expect(delErr).NotTo(gomega.HaveOccurred())
+
+		// Gate on the registry reflecting the intended post-delete state before
+		// migrating: the kept stream must be resolvable and the deleted one gone, so
+		// the migration's per-row schema lookup classifies each correctly (a not-yet-
+		// propagated kept schema would otherwise be misread as orphan).
+		ginkgo.By("waiting until the registry settles (kept stream resolvable, deleted stream gone)")
+		gomega.Eventually(func() error {
+			if _, e := streamReg.Get(ctx, &databasev1.StreamRegistryServiceGetRequest{Metadata: &commonv1.Metadata{Name: keep, Group: group}}); e != nil {
+				return fmt.Errorf("kept stream %s not resolvable yet: %w", keep, e)
+			}
+			if _, e := streamReg.Get(ctx, &databasev1.StreamRegistryServiceGetRequest{Metadata: &commonv1.Metadata{Name: toDelete, Group: group}}); e == nil {
+				return fmt.Errorf("deleted stream %s still resolvable", toDelete)
+			}
+			return nil
+		}, flags.EventuallyTimeout, time.Second).Should(gomega.Succeed())
+
+		ginkgo.By("running the real lifecycle migration with orphan archive enabled")
+		tmpDir, err := os.MkdirTemp("", "orphan-e2e-stream")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		defer os.RemoveAll(tmpDir)
+		// The archive lands in <stream-root-path>/<subdir>/<group>; the test points
+		// the stream root at SrcDir, so read it back from there.
+		const archiveSubdir = "orphan-archive"
+		groupArchiveDir := filepath.Join(SharedContext.SrcDir, archiveSubdir, group)
+		defer os.RemoveAll(groupArchiveDir)
+		runLifecycleMigrationWithArchive(filepath.Join(tmpDir, "progress.json"), filepath.Join(tmpDir, "report"), archiveSubdir)
+
+		ginkgo.By("verifying every archived stream record is correct (element_id present, no fields)")
+		recs, manifestRows := readOrphanArchive(groupArchiveDir)
+		gomega.Expect(recs).To(gomega.HaveLen(2))
+		gomega.Expect(manifestRows).To(gomega.Equal(2))
+		for _, r := range recs {
+			gomega.Expect(r.Measure).To(gomega.Equal(toDelete), "only the deleted stream may be archived")
+			gomega.Expect(r.Group).To(gomega.Equal(group))
+			gomega.Expect(r.Catalog).To(gomega.Equal("stream"))
+			gomega.Expect(r.ElementID).NotTo(gomega.BeEmpty(), "stream archive record must carry element_id")
+			gomega.Expect(r.Fields).To(gomega.BeEmpty(), "stream archive record must not carry fields")
+		}
+
+		ginkgo.By("verifying the orphan source segment was deleted")
+		srcGroupRoot := filepath.Join(SharedContext.SrcDir, "stream", "data", group)
+		gomega.Eventually(func() bool { return noSegDirs(srcGroupRoot) }, flags.EventuallyTimeout).
+			Should(gomega.BeTrue(), "source segment(s) under %s must be deleted after migration", srcGroupRoot)
+
+		ginkgo.By("verifying the kept stream migrated and is queryable on the warm stage")
+		queryClient := streamv1.NewStreamServiceClient(conn)
+		gomega.Eventually(func() error {
+			resp, qErr := queryClient.Query(ctx, &streamv1.QueryRequest{
+				Groups: []string{group}, Name: keep,
+				TimeRange:  &modelv1.TimeRange{Begin: timestamppb.New(leftTS.Add(-time.Hour)), End: timestamppb.New(rightTS.Add(time.Hour))},
+				Projection: &modelv1.TagProjection{TagFamilies: []*modelv1.TagProjection_TagFamily{{Name: "searchable", Tags: []string{"business_id", "entity_id"}}}},
+				// OrderBy with no index-rule name + SORT_UNSPECIFIED means "by event
+				// time"; stream queries need it to select the time index.
+				OrderBy: &modelv1.QueryOrder{Sort: modelv1.Sort_SORT_UNSPECIFIED},
+				Stages:  []string{"warm"},
+			})
+			if qErr != nil {
+				return qErr
+			}
+			if len(resp.Elements) != 2 {
+				return fmt.Errorf("want 2 kept elements on warm, got %d", len(resp.Elements))
+			}
+			return nil
+		}, flags.EventuallyTimeout).Should(gomega.Succeed())
+	})
+})
+
+// noSegDirs reports whether root has no seg-* directories left (only a lock file
+// or nothing), i.e. the migration deleted the source segment(s).
+func noSegDirs(root string) bool {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return true // group dir gone entirely is also "deleted"
+	}
+	for _, e := range entries {
+		if e.IsDir() && strings.HasPrefix(e.Name(), "seg-") {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

During lifecycle tier migration (hot → warm → cold), the migration re-resolves every row's measure/stream schema from the registry to rebuild its write request. If that schema was **deleted from the registry** — for example when an upstream OAP metric is renamed or removed — the row can no longer be written to any target, and the migration previously **aborted the whole group**: the healthy data in that group never moved forward either.

This PR makes those **orphan** rows non-fatal. The migration now detects a row whose schema is gone, skips it so the rest of the group still migrates, and — by default — **archives** the row to a self-describing file so an operator can still recover it. The orphan policy is configurable: `archive` (default) keeps the data, `discard` drops it.

## Motivation

A real production migration failed with:

```
measure schema sw_metricsHour/meter_banyandb_instance_disk_usage_all_hour not found in group snapshot
```

The metric had been renamed upstream and its schema removed from the registry, but its on-disk data still lived in a source segment. Rather than moving the rest of the (healthy) group forward, the migration aborted the entire group. Orphan handling turns this localized, expected condition into a recoverable, observable event instead of a hard stop.

## What changed

### Detection

- A row whose schema is absent from the registry is classified as an orphan (`errOrphanSchema`):
  - **Measure**: the replayer pre-fetches all measure schemas once at construction (`ListMeasure`); a name missing from that consistent snapshot is an orphan.
  - **Stream**: `loadSchema` resolves per subject via `GetStream`; only a genuine `schema.ErrGRPCResourceNotFound` is treated as orphan. **Any other error (network, closed registry, context cancellation) stays fatal**, so a transient registry failure is never mistaken for a droppable orphan.
- Orphan skips and series-index-gap skips (`errSkipSeries`) are distinct, mutually-exclusive sentinels routed via a `skipError.kind`, and are tallied in separate counters.

### Policy: `--migration-orphan-policy` (`archive` | `discard`, default `archive`)

- **`archive`**: each orphan row is written as one JSON line, **self-describing** — decoded from the part's own column types with no registry schema needed. It carries the group, catalog, measure/stream name, source location (stage/segment/shard/part), series id, entity, timestamp (RFC3339 + epoch-nanos), tags, and — for measures — `version`, `indexed_tags`, and `fields`; streams carry `element_id` instead and omit `version`. Per-part JSONL is **gzip-compressed** on disk (highly repetitive rows compress ~37×). A per-segment `manifest.json` indexes which deleted subjects were archived and their row counts; it is written atomically (write-tmp + rename) so a crash never leaves a truncated manifest. Re-replaying a part rewrites its file idempotently (no double-counting on resume).
- **`discard`**: orphan rows are dropped and surfaced only in the report; nothing is written to disk.

### Archive location: `--migration-orphan-archive-subdir` (relative, default `archive`)

The archive lives in a **relative subdirectory under each catalog's own root path**, not a separate absolute directory:

```
<catalog-root-path>/<subdir>/<group>/seg-<segment-suffix>/shard-<id>/part-<part-id>.jsonl.gz
<catalog-root-path>/<subdir>/<group>/seg-<segment-suffix>/manifest.json
```

So measure orphans land under `<measure-root-path>/archive/...` and stream orphans under `<stream-root-path>/archive/...`. The catalog is **not** a path level (it is recorded inside every record and manifest instead). This means the archive shares the durability of the volume that already holds the catalog data — no separate path to provision, and no ephemeral `/tmp` default. The flag must be relative (validated at startup).

### Source-segment retention decoupling

The migration deletes source segments after a successful run. This PR separates two skip reasons:

- **series-index gap** (`errSkipSeries`): a series could not be resolved/rebuilt, so its rows remain **only** in the source — the source segment is **retained** (excluded from the post-migration delete set) to avoid permanent data loss.
- **orphan** (`errOrphanSchema`): the rows are archived (or discarded) and the schema is gone, so the source segment is **deleted normally**.

`excludeRetainedSuffixes` removes the retained segment suffixes from the delete candidate list at the end of migration.

### Reporting

Orphan handling is **expected behavior, not a migration error**. Instead of polluting the report's `errors` buckets (and inflating part-error counts), the migration report now carries a dedicated `orphans` section:

```json
"orphans": {
  "policy": "archive",
  "measure": { "sw_metricsHour": { "meter_..._hour": 1234 } },
  "stream":  { "<group>": { "<stream>": 56 } }
}
```

Counts are tracked per deleted subject, persisted in progress, and accumulate across resume cycles.

### Safety

- A failed archive write under the `archive` policy is **fatal**: the part aborts, the source segment is retained, and resume retries the whole part. An orphan row is never silently dropped due to an archive I/O error.
- **Trace is not covered**: a trace group has a single schema, so a deleted trace schema is a whole-group concern rather than a per-series orphan within a surviving group.

## Configuration

| Flag | Description | Default |
| --- | --- | --- |
| `--migration-orphan-policy` | What to do with rows whose schema was deleted from the registry: `archive` or `discard` | `archive` |
| `--migration-orphan-archive-subdir` | Relative subdirectory, under each catalog's root path, where orphan rows are archived when policy is `archive` | `archive` |

## Reading the archive

The `manifest.json` files are plain text. The per-part data is gzip-compressed JSON Lines:

```bash
# inspect one part's rows (Linux: zcat; macOS: gzcat)
gunzip -c <measure-root-path>/archive/<group>/seg-20260601/shard-0/part-000000000000003b.jsonl.gz | jq .

# what was archived for a segment (counts per deleted subject)
jq '{total_rows, total_series, measures:[.measures[]|{measure,rows}]}' .../seg-20260601/manifest.json
```

## Testing

**Unit tests** (`banyand/backup/lifecycle`):

- Archive write + gzip round-trip + manifest tallies (rows, distinct-series union across parts).
- Idempotent resume (re-replay rewrites the part file and does not double-count).
- `discard` policy writes nothing to disk.
- Archive write/open failure is fatal and retains the source segment.
- Orphan vs sidx-gap counter separation; per-subject orphan counts.
- **Transient registry error is NOT classified as orphan** (stream) — guards the data-loss boundary.
- Report `orphans` section shape and `Progress.AddOrphanRows` aggregation.
- Path layout (`<root>/<group>/seg-.../...`, no catalog level).

**Distributed e2e** (`test/cases/lifecycle/orphan.go`, measure + stream):

Runs the real lifecycle command with the archive policy on the distributed lifecycle cluster. Each spec creates a group with two resources (one to delete, one to keep), writes rows that straddle the segment boundary, deletes one schema, runs the migration, then asserts:

1. every archived record is correct (measure carries `fields`; stream carries `element_id` and no fields), and the manifest row count matches;
2. the orphan source segment is deleted;
3. the kept resource migrated and is queryable on the warm stage.

A pre-migration registry-settle gate (poll until the kept resource is resolvable and the deleted one is gone) avoids a flaky race where a not-yet-propagated kept schema could be misread as orphan.

## Limitations and operations notes

- The archive directory is **not** cleaned up automatically; prune it once the data is no longer needed.

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Fixes apache/skywalking#<issue number>.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking-banyandb/blob/main/CHANGES.md).
