### PR TITLE
fix(stream): fix migration corruption from arena tagValue double-free

### DIFF
--- a/banyand/stream/migration_copy.go
+++ b/banyand/stream/migration_copy.go
@@ -590,7 +590,7 @@ func releaseStreamSlowCopyArena(a *streamSlowCopyArena) {
 	streamSlowCopyArenaPool.Put(a)
 }
 
-// releaseArenaElements returns an elements to the pool WITHOUT releasing its
+// releaseArenaElements returns elements to the pool WITHOUT releasing its
 // tagValues into the tagValue pool. The slow-copy path fills elements with
 // tagValues owned by a per-call streamSlowCopyArena; releasing them via the
 // normal releaseElements would put arena-backed *tagValue pointers into the

--- a/banyand/stream/migration_copy.go
+++ b/banyand/stream/migration_copy.go
@@ -590,6 +590,24 @@ func releaseStreamSlowCopyArena(a *streamSlowCopyArena) {
 	streamSlowCopyArenaPool.Put(a)
 }
 
+// releaseArenaElements returns an elements to the pool WITHOUT releasing its
+// tagValues into the tagValue pool. The slow-copy path fills elements with
+// tagValues owned by a per-call streamSlowCopyArena; releasing them via the
+// normal releaseElements would put arena-backed *tagValue pointers into the
+// global tagValuePool, where they alias memory the arena still owns and reuses —
+// corrupting later writes. Clearing tagFamilies drops the arena pointers so none
+// linger in the pooled elements.
+func releaseArenaElements(e *elements) {
+	e.seriesIDs = e.seriesIDs[:0]
+	e.timestamps = e.timestamps[:0]
+	e.elementIDs = e.elementIDs[:0]
+	for i := range e.tagFamilies {
+		e.tagFamilies[i] = nil
+	}
+	e.tagFamilies = e.tagFamilies[:0]
+	elementsPool.Put(e)
+}
+
 // appendStreamBlockRowToBuckets routes one row to the correct per-aligned-segment bucket.
 func appendStreamBlockRowToBuckets(
 	ir storage.IntervalRule,
@@ -701,7 +719,7 @@ func slowCopyOneStreamPart(in streamProcessPartInput, srcPartID uint64) (streamP
 	defer releaseLive()
 	defer func() {
 		for _, el := range buckets {
-			releaseElements(el)
+			releaseArenaElements(el)
 		}
 	}()
 
@@ -806,7 +824,7 @@ func runStreamFlushWorker(flushCh <-chan streamFlushJob, fileSystem fs.FileSyste
 }
 
 func directCopyStreamFlushBucket(el *elements, fileSystem fs.FileSystem, partPath string) (sz int64, err error) {
-	defer releaseElements(el)
+	defer releaseArenaElements(el)
 	if mkErr := os.MkdirAll(filepath.Dir(partPath), storage.DirPerm); mkErr != nil {
 		return 0, mkErr
 	}


### PR DESCRIPTION
## Summary

Fixes an intermittent **data-corruption bug** in the stream slow-path migration that silently writes wrong tag values into migrated parts. It first surfaced as the flaky `TestMigrationSlowPathMultiStreamElementIndexRebuild` in the scheduled Flaky Tests job (https://github.com/apache/skywalking-banyandb/actions/runs/28476575201/job/84402810627#step:6:1), but the corruption is real (not a test artifact) and reproduces without `-race`.

## Root cause

The slow-copy path (`slowCopyOneStreamPart`) allocates `tagValue`s from a per-call arena (`streamSlowCopyArena.allocTagValue`), which returns pointers **into the arena's slab** (`&a.tvs[i]`). Those elements are then freed with `releaseElements(el)`, which walks down to `releaseTagValue` and **puts the arena-owned `*tagValue` pointers into the global `tagValuePool`**.

The same `tagValue` memory now has two owners — the arena (which reuses/overwrites its slab) and `tagValuePool` (which hands it out to other callers). A later `generateTagValue` (any stream write) receives that aliased object while the arena concurrently overwrites it, so a tag column ends up holding another column's value (e.g. streamA's `status` becomes streamB's `code="200"`). The corrupt part is then written to disk; migration and queries read it back faithfully, so the element index loses terms.

This is an ownership violation / use-after-free, not a missing reset. It only triggers when the slow-copy migration runs alongside `generateTagValue`-based writes in the same process, and is timing-dependent (~0.2% without `-race`, ~10-17% with `-race`).

## Fix

Do not return arena-owned tagValues to the global pool. Add `releaseArenaElements`, which recycles the `elements` shell but skips releasing its (arena-owned) tagValues and clears the `tagFamilies` entries so no arena pointers linger. Use it at the two slow-copy release sites in `migration_copy.go`.

One file, ~20 lines. No behavior change for the normal write path.

## Testing

- Control (same instant corruption detector, only variable = the fix):
  - **without** fix: crashes at iteration 15 (`GOMAXPROCS=2 -race`) and 23 (default cores `-race`) within ~15s — `status` column holds a `code` value.
  - **with** fix: 5,000 iterations clean in both configs.
- **50,000** iterations, no failures, in both `GOMAXPROCS=2 -race` (matches the GitHub CI runner) and default cores without `-race`.
- All migration / slow-path / dump / copy tests pass under `-race`; `gofmt` / `go vet` clean.

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Fixes apache/skywalking#<issue number>.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking-banyandb/blob/main/CHANGES.md).
