### PR TITLE
feat(trace): package sampler plugins into mountable images and add a plugin dev toolkit

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,32 @@
+# Licensed to Apache Software Foundation (ASF) under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Apache Software Foundation (ASF) licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# This file applies to EVERY docker build whose context is the repo root:
+# banyand/Dockerfile's "-plugins" builder stages (COPY --from=reporoot .),
+# AND test/docker/Dockerfile (built with context ../../ by test/docker/Makefile
+# and .github/actions/build-docker-image). It therefore must NOT exclude the
+# release-output directories that test/docker COPYs
+# (banyand/build/bin/..., bydbctl/build/bin/...) — doing so silently breaks
+# the DEFAULT publish path. We only trim what no build context needs: the git
+# history, JS dependency trees, and local caches/logs.
+
+.git
+**/node_modules
+canopy/dist
+**/*.log
+**/.gocache
+**/.gomodcache

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -65,13 +65,45 @@ jobs:
       - name: Build Linux binaries
         run: |
           TARGET_OS=linux PLATFORMS=linux/amd64,linux/arm64 make release
+      # Regression gate (Critic Major #2 / plugin-packaging DD6): the default
+      # banyand-server binary must stay CGO_ENABLED=0 and statically linked —
+      # a Go plugin host requires CGO+dynamic linking, so any accidental drift
+      # here would silently make the default image plugin-hostable (a
+      # supply-chain/size/CVE-surface regression) or, worse, break the
+      # "default path 100% intact" invariant the -plugins variant depends on.
+      # Checked on the raw cross-compiled binaries (before dockerizing) with
+      # `file`, since the runtime busybox:stable-glibc image intentionally
+      # carries no `file`/`ldd` to inspect itself with.
+      - name: Assert default banyand-server binaries are static (no CGO)
+        run: |
+          set -e
+          for arch in amd64 arm64; do
+            for variant in static slim; do
+              bin="banyand/build/bin/linux/${arch}/banyand-server-${variant}"
+              echo "Checking $bin"
+              # Fail if the expected binary is missing, so a moved/renamed
+              # output path can never make this gate pass vacuously.
+              test -f "$bin" || { echo "FAIL: expected release binary $bin not found" >&2; exit 1; }
+              desc=$(file "$bin")
+              echo "$desc"
+              if echo "$desc" | grep -qi "dynamically linked"; then
+                echo "FAIL: $bin is dynamically linked; the default/slim images must stay CGO_ENABLED=0 static" >&2
+                exit 1
+              fi
+              # Assert the positive too: the binary must actually report as static.
+              if ! echo "$desc" | grep -qi "statically linked"; then
+                echo "FAIL: $bin does not report as statically linked; got: $desc" >&2
+                exit 1
+              fi
+            done
+          done
       - name: Build docker image
         if: github.ref != 'refs/heads/main' # Only build docker image on PR(Push image when pushed to main branch)
         run: |
           make docker.build || make docker.build
           BINARYTYPE=slim make -C banyand docker || BINARYTYPE=slim make -C banyand docker
           make -C test/docker build || make -C test/docker build
-          make -C mcp docker || make -C mcp docker 
+          make -C mcp docker || make -C mcp docker
           docker image ls
       - name: Log in to the Container registry
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
@@ -86,3 +118,91 @@ jobs:
           PLATFORMS=linux/amd64,linux/arm64 make docker.push || PLATFORMS=linux/amd64,linux/arm64 make docker.push
           PLATFORMS=linux/amd64,linux/arm64 BINARYTYPE=slim make -C banyand docker.push || PLATFORMS=linux/amd64,linux/arm64 BINARYTYPE=slim make -C banyand docker.push
           make -C test/docker push || make -C test/docker push
+
+  # push-banyandb-plugins-image builds/pushes BOTH plugin images at the SAME
+  # <sha> tag (plan DD2/DD6; see docs/operation/plugins.md):
+  #   - skywalking-banyandb:<sha>-plugins          (CGO host image, final-plugins stage)
+  #   - skywalking-banyandb:<sha>-plugins-carrier  (carrier image, final-carrier stage)
+  # Same repo, distinguished by tag suffix. They MUST ship together: the carrier
+  # .so is loaded by the host
+  # binary via plugin.Open, which demands exact toolchain parity — guaranteed
+  # here because both come from one build-plugins-base at one commit in one CI
+  # run. It is a SEPARATE job — not a step bolted onto push-banyandb-image —
+  # deliberately: this build is slower (a from-source CGO compile inside the
+  # Dockerfile, arm64 under QEMU emulation) and must never be able to fail or
+  # time out the default image publish (Critic Major #2). It has NO
+  # `needs:`/artifact dependency on push-banyandb-image: it checks out and
+  # compiles from source independently, so the two jobs' failure domains are
+  # fully isolated.
+  #
+  # timeout-minutes: 180 is an ESTIMATE, not a measured figure — the
+  # arm64-under-QEMU CGO compile time has not yet been observed on CI hardware.
+  # If it proves too slow to fit this budget, the plan's DD3 escape hatch is to
+  # switch the arm64 build to a cross-CGO toolchain (install
+  # gcc-aarch64-linux-gnu and set CC/CXX per GOARCH in the builder stage) —
+  # a same-artifact swap, not a scope change. Revisit this number after the
+  # first real arm64 run.
+  push-banyandb-plugins-image:
+    if: github.repository == 'apache/skywalking-banyandb'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    timeout-minutes: 180
+    env:
+      TAG: ${{ github.sha }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+      - name: Setup build environment
+        uses: ./.github/actions/setup-build-env
+        with:
+          download-artifacts: 'false'
+          setup-docker: 'true'
+      - name: Cache Tools
+        uses: actions/cache@v4
+        id: cache-tool
+        with:
+          path: bin
+          key: ${{ runner.os }}-build-tool-${{ hashFiles('**version.mk') }}
+      - name: Generate codes
+        run: make generate
+      # The -plugins HOST Dockerfile builder stage COPYs the full source tree
+      # (via the named build context "reporoot") and compiles banyand-server
+      # with CGO_ENABLED=1; the carrier builder stage compiles every
+      # plugins/*.so the same way. `make release` here only supplies the FOUR
+      # companion binaries (backup/restore/lifecycle/migration) that don't host
+      # plugins and stay plain CGO_ENABLED=0 static, reused unmodified from
+      # banyand/Dockerfile's default path (host image only).
+      - name: Build companion binaries (backup/restore/lifecycle/migration)
+        run: |
+          # download-artifacts:false above, so the prebuilt ui/dist artifact is
+          # absent and `make release` would fail compiling the UI-embedding
+          # banyand-server-static (ui/embed.go `//go:embed dist`). This job needs
+          # only the non-UI companion binaries; the -plugins host is built
+          # slim/no-UI inside Docker. Stub ui/dist (same placeholder the -plugins
+          # Docker builder stage uses) so the release build compiles.
+          mkdir -p ui/dist && touch ui/dist/index.html
+          TARGET_OS=linux PLATFORMS=linux/amd64,linux/arm64 make release
+      - name: Build plugin images (host + carrier)
+        if: github.ref != 'refs/heads/main' # Only build on PR; push when merged to main
+        run: |
+          BINARYTYPE=plugins make -C banyand docker || BINARYTYPE=plugins make -C banyand docker
+          make -C banyand docker.plugins-carrier || make -C banyand docker.plugins-carrier
+          docker image ls
+      - name: Log in to the Container registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
+        if: github.ref == 'refs/heads/main'
+        with:
+          registry: ${{ env.HUB }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push plugin images (host + carrier, same <sha> tag)
+        if: github.ref == 'refs/heads/main'
+        run: |
+          PLATFORMS=linux/amd64,linux/arm64 BINARYTYPE=plugins make -C banyand docker.push || \
+            PLATFORMS=linux/amd64,linux/arm64 BINARYTYPE=plugins make -C banyand docker.push
+          PLATFORMS=linux/amd64,linux/arm64 make -C banyand docker.plugins-carrier.push || \
+            PLATFORMS=linux/amd64,linux/arm64 make -C banyand docker.plugins-carrier.push

--- a/.github/workflows/test-plugin-sidecar-e2e.yml
+++ b/.github/workflows/test-plugin-sidecar-e2e.yml
@@ -1,0 +1,113 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Plugin Sidecar E2E (Kind)
+
+# Self-contained, isolated job (like the plugins publish job in
+# publish-docker.yml): triggers on its own on PRs/pushes that touch plugin
+# packaging paths, with no dependency on the main CI orchestrator. Path
+# filters keep it off unrelated changes; workflow_dispatch allows manual runs.
+on:
+  pull_request:
+    paths:
+      - 'plugins/**'
+      - 'pkg/pipeline/sdk/**'
+      - 'banyand/trace/**'
+      - 'banyand/Dockerfile'
+      - 'scripts/build/docker.mk'
+      - 'test/plugin-sidecar/**'
+      - '.github/workflows/test-plugin-sidecar-e2e.yml'
+  push:
+    branches:
+      - main
+  workflow_dispatch: {}
+
+jobs:
+  # Isolated kind gate proving the CGO "-plugins" host image + carrier-mount
+  # design works in real Kubernetes (assertions a/b/c in test/plugin-sidecar).
+  # It builds BOTH plugin images itself (CGO from source in-Dockerfile), so it
+  # has no artifact dependency on the publish job — its own failure domain,
+  # like the plugins publish job.
+  plugin-sidecar-kind:
+    # amd64 runs natively on ubuntu-latest; arm64 on GitHub's native arm64
+    # runner (ubuntu-24.04-arm). arm64 cannot be validated locally, so CI is the
+    # only place the arm64 CGO host + arm64 .so plugin.Open parity is exercised.
+    # fail-fast:false so one arch's result never cancels the other.
+    if: github.repository == 'apache/skywalking-banyandb'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+
+      - name: Setup build environment
+        uses: ./.github/actions/setup-build-env
+        with:
+          download-artifacts: 'false'
+          setup-docker: 'true'
+
+      - name: Install kubectl
+        run: |
+          mkdir -p "${HOME}/.local/bin"
+          # arch-aware download (the shared install-kubectl.sh hardcodes linux/amd64).
+          curl -fsSL -o "${HOME}/.local/bin/kubectl" \
+            "https://dl.k8s.io/release/v1.30.0/bin/linux/${{ matrix.arch }}/kubectl"
+          chmod +x "${HOME}/.local/bin/kubectl"
+          echo "${HOME}/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Install kind
+        run: |
+          mkdir -p "${HOME}/.local/bin"
+          curl -fsSL -o "${RUNNER_TEMP}/kind" "https://kind.sigs.k8s.io/dl/v0.23.0/kind-linux-${{ matrix.arch }}"
+          install -m 0755 "${RUNNER_TEMP}/kind" "${HOME}/.local/bin/kind"
+          echo "${HOME}/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Generate codes
+        run: make generate
+
+      - name: Build companion static binaries
+        run: |
+          # This job runs setup-build-env with download-artifacts:false, so the
+          # prebuilt ui/dist artifact (from prepare.yml) is absent. `make release`
+          # builds banyand-server-static, whose ui/embed.go `//go:embed dist`
+          # then fails ("pattern dist: no matching files found"). The kind gate
+          # needs only the NON-UI companion binaries (backup/restore/lifecycle/
+          # migration); the -plugins host is built slim/no-UI inside Docker.
+          # Stub ui/dist (the same placeholder build-trace-pipeline-server and the
+          # -plugins Docker builder stage use) so the UI-embedding server compiles;
+          # that binary is unused by the -plugins image and never ships.
+          mkdir -p ui/dist && touch ui/dist/index.html
+          TARGET_OS=linux PLATFORMS=linux/${{ matrix.arch }} make -C banyand release
+
+      - name: Build plugin host + carrier images (${{ matrix.arch }})
+        run: |
+          PLATFORMS=linux/${{ matrix.arch }} BINARYTYPE=plugins make -C banyand docker
+          PLATFORMS=linux/${{ matrix.arch }} make -C banyand docker.plugins-carrier
+          docker image ls | grep -E 'skywalking-banyandb(-plugins)?' || true
+
+      - name: Run plugin-sidecar ship gate
+        run: |
+          SKIP_BUILD=true make -C test/plugin-sidecar e2e-plugin-sidecar

--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,23 @@ build-trace-pipeline-telemetry-plugins: ## Build telemetrysampler.so and faultys
 		./test/plugins/_faultysampler
 	@echo "Built $(PLUGIN_OUTPUT_DIR)/faultysampler.so"
 
+.PHONY: build-plugins
+build-plugins: ## Build every plugins/<vendor>/<name> sampler into $(PLUGIN_OUTPUT_DIR) (Linux/macOS only; requires a C toolchain)
+	@if ! command -v gcc > /dev/null 2>&1 && ! command -v clang > /dev/null 2>&1; then \
+		echo "ERROR: build-plugins requires a C toolchain (gcc or clang) but neither was found in PATH."; \
+		exit 1; \
+	fi
+	@mkdir -p $(PLUGIN_OUTPUT_DIR)
+	@set -e; for dir in plugins/*/*/; do \
+		[ -f "$$dir/main.go" ] || continue; \
+		name=$$(basename "$$dir"); \
+		echo "Building $(PLUGIN_OUTPUT_DIR)/$$name.so from $$dir"; \
+		CGO_ENABLED=1 go build -buildmode=plugin -trimpath \
+			-o $(PLUGIN_OUTPUT_DIR)/$$name.so \
+			./$$dir; \
+	done
+	@echo "Built plugins into $(PLUGIN_OUTPUT_DIR)"
+
 .PHONY: build-trace-pipeline-server
 build-trace-pipeline-server: ## Build banyand-server with explicit CGO_ENABLED=1 for plugin hosting (Linux/macOS only)
 	@if ! command -v gcc > /dev/null 2>&1 && ! command -v clang > /dev/null 2>&1; then \

--- a/banyand/Dockerfile
+++ b/banyand/Dockerfile
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 FROM alpine:edge AS certs
 RUN apk add --no-cache ca-certificates && update-ca-certificates
 
@@ -41,3 +40,171 @@ EXPOSE 6060
 EXPOSE 2121
 
 ENTRYPOINT ["/banyand"]
+
+# ---------------------------------------------------------------------------
+# Plugin packaging: TWO opt-in images (see docs/operation/plugins.md, plan DD2).
+#
+#   1. final-plugins  -> apache/skywalking-banyandb:<TAG>-plugins
+#        The plugin-capable CGO/dynamic HOST image. Ships an EMPTY /plugins
+#        trusted-dir mount point and NO .so files. Built via
+#        `BINARYTYPE=plugins make -C banyand docker`.
+#   2. final-carrier  -> apache/skywalking-banyandb:<TAG>-plugins-carrier
+#        The CARRIER image (same repo, "-plugins-carrier" tag suffix): just the
+#        built .so on busybox:stable-glibc.
+#        MOUNTED into the host at /plugins at deploy time (image-volume or
+#        initContainer). Built via `make -C banyand docker.plugins-carrier`.
+#
+# Everything below this point is UNREACHABLE from the default `final` target
+# above (an unreferenced stage in a multi-stage Dockerfile is never built), so
+# it cannot regress the default CGO_ENABLED=0 static/slim image or its build.
+# The host image is built with `--target final-plugins`, the carrier with
+# `--target final-carrier` (both wired in scripts/build/docker.mk).
+#
+# Go plugins require plugin.Open's host to be CGO-enabled and dynamically
+# linked, sharing the exact toolchain/module graph/libc as every .so it loads
+# (see plugins/README.md). `make release` therefore never produces either
+# artifact: the host binary AND every plugins/*/*/main.go are compiled here,
+# from ONE shared builder base (build-plugins-base) at ONE commit, so the
+# host<->.so parity plugin.Open demands holds by lockstep — the two images
+# MUST be built and tagged together (same CI run, same <TAG>), never versioned
+# independently.
+#
+# The full repo module (go.mod lives one directory above this Dockerfile's
+# own build context, banyand/) is supplied via the named build context
+# "reporoot" (wired by docker.mk for the plugin targets) rather than by
+# changing this Dockerfile's primary context — so the default path's context
+# and COPY sources above are untouched.
+#
+# NOTE: the `-plugins` stages use buildx named build contexts
+# (`--build-context reporoot=..` + `COPY --from=reporoot`), which require
+# BuildKit (Docker 20.10+/buildx 0.8+). No `# syntax=` frontend directive is
+# needed — named contexts are handled by the built-in Dockerfile frontend —
+# and one is intentionally omitted so the license header can remain the first
+# lines of the file (a `# syntax` line must be line 1 to be honored, which
+# would displace the header). The default (busybox static/slim) stages above
+# use only classic Dockerfile features and build under any engine.
+# ---------------------------------------------------------------------------
+
+FROM golang:1.25-bookworm AS build-plugins-base
+
+ENV GOTOOLCHAIN=auto
+ENV CGO_ENABLED=1
+WORKDIR /src
+
+COPY --from=reporoot go.mod go.sum ./
+RUN go mod download
+COPY --from=reporoot . .
+
+# build-plugins-server compiles the CGO-dynamic banyand-server. Flags mirror
+# `make build-trace-pipeline-server` (root Makefile) exactly: -trimpath, no
+# -s/-w stripping, so the host's build-id/module-graph metadata that
+# plugin.Open's package-hash check relies on matches the plugin builder below.
+#
+# `mkdir -p ui/dist && touch ui/dist/index.html` is the same placeholder
+# `build-trace-pipeline-server` uses for local dev builds: ui/embed.go's
+# `//go:embed dist` needs at least one non-hidden file to embed. It is NOT
+# destructive — `touch` only updates mtime and never truncates an existing
+# file — so when the CI job that builds this stage has already run
+# `make generate` (which builds the real ui/dist via the ui/ subproject)
+# before invoking this Dockerfile, the real UI is what gets embedded; this
+# line only kicks in as a fallback when ui/dist is missing entirely.
+#
+# GO_LINK_VERSION carries the same `-X <pkg>.build=... -X <pkg>.revision=...`
+# version-stamp ldflags `make release` uses (scripts/build/base.mk), passed
+# through docker.mk so `banyand version` reports the correct build in the
+# published -plugins artifact. `-X` only injects string constants; it does
+# NOT change the compiled module graph, so host/plugin plugin.Open parity is
+# unaffected.
+#
+# `-tags slim` matches the `-slim` release binary: it selects
+# banyand/liaison/http/rpath_empty.go over rpath_ui.go (`//go:build !slim`),
+# dropping the `//go:embed ui/dist` web console. A plugin-hosting data node has
+# no need for the UI, so omitting it cuts image size and CVE surface. The
+# `mkdir -p ui/dist && touch ui/dist/index.html` placeholder is still needed:
+# ui/embed.go's `//go:embed dist` requires at least one non-hidden file to
+# embed even under slim (the slim build path compiles ui/embed.go but the
+# empty embed is never served). CGO_ENABLED=1 (from build-plugins-base) and all
+# other flags are unchanged, so host<->.so plugin.Open parity holds.
+FROM build-plugins-base AS build-plugins-server
+ARG GO_LINK_VERSION
+RUN mkdir -p ui/dist && touch ui/dist/index.html \
+    && go build -trimpath -ldflags "${GO_LINK_VERSION}" -tags slim -o /out/banyand-server-plugins ./banyand/cmd/server
+
+# build-plugins-so compiles every first-party plugin under plugins/<vendor>/<name>
+# with the IDENTICAL toolchain/flags as build-plugins-server above (same base
+# image, same builder stage lineage) — parity by construction, per
+# plugins/README.md. Adding a new plugins/*/*/main.go needs no Dockerfile
+# change: this loop discovers it.
+#
+# `set -e` is load-bearing: a shell for-loop's exit status is only its LAST
+# iteration's, so without it a non-last plugin that fails to compile would be
+# silently skipped and ship an image missing that .so. With `set -e` any
+# failed `go build` aborts the whole RUN (and the image build).
+FROM build-plugins-base AS build-plugins-so
+RUN set -e; \
+    mkdir -p /out/plugins; \
+    for dir in plugins/*/*/; do \
+      [ -f "$dir/main.go" ] || continue; \
+      name=$(basename "$dir"); \
+      echo "building $name.so from $dir"; \
+      go build -buildmode=plugin -trimpath -o /out/plugins/"$name".so ./"$dir"; \
+    done
+
+# final-plugins is the plugin-capable HOST image ("-plugins" variant):
+# gcr.io/distroless/base-debian12 (NOT busybox) because the CGO-dynamic
+# banyand-server links against glibc; distroless base-debian12 is a Debian
+# "bookworm" image (glibc 2.36), matching the glibc the golang:1.25-bookworm
+# builder links against — so host<->.so parity holds (see plugins/README.md's
+# ABI/toolchain-lock section). Distroless is chosen over debian:bookworm-slim
+# to shrink the CVE surface: it carries no shell, no apt, and no package
+# manager (just glibc + ca-certificates + the few runtime libs), so the
+# standing glibc-CVE-tracked footprint is minimal. (If banyand fails to boot
+# for a missing shared lib, switch this FROM to gcr.io/distroless/cc-debian12,
+# which adds libstdc++/libgcc — also bookworm.)
+#
+# It ships an EMPTY /plugins directory (the trusted-dir mount POINT) and NO .so
+# files: plugins are delivered at deploy time by MOUNTING the carrier image
+# (final-carrier below) at /plugins. Because /plugins is empty, a mount there
+# shadows nothing. banyand-backup/restore/lifecycle/migration do not host
+# plugins, so they are reused unmodified from the ordinary `make release`
+# static build output (this Dockerfile's own context, like the default
+# `build-linux` stage above) — the plugin CI job runs `make release` first for
+# exactly this.
+FROM gcr.io/distroless/base-debian12 AS final-plugins
+
+ARG TARGETARCH
+
+COPY --from=build-plugins-server /out/banyand-server-plugins /banyand
+# Empty trusted-dir mount point. NO .so is baked in — the carrier image is
+# mounted here at deploy time (docs/operation/plugins.md). Created via WORKDIR
+# (no shell in distroless to run mkdir): WORKDIR /plugins makes the dir, then
+# WORKDIR / restores the working dir.
+WORKDIR /plugins
+WORKDIR /
+COPY build/bin/linux/${TARGETARCH}/banyand-backup-static /backup
+COPY build/bin/linux/${TARGETARCH}/banyand-restore-static /restore
+COPY build/bin/linux/${TARGETARCH}/banyand-lifecycle-static /lifecycle
+COPY build/bin/linux/${TARGETARCH}/banyand-migration-static /migration
+
+ENV GRPC_GO_LOG_SEVERITY_LEVEL=ERROR
+ENV GRPC_GO_LOG_FORMATTER=json
+
+EXPOSE 17912
+EXPOSE 17913
+EXPOSE 6060
+EXPOSE 2121
+
+ENTRYPOINT ["/banyand"]
+
+# final-carrier is the CARRIER image (same repo, "-plugins-carrier" tag suffix:
+# apache/skywalking-banyandb:<TAG>-plugins-carrier): ONLY the built .so files,
+# on busybox:stable-glibc. busybox is chosen because (a) it is glibc-consistent
+# with the bookworm-built .so, and (b) it has a shell + `cp`, so the same image
+# doubles as the initContainer that copies plugins into a shared emptyDir (the
+# portable, pre-1.31 delivery path — see docs/operation/plugins.md). It is
+# built from the SAME build-plugins-so stage / same commit / same CI run as the
+# host binary above, so the .so it ships is lockstep-parity with the host that
+# will load it. The plugins land at /plugins so an image-volume mount of this
+# carrier at the host's /plugins lines up 1:1.
+FROM busybox:stable-glibc AS final-carrier
+COPY --from=build-plugins-so /out/plugins /plugins

--- a/banyand/Makefile
+++ b/banyand/Makefile
@@ -34,3 +34,33 @@ include ../scripts/build/help.mk
 prepare-build: generate
 
 release: $(STATIC_BINARIES) $(SLIM_BINARIES)
+
+# license-plugins-report prints the runtime package manifest of the "-plugins"
+# HOST image (DD7 / docs/operation/plugins.md's Licensing section): unlike the
+# default busybox:stable-glibc image, this variant's distroless runtime layer
+# carries a glibc/ca-certificates package set not covered by `make
+# license-dep`'s Go/JS module-license resolution. This target enumerates
+# exactly what is present so NOTICE/LICENSE attribution can be assembled or
+# verified against ground truth rather than an assumed package list; it does
+# not itself write NOTICE/LICENSE.
+#
+# The host image is distroless (no shell, no dpkg-query), so we cannot run a
+# command inside it. Instead we extract the per-package dpkg metadata distroless
+# ships under /var/lib/dpkg/status.d/ via `docker create` + `docker cp` (no
+# container is ever RUN) and print Package/Version pairs.
+#
+# MUST be invoked with BINARYTYPE=plugins, e.g.
+#   BINARYTYPE=plugins make -C banyand license-plugins-report
+# so docker.mk resolves $(IMG) to the "-plugins"-suffixed HOST tag. It reads
+# $(IMG) directly (rather than re-appending "-plugins") to avoid a double suffix.
+.PHONY: license-plugins-report
+license-plugins-report: ## Print the "-plugins" host image's distroless package manifest; run with BINARYTYPE=plugins
+	@case "$(IMG)" in \
+	  *-plugins) ;; \
+	  *) echo "ERROR: run with BINARYTYPE=plugins (got image $(IMG))" >&2; exit 1 ;; \
+	esac
+	@echo "# Package manifest for $(IMG) (distroless base-debian12 runtime layer)"
+	@cid=$$(docker create "$(IMG)"); \
+	docker cp "$$cid":/var/lib/dpkg/status.d - 2>/dev/null | tar -xO 2>/dev/null \
+	  | awk '/^Package:/{p=$$2} /^Version:/{print p "\t" $$2}' | sort; \
+	docker rm "$$cid" >/dev/null

--- a/banyand/trace/pipeline_chain.go
+++ b/banyand/trace/pipeline_chain.go
@@ -128,50 +128,21 @@ func (mc *mergeChain) Execute(batch *sdk.TraceBatch, timeout time.Duration) (sdk
 	}
 }
 
-// runChain applies each sampler in order, ANDing the per-link keep mask into the
-// running conjunction. A link that panics, errors, or returns a wrong-length
-// verdict is bypassed (pass-through: the running mask is unchanged).
+// runChain evaluates the chain via the shared sdk.EvaluateChain — the same
+// AND-aggregation + per-link panic/error/length-mismatch fail-open logic the
+// offline sdktest.RunChain harness uses — passing an onBypass observer that
+// reproduces the pre-refactor WARN logs (same fields, same messages) so this
+// change is behavior-preserving.
 func (mc *mergeChain) runChain(batch *sdk.TraceBatch) sdk.Verdict {
-	mask := make([]bool, len(batch.Traces))
-	for i := range mask {
-		mask[i] = true
-	}
-	for _, sampler := range mc.samplers {
-		if sampler == nil {
-			continue
+	onBypass := func(_ int, info sdk.BypassInfo) {
+		if info.Reason == sdk.BypassReasonLengthMismatch {
+			chainLog.Warn().Int("got", info.Got).Int("want", info.Want).
+				Str("group", mc.group).Str("schema", mc.schema).Msg("sampler verdict length mismatch; bypassing (retain)")
+			return
 		}
-		mc.applyLink(sampler, batch, mask)
+		chainLog.Warn().Err(info.Err).Str("group", mc.group).Str("schema", mc.schema).Msg("sampler link failed; bypassing (retain)")
 	}
-	return sdk.Verdict{Keep: mask}
-}
-
-// applyLink calls sampler.Decide under recover and ANDs its keep mask into mask.
-// On panic, error, or length mismatch the link is bypassed (mask unchanged).
-func (mc *mergeChain) applyLink(sampler sdk.Sampler, batch *sdk.TraceBatch, mask []bool) {
-	var (
-		verdict sdk.Verdict
-		decErr  error
-	)
-	func() {
-		defer func() {
-			if r := recover(); r != nil {
-				decErr = fmt.Errorf("plugin panic: %v", r)
-			}
-		}()
-		verdict, decErr = sampler.Decide(batch)
-	}()
-	if decErr != nil {
-		chainLog.Warn().Err(decErr).Str("group", mc.group).Str("schema", mc.schema).Msg("sampler link failed; bypassing (retain)")
-		return
-	}
-	if len(verdict.Keep) != len(batch.Traces) {
-		chainLog.Warn().Int("got", len(verdict.Keep)).Int("want", len(batch.Traces)).
-			Str("group", mc.group).Str("schema", mc.schema).Msg("sampler verdict length mismatch; bypassing (retain)")
-		return
-	}
-	for i := range mask {
-		mask[i] = mask[i] && verdict.Keep[i]
-	}
+	return sdk.EvaluateChain(mc.samplers, batch, onBypass)
 }
 
 // assembleTraceBlock builds a COPY-backed sdk.TraceBlock from a loaded merge

--- a/banyand/trace/pipeline_chain_test.go
+++ b/banyand/trace/pipeline_chain_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/apache/skywalking-banyandb/pkg/fs"
 	pbv1 "github.com/apache/skywalking-banyandb/pkg/pb/v1"
 	"github.com/apache/skywalking-banyandb/pkg/pipeline/sdk"
+	"github.com/apache/skywalking-banyandb/pkg/pipeline/sdk/sdktest"
 	"github.com/apache/skywalking-banyandb/pkg/test"
 )
 
@@ -200,9 +201,16 @@ func TestMergeFilter_FailOpenOnPanic(t *testing.T) {
 	require.Empty(t, dropped)
 }
 
+// TestMergeChain_Timeout_FailsOpen builds its batch via sdktest (rather than a
+// hand-built literal &sdk.TraceBatch{...}) as proof-of-use of the offline dev
+// toolkit's fixture builder from inside the engine's own test suite.
 func TestMergeChain_Timeout_FailsOpen(t *testing.T) {
 	chain := newMergeChain("g", "s", []sdk.Sampler{&sleepSampler{d: 200 * time.Millisecond}}, 0)
-	batch := &sdk.TraceBatch{Traces: []sdk.TraceBlock{{TraceID: "x"}, {TraceID: "y"}}}
+	traceX, buildErr := sdktest.NewTrace("x").Build()
+	require.NoError(t, buildErr)
+	traceY, buildErr := sdktest.NewTrace("y").Build()
+	require.NoError(t, buildErr)
+	batch := sdktest.Batch(traceX, traceY)
 	verdict, err := chain.Execute(batch, 10*time.Millisecond)
 	require.Error(t, err)
 	require.Equal(t, "timeout", err.Error())
@@ -211,7 +219,9 @@ func TestMergeChain_Timeout_FailsOpen(t *testing.T) {
 
 func TestMergeChain_CircuitBreakerOpens(t *testing.T) {
 	chain := newMergeChain("g", "s", []sdk.Sampler{&sleepSampler{d: 200 * time.Millisecond}}, 2)
-	batch := &sdk.TraceBatch{Traces: []sdk.TraceBlock{{TraceID: "x"}}}
+	traceX, buildErr := sdktest.NewTrace("x").Build()
+	require.NoError(t, buildErr)
+	batch := sdktest.Batch(traceX)
 	_, err1 := chain.Execute(batch, 10*time.Millisecond)
 	require.Equal(t, "timeout", err1.Error())
 	_, err2 := chain.Execute(batch, 10*time.Millisecond)

--- a/banyand/trace/pipeline_conformance_test.go
+++ b/banyand/trace/pipeline_conformance_test.go
@@ -1,0 +1,82 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package trace
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/apache/skywalking-banyandb/pkg/pipeline/sdk"
+	"github.com/apache/skywalking-banyandb/pkg/pipeline/sdk/sdktest"
+)
+
+// TestConformance_EngineMergePathMatchesSdktest is the DD-T6 golden test: it
+// feeds the SAME logical fixture — three traces, one sampler configured to
+// drop the middle one — through BOTH the real engine merge path
+// (mergeWithFilter, exercising mergeChain.Execute/runChain over actual
+// on-disk parts) and the offline sdktest.RunChain harness, and asserts the
+// two report identical keep/drop verdicts.
+//
+// Today this is guaranteed to hold structurally, because runChain and
+// RunChain both delegate to the single shared sdk.EvaluateChain (D0) — but
+// that is exactly the point: this test is the belt-and-suspenders guard that
+// keeps it that way. If a future change (e.g. #1126-style column-assembly
+// semantics) makes the engine's fixture-building or chain wiring diverge from
+// sdktest's, this test fails loudly instead of the divergence going
+// unnoticed until a field report.
+func TestConformance_EngineMergePathMatchesSdktest(t *testing.T) {
+	ids := []string{"traceA", "traceB", "traceC"}
+	sampler := &fakeSampler{dropIDs: map[string]struct{}{"traceB": {}}}
+
+	// --- Real engine merge path ---
+	filter := &mergeFilter{
+		chain:   newMergeChain("g", "s", []sdk.Sampler{sampler}, 0),
+		timeout: time.Second,
+	}
+	engineGot, engineDropped := mergeWithFilter(t, singleTraceParts(ids), filter)
+	require.Equal(t, []string{"traceA", "traceC"}, engineGot)
+	require.Contains(t, engineDropped, "traceB")
+	require.Len(t, engineDropped, 1)
+
+	// --- Offline sdktest chain harness, same sampler, same trace IDs ---
+	blocks := make([]sdk.TraceBlock, 0, len(ids))
+	for _, id := range ids {
+		block, buildErr := sdktest.NewTrace(id).Build()
+		require.NoError(t, buildErr)
+		blocks = append(blocks, block)
+	}
+	batch := sdktest.Batch(blocks...)
+	verdict, report := sdktest.RunChain([]sdk.Sampler{sampler}, batch)
+	require.Empty(t, report.Bypassed, "the shared sampler must not be bypassed on either path")
+
+	sdktestDropped := make(map[string]struct{})
+	for i, keep := range verdict.Keep {
+		if !keep {
+			sdktestDropped[batch.Traces[i].TraceID] = struct{}{}
+		}
+	}
+
+	require.Equal(t, len(engineDropped), len(sdktestDropped),
+		"the real engine merge path and sdktest.RunChain must drop the same NUMBER of traces")
+	for id := range engineDropped {
+		_, ok := sdktestDropped[id]
+		require.True(t, ok, "trace %q dropped by the engine merge path must also be dropped by sdktest.RunChain", id)
+	}
+}

--- a/banyand/trace/pipeline_loader.go
+++ b/banyand/trace/pipeline_loader.go
@@ -22,7 +22,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"path/filepath"
-	"plugin"
 	"strings"
 	"sync"
 
@@ -181,60 +180,7 @@ func loadSamplerPlugin(sp *commonv1.SamplerPlugin, trustedDir, group string, bin
 // newSamplerFromPlugin opens the .so, verifies its ABIVersion symbol, and calls
 // the constructor. It is a package var so tests can substitute a Go sampler and
 // exercise the cache/keying/bindHost logic under -race without a real .so. The
-// default implementation is behavior-preserving: it is the exact plugin.Open +
-// ABI check + constructor sequence that loadSamplerPlugin ran inline before the
-// seam was introduced.
-var newSamplerFromPlugin = func(resolvedPath, symbol string, cfgJSON []byte) (sdk.Sampler, error) {
-	var p *plugin.Plugin
-	var openErr error
-	func() {
-		defer func() {
-			if r := recover(); r != nil {
-				openErr = fmt.Errorf("panic opening plugin %q: %v", resolvedPath, r)
-			}
-		}()
-		p, openErr = plugin.Open(resolvedPath)
-	}()
-	if openErr != nil {
-		return nil, fmt.Errorf("cannot open plugin %q: %w", resolvedPath, openErr)
-	}
-
-	abiSym, lookupErr := p.Lookup("ABIVersion")
-	if lookupErr != nil {
-		return nil, fmt.Errorf("plugin %q missing ABIVersion symbol: %w", resolvedPath, lookupErr)
-	}
-	pluginABI, ok := abiSym.(*int)
-	if !ok {
-		return nil, fmt.Errorf("plugin %q ABIVersion has wrong type", resolvedPath)
-	}
-	if *pluginABI != sdk.ABIVersion {
-		return nil, fmt.Errorf("plugin %q ABI version %d does not match engine %d", resolvedPath, *pluginABI, sdk.ABIVersion)
-	}
-
-	ctorSym, lookupErr := p.Lookup(symbol)
-	if lookupErr != nil {
-		return nil, fmt.Errorf("plugin %q missing symbol %q: %w", resolvedPath, symbol, lookupErr)
-	}
-	ctor, ok := ctorSym.(func([]byte) (sdk.Sampler, error))
-	if !ok {
-		return nil, fmt.Errorf("plugin %q symbol %q has wrong type", resolvedPath, symbol)
-	}
-
-	var sampler sdk.Sampler
-	var ctorErr error
-	func() {
-		defer func() {
-			if r := recover(); r != nil {
-				ctorErr = fmt.Errorf("panic in plugin %q constructor: %v", resolvedPath, r)
-			}
-		}()
-		sampler, ctorErr = ctor(cfgJSON)
-	}()
-	if ctorErr != nil {
-		return nil, fmt.Errorf("plugin %q constructor failed: %w", resolvedPath, ctorErr)
-	}
-	if sampler == nil {
-		return nil, fmt.Errorf("plugin %q constructor returned nil sampler", resolvedPath)
-	}
-	return sampler, nil
-}
+// default implementation delegates to sdk.OpenSampler — the single shared
+// loader-contract implementation also used by sdktest.LoadSO — so the host and
+// the offline dev toolkit never drift.
+var newSamplerFromPlugin = sdk.OpenSampler

--- a/dist/NOTICE-plugins
+++ b/dist/NOTICE-plugins
@@ -1,0 +1,51 @@
+Apache SkyWalking BanyanDB - plugin images addendum
+================================================================
+
+This file documents the ADDITIONAL third-party components carried by the two
+opt-in plugin images, on top of what the default (CGO_ENABLED=0 static,
+busybox:stable-glibc-based) image already covers via NOTICE and dist/LICENSE
+(see `make license-dep`):
+
+  - HOST image    apache/skywalking-banyandb:<tag>-plugins
+  - CARRIER image apache/skywalking-banyandb:<tag>-plugins-carrier
+
+Both are tags on the same apache/skywalking-banyandb repository.
+
+HOST image (adds a distroless glibc layer)
+------------------------------------------
+The host image's runtime layer is `gcr.io/distroless/base-debian12` (required
+because its banyand-server is CGO_ENABLED=1 and dynamically linked against
+glibc, so it can host Go plugins via plugin.Open — see
+docs/operation/plugins.md). distroless base-debian12 is a minimal Debian
+"bookworm" base carrying glibc + ca-certificates + a few runtime libs, with NO
+shell, apt, or package manager — chosen over debian:bookworm-slim to minimize
+the standing CVE surface. It still adds a glibc runtime not present in the
+default busybox-based image.
+
+The authoritative, up-to-date package/library manifest for a given build is
+NOT hand-maintained in this file (versions move with the upstream distroless
+base image); regenerate it from the actual built host image with:
+
+    BINARYTYPE=plugins make -C banyand license-plugins-report
+
+At the time this addendum was written, the base was dominated by the LGPL-2.1+
+glibc runtime family (libc6 and its supporting libraries) plus MPL-2.0-licensed
+`ca-certificates` (Mozilla's CA bundle). distroless ships the corresponding
+license/copyright files under /usr/share/doc; consult the distroless
+base-debian12 image's published attribution for the authoritative
+per-component license text.
+
+CARRIER image (no new base components)
+--------------------------------------
+The carrier image is `busybox:stable-glibc` — the SAME base as the default
+banyand image — plus only the first-party plugin `.so` files that this repo
+itself builds from `plugins/`. It therefore introduces NO third-party base
+components beyond what the default image's NOTICE/dist/LICENSE already cover;
+its only added content is Apache-2.0 first-party code compiled to `.so`.
+
+Operational consequence (see docs/operation/plugins.md and the plan's DD7):
+the host image is a permanent, heavier, glibc-CVE-tracked artifact relative to
+the default image, and both plugin images are standing, published artifacts.
+Track BOTH in the same CVE scan/patch matrix as the default image, not as an
+afterthought — `BINARYTYPE=plugins make -C banyand license-plugins-report` is
+also a convenient input to that scan for the host image.

--- a/docs/menu.yml
+++ b/docs/menu.yml
@@ -129,6 +129,14 @@ catalog:
         path: "/operation/system"
       - name: "Upgrade"
         path: "/operation/upgrade"
+      - name: "Trace Pipeline Plugins"
+        catalog:
+          - name: "Development Guide"
+            path: "/operation/plugins-development"
+          - name: "Packaging and Deployment"
+            path: "/operation/plugins"
+          - name: "Debugging (Offline)"
+            path: "/operation/plugins-debugging"
       - name: "Observability"
         catalog:
           - name: "Overview"

--- a/docs/operation/plugins-debugging.md
+++ b/docs/operation/plugins-debugging.md
@@ -1,0 +1,98 @@
+# Debugging Trace-Pipeline Sampler Plugins (Offline / Config)
+
+This is the offline/config half of the trace-pipeline sampler-plugin
+debugging runbook: everything here can be checked from configuration and
+existing metrics/logs, or reproduced with the offline dev toolkit
+(`pkg/pipeline/sdk/sdktest`) — no live cluster access is required beyond
+reading its config and metrics.
+
+> The live-observability half of this runbook (per-decision metrics, a
+> decision-sample debug log, and a `banyand-plugin decide`/capture-replay
+> workflow) is **not part of this document** — those tools are planned in a
+> follow-up PR and do not exist yet. Do not search for metrics or commands
+> beyond what is listed below; they are not yet built.
+
+See [`docs/operation/plugins.md`](plugins.md) for deployment and
+[`plugins/README.md`](../../plugins/README.md) for the plugin contract.
+
+## Symptom: "my data is not being sampled" (nothing is dropped)
+
+Work through these checks in order; each one either explains the symptom or
+rules out a cause.
+
+1. **Is the feature enabled on this node?** `-trace-pipeline-native-plugin-enabled`
+   must be `true` and `-trace-pipeline-trusted-plugin-dir` must be set to a
+   real, existing directory. Both are data-node flags; a liaison node never
+   hosts plugins, so pointing plugins at a liaison silently does nothing.
+2. **Is the pipeline enabled for this group?** The group's `TracePipelineConfig.enabled`
+   must be `true`. Also check `enabled_events`: an empty `enabled_events`
+   defaults the in-merge filter (`PIPELINE_EVENT_MERGE`) **on**, but does
+   **not** default segment finalization (`PIPELINE_EVENT_FINALIZE`) on — if
+   you expected finalization-time retention and didn't list it explicitly, it
+   never runs.
+3. **Were any samplers actually installed for this group?** Check the
+   `sampler_active_count{group}` gauge. Zero means no sampler chain was ever
+   built for this group — reconcile either never ran (config not applied) or
+   every plugin failed to load (see the next check).
+4. **Did a plugin fail to load?** Check `sampler_load_failed{group,name,reason}`
+   and the data node's log for the ERROR line *"sampler plugin load failed;
+   keeping previous good set (fail-open)"*. A load failure is fail-open and
+   loud: the group keeps whatever sampler set it had before (or retains all
+   traces, if this is the first-ever load) — it never crashes the node or
+   silently corrupts data. Common `reason` values point at ABI/toolchain
+   skew (see `plugins/README.md`'s ABI/toolchain-lock section — the most
+   common cause is a third-party `.so` built with a different Go
+   toolchain/SDK than the running host).
+5. **Is the sampler chain actually deciding to keep everything?** This is
+   where you leave the cluster and go offline: reproduce the sampler's
+   config and representative trace shapes with
+   `pkg/pipeline/sdk/sdktest.NewTrace(...)...Build()`, then run
+   `sdktest.Run` (single sampler) or `sdktest.RunChain` (the configured
+   chain) and inspect the returned `Verdict.Keep`. If every fixture you'd
+   expect to be dropped comes back `true`, the sampler's own logic (or its
+   config, e.g. a threshold set too permissively) is the cause, not the
+   engine.
+6. **Remember: plugins target the whole group, not a schema or a stage.**
+   `TracePipelineConfig.schema_names` / `schema_name_regex` / `stages` are
+   accepted by the proto but **not wired** into the engine today — the
+   validator rejects any config that tries to use them
+   (`api/validate/validate.go`), and the group as a whole is the only unit a
+   pipeline can target. If you were expecting a schema-scoped or
+   stage-scoped effect, that scoping does not exist yet.
+
+## Symptom: "unexpected data is being sampled" (wrong traces kept or dropped)
+
+1. **Suspect a column the sampler reads but never projects.** `Sampler.Decide`
+   only ever sees the tag columns, span-ID column, and span-body column the
+   sampler's own `Project()` declared — anything else decodes to an absent
+   column (`TraceBlock.Tag` returns `nil`). If a sampler's logic quietly
+   depends on an unprojected column when you hand-build a test fixture with
+   every column present, it will behave differently in production (where the
+   engine decodes only what was projected). Catch this **offline**:
+   `sdktest.Run` runs `Decide` twice — once on the fixture as given, once on
+   a copy trimmed to exactly `Project()`'s columns — and reports every trace
+   ID where the two verdicts disagree in `Report.ProjectionDivergedIDs`. A
+   non-empty result means this is very likely your root cause.
+2. **Suspect a bypassed chain link.** A chain link that panics, returns an
+   error, or returns a keep-mask of the wrong length is bypassed — the
+   running keep-mask is left unchanged for that link (fail-open per link),
+   and the data node logs a WARN line (*"sampler link failed; bypassing
+   (retain)"* or *"sampler verdict length mismatch; bypassing (retain)"*).
+   Reproduce the same samplers and fixture with `sdktest.RunChain` and
+   inspect `ChainReport.Bypassed` — each entry names the link's index and a
+   `Reason` (`decide_error`, `length_mismatch`, or `panic`), matching exactly
+   what the engine's `sdk.EvaluateChain` (the shared implementation the
+   engine's merge chain runs too — no separate re-implementation to drift
+   from it) would have logged in production.
+3. **Suspect the whole chain failed open.** A whole-chain timeout or an open
+   circuit breaker retains **every** trace in the batch — a different
+   failure mode from a single bypassed link (which only drops that one
+   link's constraint). This is currently only visible via the data node's
+   WARN/ERROR logs (`"timeout"` / `"circuit_open"`); no dedicated metric for
+   it exists yet.
+4. **Suspect cross-part/late-data assembly.** Retention decisions are made
+   per merge, over whatever parts are being merged together at that moment;
+   a trace whose spans arrive in multiple merges can be evaluated more than
+   once as its span-set grows. This is a property of the merge grace window
+   (`TracePipelineConfig.merge_grace`, default 30s) and how the merge
+   scheduler groups parts, not of any single sampler.

--- a/docs/operation/plugins-development.md
+++ b/docs/operation/plugins-development.md
@@ -1,0 +1,138 @@
+# Developing Trace-Pipeline Sampler Plugins
+
+A single, linear walkthrough — **implement → verify → debug → deploy** — for a
+trace-pipeline sampler plugin. It is the entry point that ties together the
+reference material:
+
+- **Contract & source layout:** [`plugins/README.md`](../../plugins/README.md)
+- **Reference plugin:** [`pkg/pipeline/sdk/_example/segment-tail-sampler`](../../pkg/pipeline/sdk/_example/segment-tail-sampler)
+- **SDK API:** the package doc on `pkg/pipeline/sdk`
+- **Offline test kit:** `pkg/pipeline/sdk/sdktest`
+- **Packaging & deploy:** [`plugins.md`](plugins.md)
+- **Debugging runbook:** [`plugins-debugging.md`](plugins-debugging.md)
+
+## What a plugin is
+
+A sampler plugin is a native Go `.so` the data node loads at runtime to decide,
+per trace, keep-or-drop during merge/finalize. It is a `package main` built with
+`go build -buildmode=plugin` that exports exactly two SDK symbols. **Read the
+ABI/toolchain lock in [`plugins/README.md`](../../plugins/README.md) before
+building for production** — a `.so` must be built with the exact toolchain/SDK
+of the host it loads into, or `plugin.Open` rejects it (safe and loud, never
+silent). For first-party plugins this parity is guaranteed by lockstep builds.
+
+Prerequisites: Go (pinned via `go.mod`), a C toolchain (`gcc`/`clang`, since
+plugins require `CGO_ENABLED=1`), Linux or macOS (not Windows).
+
+## Step 1 — Implement
+
+Create `plugins/skywalking/<name>/main.go`:
+
+```go
+package main
+
+import "github.com/apache/skywalking-banyandb/pkg/pipeline/sdk"
+
+var ABIVersion = sdk.ABIVersion // re-export, unchanged — MUST equal the host's
+
+// NewSampler is the default constructor symbol; config is the canonical JSON of
+// the SamplerPlugin.config google.protobuf.Struct.
+func NewSampler(config []byte) (sdk.Sampler, error) { /* parse config, return sampler */ }
+
+func main() {} // required by -buildmode=plugin
+```
+
+Your `sdk.Sampler` implements `Kind`, `Project`, `Decide`, `Close`:
+
+- **`Project()`** declares up-front which tag columns / span data your `Decide`
+  reads. **Only projected columns are decoded** — reading an unprojected tag
+  returns null, the #1 cause of "unexpected sampling" (Step 3 catches this).
+- **`Decide(batch *sdk.TraceBatch) (sdk.Verdict, error)`** returns a keep-mask
+  aligned to `batch.Traces`. The batch is READ-ONLY.
+
+See the reference plugin and `plugins/README.md`'s "The plugin contract" for the
+full detail.
+
+## Step 2 — Verify offline (no `.so`, no cluster)
+
+Write a `_test.go` next to `main.go` using the `sdktest` kit — the fastest loop,
+before you ever build a `.so`:
+
+```go
+batch := sdktest.NewTrace("t1").
+    Tag("status", "error").TagAs("duration", valuetype.ValueTypeInt64, int64(900)).
+    Build()
+verdict, report := sdktest.Run(sampler, sdktest.Batch(batch))
+// report flags a sampler whose verdict changes when unprojected columns are
+// added (the differential projection guard). Use sdktest.RunChain for a chain.
+```
+
+Then build the `.so` locally to confirm it compiles in plugin mode:
+
+```sh
+make build-plugins   # → $(PLUGIN_OUTPUT_DIR), default build/bin/plugins
+```
+
+Worked example: `plugins/skywalking/latencystatussampler/main_test.go`.
+
+## Step 3 — Debug
+
+Use the symptom-driven runbook: [`plugins-debugging.md`](plugins-debugging.md).
+It covers, offline via `sdktest`, the two field symptoms:
+
+- **"nothing is being sampled"** → check the feature flag, `cfg.enabled`, the
+  event gate, plugin load failure (`sampler_load_failed` metric / the fail-open
+  ERROR log), grace, and an all-keep verdict.
+- **"unexpected data is sampled"** → reproduce with `sdktest`; the differential
+  guard flags a `Decide` that depends on an unprojected column; check keep-mask
+  length, chain AND semantics, and late-data assembly.
+
+On a live node the load signals are `sampler_active_count{group}` (>0 = loaded)
+and `sampler_load_failed{group,name,reason}`; a load failure is loud (ERROR log)
+and fail-open (the group keeps its previous sampler set, node stays up).
+
+## Step 4 — Deploy
+
+First-party plugins ship in the carrier image
+(`apache/skywalking-banyandb:<tag>-plugins-carrier`) and are **mounted** into the
+plugin-capable host image (`apache/skywalking-banyandb:<tag>-plugins`) at
+`/plugins`. Enable on the **data-node** pod:
+
+```
+-trace-pipeline-native-plugin-enabled=true
+-trace-pipeline-trusted-plugin-dir=/plugins
+```
+
+Reference the plugin by filename in the group's `TracePipelineConfig`:
+
+```json
+{ "enabled": true, "enabledEvents": ["PIPELINE_EVENT_MERGE"],
+  "plugins": [ { "name": "latency-status",
+    "sampler": { "path": "latencystatussampler.so", "abiVersion": 1,
+                 "config": { "thresholdMs": 500, "successValue": "success" } } } ] }
+```
+
+Mount the carrier at `/plugins` via an **OCI image volume** (K8s ≥1.31) or an
+**initContainer + emptyDir** (portable) — full instructions, both mechanisms,
+third-party plugins, and Kubernetes manifests are in [`plugins.md`](plugins.md)
+and [`examples/kubernetes/plugins/`](../../examples/kubernetes/plugins).
+
+## Step 5 — Validate the deployment shape in Kubernetes
+
+The `test/plugin-sidecar` kind gate proves the CGO host + carrier-mount design
+works in real Kubernetes (host boots, carrier delivers the `.so`, the node loads
+it). Run it locally before shipping a packaging change:
+
+```sh
+make -C test/plugin-sidecar e2e-plugin-sidecar
+```
+
+It also runs automatically in CI (`.github/workflows/test-plugin-sidecar-e2e.yml`)
+on PRs that touch the plugin surface.
+
+## Third-party plugins
+
+A third-party `.so` is **not** committed here — the vendor builds it against the
+pinned SDK + toolchain of the target release (see the ABI/toolchain lock) and
+mounts it at the reserved subdirectory `/plugins/thirdparty`. See
+[`plugins.md`](plugins.md).

--- a/docs/operation/plugins.md
+++ b/docs/operation/plugins.md
@@ -1,0 +1,180 @@
+# Trace-Pipeline Sampler Plugins
+
+BanyanDB's trace pipeline can retain/drop traces in-merge (and at segment
+finalization) using operator-installed native Go plugins ("samplers"). This
+document covers packaging and deploying plugins on a running cluster. See
+[`docs/design/post-trace-pipeline.md`](../design/post-trace-pipeline.md) for
+the plugin ABI/contract, and
+[`plugins/README.md`](../../plugins/README.md) for authoring a first-party
+plugin. For diagnosing "nothing is being sampled" / "unexpected data is being
+sampled" symptoms offline, see
+[`docs/operation/plugins-debugging.md`](plugins-debugging.md).
+
+## Overview
+
+- Plugins are loaded **on demand at group-schema reconcile**, on the **data
+  node role only** (the standalone service also satisfies this role; the
+  liaison never hosts plugins).
+- The feature is gated by two flags, both off by default:
+  - `-trace-pipeline-native-plugin-enabled` (bool) — the whole feature switch.
+  - `-trace-pipeline-trusted-plugin-dir` (string) — the **single** directory
+    `.so` paths are resolved within. There is no second flag and no
+    multi-directory support.
+- A plugin load failure is **fail-open and loud**: the group keeps its
+  previous good sampler set (or retains all traces, on first load), an ERROR
+  log line is emitted, and the `sampler_load_failed{group,name,reason}` metric
+  increments. It is never a node crash or a hard stop.
+- Go plugins **cannot be unloaded**; once a `.so` is opened it stays mapped
+  for the process lifetime.
+
+## Images
+
+Plugins ship as **two** opt-in images, built and tagged together (see the
+lockstep note below):
+
+| Image | Base | Contents | Role |
+|---|---|---|---|
+| default (`apache/skywalking-banyandb:<tag>`) | `busybox:stable-glibc` | `CGO_ENABLED=0` static `banyand-server` | Normal image; hosts **no** plugins, ever |
+| slim (`...:<tag>-slim`) | `busybox:stable-glibc` | `CGO_ENABLED=0` static `banyand-server` | Slim default; hosts no plugins |
+| **plugins host** (`...:<tag>-plugins`) | `gcr.io/distroless/base-debian12` | `CGO_ENABLED=1` dynamic `banyand-server` + an **empty** `/plugins` | The plugin-capable host; `.so` are mounted in, not baked |
+| **plugins carrier** (`...:<tag>-plugins-carrier`) | `busybox:stable-glibc` | the built first-party `.so` at `/plugins` | Mounted into the host at `/plugins` to deliver plugins |
+
+All four are tags on the **same** `apache/skywalking-banyandb` repository.
+
+**A Go plugin cannot be loaded into a `CGO_ENABLED=0` statically-linked
+host** — `plugin.Open` requires the host to be CGO-enabled and dynamically
+linked, and the `.so` must share the host's exact Go toolchain, module graph
+(including `pkg/pipeline/sdk`), CGO mode, race mode, and a compatible libc.
+The default and slim images can host **no** plugins; use the `-plugins` host
+image.
+
+**The host image ships `/plugins` empty and carries no `.so`.** Plugins —
+first-party and third-party alike — are delivered by **mounting** them at the
+trusted dir. The first-party carrier image (the `-plugins-carrier`-tagged
+image on the same repo) holds the SkyWalking-maintained `.so` and is mounted
+at `/plugins`.
+
+> **Lockstep parity (mandatory).** `plugin.Open` requires the `.so` and the
+> host binary to share an exact toolchain/module-graph/libc. The host binary
+> and the carrier `.so` are compiled from **one shared builder base at one
+> commit in one CI run**, and both images are published at the **same `<tag>`**
+> (the carrier tag equals the host tag). Always deploy the carrier at the same
+> tag as the host image. A separate image is fully supported; independently
+> *versioning* the carrier is not — any drift makes `plugin.Open` reject the
+> `.so` (fail-open, loud; see below).
+
+## Enabling plugins
+
+Use the `-plugins` **host** image for the **data-node** pod (liaison pods
+never host plugins) and set the two flags:
+
+```
+-trace-pipeline-native-plugin-enabled=true
+-trace-pipeline-trusted-plugin-dir=/plugins
+```
+
+Mount the carrier at `/plugins`, then reference a plugin by filename in the
+group's pipeline config (`TracePipelineConfig` on the `Group`,
+`SamplerPlugin.path`), e.g.:
+
+```json
+{
+  "enabled": true,
+  "enabledEvents": ["PIPELINE_EVENT_MERGE"],
+  "plugins": [
+    {
+      "name": "latency-status",
+      "sampler": {
+        "path": "latencystatussampler.so",
+        "abiVersion": 1,
+        "config": { "thresholdMs": 500, "successValue": "success" }
+      }
+    }
+  ]
+}
+```
+
+## Delivering the carrier (first-party) and third-party plugins
+
+The loader supports exactly **one** trusted dir
+(`-trace-pipeline-trusted-plugin-dir`, a single flag; every
+`SamplerPlugin.path` resolves within it). First-party plugins mount at
+`/plugins` (`SamplerPlugin.path=<name>.so`); third-party plugins mount at the
+reserved subdirectory `/plugins/thirdparty`
+(`SamplerPlugin.path=thirdparty/<name>.so`). Because the host image ships
+`/plugins` **empty**, mounting the carrier there shadows nothing.
+
+Two delivery mechanisms — both work for first- and third-party:
+
+1. **OCI image volume** (Kubernetes ≥1.31, beta in 1.33): mount the carrier
+   image's filesystem read-only at `/plugins`; mount a third-party plugin
+   image as a *nested* volume at `/plugins/thirdparty`. No `cp`, no shell.
+   See [`examples/kubernetes/plugins/first-party-image-volume.yaml`](../../examples/kubernetes/plugins/first-party-image-volume.yaml)
+   and [`examples/kubernetes/plugins/third-party-image-volume.yaml`](../../examples/kubernetes/plugins/third-party-image-volume.yaml).
+2. **initContainer + emptyDir** (portable to all Kubernetes versions): one
+   shared `emptyDir` at `/plugins`; a first-party initContainer (the busybox
+   carrier image) `cp`s its `.so` into `/plugins/`, and a third-party
+   initContainer `cp`s into `/plugins/thirdparty/`. The carrier's busybox base
+   provides the shell/`cp` this needs (a `scratch`/`.so`-only image cannot do
+   it — use the image-volume mechanism for such images).
+   See [`examples/kubernetes/plugins/first-party-init-container.yaml`](../../examples/kubernetes/plugins/first-party-init-container.yaml)
+   and [`examples/kubernetes/plugins/third-party-init-container.yaml`](../../examples/kubernetes/plugins/third-party-init-container.yaml).
+
+First-party parity is guaranteed by lockstep (deploy the carrier at the host's
+tag). Third-party `.so` parity is the **operator's** responsibility — they
+build against the pinned SDK + toolchain published for that release (this
+repo's `go.mod` at that tag; `pkg/pipeline/sdk`). Mismatch is always safe and
+loud: the loader rejects a skewed `.so` (`plugin.Open` "different version of
+package …", or an `ABIVersion` mismatch), fails open (ERROR log +
+`sampler_load_failed` metric), and the affected group simply keeps its
+previous sampler set. Other groups, and the node itself, are unaffected.
+
+## Building and verifying plugins before deploying
+
+- `plugins/README.md` covers the plugin contract, the ABI/toolchain lock, and
+  `make build-plugins` (local, dev-only `.so` builds).
+- `pkg/pipeline/sdk/sdktest` is the offline dev-toolkit: build fixtures, run
+  `Decide` against a sampler (with a differential guard that flags a
+  sampler reading a column it never projected), run a chain of samplers, and
+  drive a real, loaded `.so` — all without a database or a cluster. See
+  `plugins/skywalking/latencystatussampler/main_test.go` for a worked
+  example.
+- `docs/operation/plugins-debugging.md` is the symptom-driven runbook for
+  "nothing is being sampled" / "unexpected data is being sampled".
+
+## Licensing
+
+The `-plugins` **host** image's runtime layer is
+`gcr.io/distroless/base-debian12` (a minimal Debian "bookworm" base: glibc +
+`ca-certificates` + a few runtime libs, with no shell, apt, or package
+manager), which — unlike the default `busybox:stable-glibc` image — carries a
+glibc runtime not present in the default image. Distroless is chosen over
+`debian:bookworm-slim` specifically to minimize this standing CVE surface. The
+**carrier** image is `busybox:stable-glibc` (the same base as the default
+image, so no new base components) plus only the first-party `.so`. See
+[`dist/NOTICE-plugins`](../../dist/NOTICE-plugins) for the addendum this adds
+on top of the default image's `NOTICE`/`dist/LICENSE` (`make license-dep`),
+and run `BINARYTYPE=plugins make -C banyand license-plugins-report` against a
+built host image to regenerate its exact package manifest. Treat the
+`-plugins` host image as carrying a standing glibc-CVE-tracking cost the
+default image does not have, and scan/patch both plugin images accordingly.
+
+## Helm
+
+There is no Helm chart in this repository — see
+[`docs/installation/kubernetes.md`](../installation/kubernetes.md). The
+following wiring into the `apache/skywalking-banyandb-helm` chart is tracked
+as a follow-up PR in that repository; the manifests in
+`examples/kubernetes/plugins/` are the plain-Kubernetes reference in the
+meantime:
+
+- `plugins.enabled` → use the `-plugins` **host** image for the data-node
+  container and set the two flags above.
+- `plugins.image` → the **carrier** image (the `-plugins-carrier`-tagged image
+  on the `apache/skywalking-banyandb` repo), mounted at `/plugins`. Its tag is
+  the host image tag + `-carrier` (lockstep parity).
+- `plugins.mountMode: imageVolume | initContainer` → selects the delivery
+  mechanism.
+- Optional third-party hooks mount an operator image onto the subdirectory
+  `/plugins/thirdparty`.
+- Target the **data-node** pod only (liaison never hosts).

--- a/examples/kubernetes/plugins/first-party-image-volume.yaml
+++ b/examples/kubernetes/plugins/first-party-image-volume.yaml
@@ -1,0 +1,74 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Data-node StatefulSet fragment: FIRST-PARTY plugins via an OCI IMAGE VOLUME
+# (Kubernetes >=1.31, beta in 1.33). See docs/operation/plugins.md.
+#
+# The story: the -plugins HOST image ships /plugins EMPTY; the separate
+# CARRIER image (the `-plugins-carrier`-tagged image) holds the .so at /plugins and is
+# mounted read-only at the host's /plugins. Set the two flags and reference the
+# plugin by filename in the group's TracePipelineConfig
+# (SamplerPlugin.path=latencystatussampler.so).
+#
+# LOCKSTEP: the carrier tag MUST equal the host image tag — the .so and the
+# host binary are built together and plugin.Open requires exact toolchain
+# parity. Here both use <TAG>.
+#
+# Only the data-node role hosts plugins; a liaison Deployment needs none of this.
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: banyandb-data
+  labels:
+    app.kubernetes.io/name: banyandb
+    app.kubernetes.io/component: data
+spec:
+  serviceName: banyandb-data
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: banyandb
+      app.kubernetes.io/component: data
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: banyandb
+        app.kubernetes.io/component: data
+    spec:
+      containers:
+        - name: banyandb-data
+          # Plugin-capable CGO/dynamic HOST image. Default/-slim are static and
+          # host NO plugins.
+          image: apache/skywalking-banyandb:<TAG>-plugins
+          args:
+            - data
+            - -trace-pipeline-native-plugin-enabled=true
+            - -trace-pipeline-trusted-plugin-dir=/plugins
+          ports:
+            - name: grpc
+              containerPort: 17912
+            - name: http
+              containerPort: 17913
+          volumeMounts:
+            - name: firstparty-plugins
+              mountPath: /plugins
+              readOnly: true
+      volumes:
+        - name: firstparty-plugins
+          image:
+            # The first-party carrier, at the SAME tag as the host image above.
+            reference: apache/skywalking-banyandb:<TAG>-plugins-carrier
+            pullPolicy: IfNotPresent

--- a/examples/kubernetes/plugins/first-party-init-container.yaml
+++ b/examples/kubernetes/plugins/first-party-init-container.yaml
@@ -1,0 +1,73 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Data-node StatefulSet fragment: FIRST-PARTY plugins via the PORTABLE
+# initContainer + emptyDir mechanism (works on all Kubernetes versions, incl.
+# pre-1.31 without image-volume support). See docs/operation/plugins.md.
+#
+# A shared emptyDir is mounted at /plugins in both the initContainer and the
+# main container. The initContainer runs the CARRIER image
+# (the `-plugins-carrier`-tagged image) — which is busybox-based, so it has a shell +
+# `cp` — and copies its /plugins/*.so into the shared volume. The host then
+# loads them from /plugins. Reference by SamplerPlugin.path=latencystatussampler.so.
+#
+# LOCKSTEP: the carrier tag MUST equal the host image tag (plugin.Open parity).
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: banyandb-data
+  labels:
+    app.kubernetes.io/name: banyandb
+    app.kubernetes.io/component: data
+spec:
+  serviceName: banyandb-data
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: banyandb
+      app.kubernetes.io/component: data
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: banyandb
+        app.kubernetes.io/component: data
+    spec:
+      initContainers:
+        - name: install-firstparty-plugins
+          # The busybox-based carrier at the SAME tag as the host image below.
+          image: apache/skywalking-banyandb:<TAG>-plugins-carrier
+          command: ["sh", "-c", "cp /plugins/*.so /out/"]
+          volumeMounts:
+            - name: plugins
+              mountPath: /out
+      containers:
+        - name: banyandb-data
+          image: apache/skywalking-banyandb:<TAG>-plugins
+          args:
+            - data
+            - -trace-pipeline-native-plugin-enabled=true
+            - -trace-pipeline-trusted-plugin-dir=/plugins
+          ports:
+            - name: grpc
+              containerPort: 17912
+            - name: http
+              containerPort: 17913
+          volumeMounts:
+            - name: plugins
+              mountPath: /plugins
+      volumes:
+        - name: plugins
+          emptyDir: {}

--- a/examples/kubernetes/plugins/third-party-image-volume.yaml
+++ b/examples/kubernetes/plugins/third-party-image-volume.yaml
@@ -1,0 +1,86 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Data-node StatefulSet fragment: FIRST-PARTY + THIRD-PARTY plugins together
+# via OCI image volumes (Kubernetes >=1.31, beta in 1.33). See
+# docs/operation/plugins.md.
+#
+# The -plugins HOST image ships /plugins EMPTY. Here we mount:
+#   - the first-party CARRIER image read-only at /plugins           (SamplerPlugin.path=<name>.so)
+#   - the operator's third-party image read-only, NESTED at         (SamplerPlugin.path=thirdparty/<name>.so)
+#     /plugins/thirdparty
+# Mounting the carrier at /plugins is correct now — the host's /plugins is
+# empty, so there is nothing to shadow. The nested third-party mount overlays
+# only the subdirectory.
+#
+# PARITY: the first-party carrier tag MUST equal the host image tag (built in
+# lockstep). Third-party .so parity is the OPERATOR's responsibility — build
+# against the pkg/pipeline/sdk + Go toolchain matching the target BanyanDB
+# release. A skewed .so is rejected loudly (fail-open: ERROR log +
+# sampler_load_failed; that group keeps its previous sampler set), never
+# silently.
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: banyandb-data
+  labels:
+    app.kubernetes.io/name: banyandb
+    app.kubernetes.io/component: data
+spec:
+  serviceName: banyandb-data
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: banyandb
+      app.kubernetes.io/component: data
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: banyandb
+        app.kubernetes.io/component: data
+    spec:
+      containers:
+        - name: banyandb-data
+          image: apache/skywalking-banyandb:<TAG>-plugins
+          args:
+            - data
+            - -trace-pipeline-native-plugin-enabled=true
+            - -trace-pipeline-trusted-plugin-dir=/plugins
+          ports:
+            - name: grpc
+              containerPort: 17912
+            - name: http
+              containerPort: 17913
+          volumeMounts:
+            - name: firstparty-plugins
+              mountPath: /plugins
+              readOnly: true
+            - name: thirdparty-plugins
+              # Nested subdirectory mount; overlays only /plugins/thirdparty.
+              mountPath: /plugins/thirdparty
+              readOnly: true
+      volumes:
+        - name: firstparty-plugins
+          image:
+            # First-party carrier, at the SAME tag as the host image above.
+            reference: apache/skywalking-banyandb:<TAG>-plugins-carrier
+            pullPolicy: IfNotPresent
+        - name: thirdparty-plugins
+          image:
+            # Operator's own plugin image; may be scratch-based (.so only)
+            # because an image volume is mounted directly, never `cp`-ed.
+            reference: registry.example.com/acme/banyandb-plugins:1.0.0
+            pullPolicy: IfNotPresent

--- a/examples/kubernetes/plugins/third-party-init-container.yaml
+++ b/examples/kubernetes/plugins/third-party-init-container.yaml
@@ -1,0 +1,85 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Data-node StatefulSet fragment: FIRST-PARTY + THIRD-PARTY plugins together
+# via the PORTABLE initContainer + emptyDir mechanism (all Kubernetes versions,
+# incl. pre-1.31 without image-volume support). See docs/operation/plugins.md.
+#
+# One shared emptyDir is mounted at /plugins in the main container. Two
+# initContainers populate it before the node starts:
+#   - the first-party CARRIER (busybox-based) copies its .so into /plugins/
+#     -> SamplerPlugin.path=<name>.so
+#   - the operator's third-party carrier copies its .so into /plugins/thirdparty/
+#     -> SamplerPlugin.path=thirdparty/<name>.so
+# Both carrier images need a shell + `cp` (busybox-based); a scratch/.so-only
+# image can't do this — use the image-volume mechanism for those.
+#
+# PARITY: the first-party carrier tag MUST equal the host image tag (lockstep).
+# Third-party .so parity is the operator's responsibility; a mismatch is
+# rejected loudly (fail-open: ERROR log + sampler_load_failed), never silently.
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: banyandb-data
+  labels:
+    app.kubernetes.io/name: banyandb
+    app.kubernetes.io/component: data
+spec:
+  serviceName: banyandb-data
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: banyandb
+      app.kubernetes.io/component: data
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: banyandb
+        app.kubernetes.io/component: data
+    spec:
+      initContainers:
+        - name: install-firstparty-plugins
+          # First-party busybox carrier at the SAME tag as the host image.
+          image: apache/skywalking-banyandb:<TAG>-plugins-carrier
+          command: ["sh", "-c", "cp /plugins/*.so /out/"]
+          volumeMounts:
+            - name: plugins
+              mountPath: /out
+        - name: install-thirdparty-plugins
+          # Operator's own busybox-based carrier (needs a shell + cp).
+          image: registry.example.com/acme/banyandb-plugins-carrier:1.0.0
+          command: ["sh", "-c", "mkdir -p /out/thirdparty && cp /opt/plugins/*.so /out/thirdparty/"]
+          volumeMounts:
+            - name: plugins
+              mountPath: /out
+      containers:
+        - name: banyandb-data
+          image: apache/skywalking-banyandb:<TAG>-plugins
+          args:
+            - data
+            - -trace-pipeline-native-plugin-enabled=true
+            - -trace-pipeline-trusted-plugin-dir=/plugins
+          ports:
+            - name: grpc
+              containerPort: 17912
+            - name: http
+              containerPort: 17913
+          volumeMounts:
+            - name: plugins
+              mountPath: /plugins
+      volumes:
+        - name: plugins
+          emptyDir: {}

--- a/pkg/pipeline/sdk/chain.go
+++ b/pkg/pipeline/sdk/chain.go
@@ -1,0 +1,126 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package sdk
+
+import "fmt"
+
+// Bypass reasons reported via BypassInfo.Reason. A link is bypassed
+// (pass-through: the running keep-mask is left unchanged for that link) for
+// exactly one of these three causes.
+const (
+	// BypassReasonDecideError means Sampler.Decide returned a non-nil error.
+	BypassReasonDecideError = "decide_error"
+	// BypassReasonLengthMismatch means Verdict.Keep's length did not match
+	// len(batch.Traces).
+	BypassReasonLengthMismatch = "length_mismatch"
+	// BypassReasonPanic means Sampler.Decide panicked; the panic was recovered.
+	// Distinguished from BypassReasonDecideError so callers can tell "the
+	// plugin returned an error" apart from "the plugin crashed" even though
+	// both fail open identically.
+	BypassReasonPanic = "panic"
+)
+
+// BypassInfo describes why EvaluateChain bypassed one chain link.
+type BypassInfo struct {
+	// Err is the Decide error (BypassReasonDecideError) or the recovered
+	// panic wrapped as an error (BypassReasonPanic). Nil for
+	// BypassReasonLengthMismatch.
+	Err error
+	// Reason classifies why the link was bypassed: one of
+	// BypassReasonDecideError, BypassReasonLengthMismatch, or
+	// BypassReasonPanic.
+	Reason string
+	// Got is len(Verdict.Keep) as returned by the link (BypassReasonLengthMismatch only).
+	Got int
+	// Want is len(batch.Traces) (BypassReasonLengthMismatch only).
+	Want int
+}
+
+// EvaluateChain runs an ordered sampler chain over batch and returns the
+// conjunction (AND) keep-mask. It is the single shared implementation of
+// chain-evaluation semantics — the host engine's merge chain
+// (banyand/trace's mergeChain.runChain) and the offline
+// pkg/pipeline/sdk/sdktest.RunChain harness both call this function, so how a
+// chain of samplers combines into one verdict is never duplicated or allowed
+// to drift between the two.
+//
+// Every sampler runs, in declared order, over the SAME batch — a chain link
+// narrows the running mask, it does not filter rows out of what the next
+// link sees. A link that panics, errors, or returns a keep-mask of the wrong
+// length is bypassed: the running mask is left unchanged for that link
+// (fail-open, per link), and onBypass — when non-nil — is invoked with the
+// link's index and a BypassInfo describing why.
+//
+// onBypass is the sole observability seam: it lets a caller log and/or count
+// a bypass without EvaluateChain importing a logger or meter (this package
+// must stay dependency-pure — see importgraph_test.go). The host passes an
+// onBypass that reproduces its pre-existing WARN log (and, going forward,
+// increments a metric); sdktest.RunChain passes a recorder that captures
+// every BypassInfo into its Report for offline inspection.
+func EvaluateChain(samplers []Sampler, batch *TraceBatch, onBypass func(idx int, info BypassInfo)) Verdict {
+	mask := make([]bool, len(batch.Traces))
+	for i := range mask {
+		mask[i] = true
+	}
+	for idx, sampler := range samplers {
+		if sampler == nil {
+			continue
+		}
+		applyChainLink(idx, sampler, batch, mask, onBypass)
+	}
+	return Verdict{Keep: mask}
+}
+
+// applyChainLink calls sampler.Decide under recover and ANDs its keep mask
+// into mask. On panic, error, or length mismatch the link is bypassed (mask
+// unchanged) and onBypass, if non-nil, is invoked with the classified reason.
+func applyChainLink(idx int, sampler Sampler, batch *TraceBatch, mask []bool, onBypass func(idx int, info BypassInfo)) {
+	var (
+		verdict   Verdict
+		decErr    error
+		recovered bool
+	)
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				recovered = true
+				decErr = fmt.Errorf("plugin panic: %v", r)
+			}
+		}()
+		verdict, decErr = sampler.Decide(batch)
+	}()
+	if decErr != nil {
+		if onBypass != nil {
+			reason := BypassReasonDecideError
+			if recovered {
+				reason = BypassReasonPanic
+			}
+			onBypass(idx, BypassInfo{Reason: reason, Err: decErr})
+		}
+		return
+	}
+	if len(verdict.Keep) != len(batch.Traces) {
+		if onBypass != nil {
+			onBypass(idx, BypassInfo{Reason: BypassReasonLengthMismatch, Got: len(verdict.Keep), Want: len(batch.Traces)})
+		}
+		return
+	}
+	for i := range mask {
+		mask[i] = mask[i] && verdict.Keep[i]
+	}
+}

--- a/pkg/pipeline/sdk/chain_test.go
+++ b/pkg/pipeline/sdk/chain_test.go
@@ -1,0 +1,123 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package sdk_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/apache/skywalking-banyandb/pkg/pipeline/sdk"
+)
+
+// chainFakeSampler is a minimal sdk.Sampler used to drive EvaluateChain
+// without a real .so. It optionally panics, errors, or returns a
+// wrong-length verdict to exercise the three bypass reasons.
+type chainFakeSampler struct {
+	dropIDs   map[string]struct{}
+	panicNow  bool
+	errNow    bool
+	wrongSize bool
+}
+
+func (f *chainFakeSampler) Kind() sdk.Kind          { return sdk.KindSampler }
+func (f *chainFakeSampler) Project() sdk.Projection { return sdk.Projection{} }
+func (f *chainFakeSampler) Close() error            { return nil }
+
+func (f *chainFakeSampler) Decide(batch *sdk.TraceBatch) (sdk.Verdict, error) {
+	if f.panicNow {
+		panic("boom")
+	}
+	if f.errNow {
+		return sdk.Verdict{}, fmt.Errorf("sampler error")
+	}
+	if f.wrongSize {
+		return sdk.Verdict{Keep: []bool{true}}, nil
+	}
+	keep := make([]bool, len(batch.Traces))
+	for i := range batch.Traces {
+		_, drop := f.dropIDs[batch.Traces[i].TraceID]
+		keep[i] = !drop
+	}
+	return sdk.Verdict{Keep: keep}, nil
+}
+
+func batchOf(ids ...string) *sdk.TraceBatch {
+	traces := make([]sdk.TraceBlock, len(ids))
+	for i, id := range ids {
+		traces[i] = sdk.TraceBlock{TraceID: id}
+	}
+	return &sdk.TraceBatch{Traces: traces}
+}
+
+func TestEvaluateChain_Conjunction(t *testing.T) {
+	batch := batchOf("a", "b", "c")
+	s1 := &chainFakeSampler{dropIDs: map[string]struct{}{"b": {}}}
+	s2 := &chainFakeSampler{dropIDs: map[string]struct{}{"c": {}}}
+	verdict := sdk.EvaluateChain([]sdk.Sampler{s1, s2}, batch, nil)
+	require.Equal(t, []bool{true, false, false}, verdict.Keep)
+}
+
+func TestEvaluateChain_NilSamplerSkipped(t *testing.T) {
+	batch := batchOf("a", "b")
+	verdict := sdk.EvaluateChain([]sdk.Sampler{nil, &chainFakeSampler{}}, batch, nil)
+	require.Equal(t, []bool{true, true}, verdict.Keep)
+}
+
+func TestEvaluateChain_DecideErrorBypasses(t *testing.T) {
+	batch := batchOf("a", "b")
+	var got []sdk.BypassInfo
+	verdict := sdk.EvaluateChain([]sdk.Sampler{&chainFakeSampler{errNow: true}}, batch,
+		func(_ int, info sdk.BypassInfo) { got = append(got, info) })
+	require.Equal(t, []bool{true, true}, verdict.Keep, "error link is bypassed => retain")
+	require.Len(t, got, 1)
+	assert.Equal(t, sdk.BypassReasonDecideError, got[0].Reason)
+	assert.Error(t, got[0].Err)
+}
+
+func TestEvaluateChain_PanicBypasses(t *testing.T) {
+	batch := batchOf("a", "b")
+	var got []sdk.BypassInfo
+	verdict := sdk.EvaluateChain([]sdk.Sampler{&chainFakeSampler{panicNow: true}}, batch,
+		func(_ int, info sdk.BypassInfo) { got = append(got, info) })
+	require.Equal(t, []bool{true, true}, verdict.Keep, "panicking link is bypassed => retain")
+	require.Len(t, got, 1)
+	assert.Equal(t, sdk.BypassReasonPanic, got[0].Reason)
+	assert.Error(t, got[0].Err)
+}
+
+func TestEvaluateChain_LengthMismatchBypasses(t *testing.T) {
+	batch := batchOf("a", "b", "c")
+	var got []sdk.BypassInfo
+	verdict := sdk.EvaluateChain([]sdk.Sampler{&chainFakeSampler{wrongSize: true}}, batch,
+		func(_ int, info sdk.BypassInfo) { got = append(got, info) })
+	require.Equal(t, []bool{true, true, true}, verdict.Keep, "length-mismatched link is bypassed => retain")
+	require.Len(t, got, 1)
+	assert.Equal(t, sdk.BypassReasonLengthMismatch, got[0].Reason)
+	assert.Equal(t, 1, got[0].Got)
+	assert.Equal(t, 3, got[0].Want)
+}
+
+func TestEvaluateChain_OnBypassNilIsSafe(t *testing.T) {
+	batch := batchOf("a")
+	require.NotPanics(t, func() {
+		sdk.EvaluateChain([]sdk.Sampler{&chainFakeSampler{panicNow: true}}, batch, nil)
+	})
+}

--- a/pkg/pipeline/sdk/encode.go
+++ b/pkg/pipeline/sdk/encode.go
@@ -1,0 +1,122 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package sdk
+
+import (
+	"fmt"
+
+	"github.com/apache/skywalking-banyandb/pkg/convert"
+	"github.com/apache/skywalking-banyandb/pkg/encoding/vararray"
+	"github.com/apache/skywalking-banyandb/pkg/pb/v1/valuetype"
+)
+
+// int64Width is the byte width of one encoded int64 (matches convert.Int64ToBytes).
+const int64Width = 8
+
+// EncodeTagValue marshals a raw Go value into the native tag-value byte
+// layout that DecodeTagValue decodes — the inverse of DecodeTagValue. It
+// deliberately takes a plain Go value (any), not a Value: Value's fields are
+// unexported and this package exports no constructor for it, so an encoder
+// built around Value would be unconstructible from outside this package
+// (e.g. from pkg/pipeline/sdk/sdktest, a different package, or a plugin
+// author's own test) — defeating the purpose of a shared, reusable encoder.
+//
+// Only a genuinely nil v (an untyped nil `any`) encodes to a nil raw value —
+// the native "tag absent on this row" representation. A present-but-empty
+// collection ([]byte{}, []string{}, []int64{}) encodes to a NON-nil empty
+// raw value, so it decodes back as an empty value rather than as null,
+// consistently across all three collection types.
+//
+// Supported (vt, Go type) pairs:
+//   - ValueTypeStr:        string
+//   - ValueTypeInt64:      int64
+//   - ValueTypeTimestamp:  int64 (unix nanoseconds; same 8-byte wire layout as Int64)
+//   - ValueTypeFloat64:    float64
+//   - ValueTypeBinaryData: []byte
+//   - ValueTypeStrArr:     []string
+//   - ValueTypeInt64Arr:   []int64
+//
+// A mismatch between vt and v's concrete Go type, or an unsupported vt,
+// returns an error.
+func EncodeTagValue(vt valuetype.ValueType, v any) ([]byte, error) {
+	if v == nil {
+		return nil, nil
+	}
+	switch vt {
+	case valuetype.ValueTypeStr:
+		s, ok := v.(string)
+		if !ok {
+			return nil, fmt.Errorf("EncodeTagValue: ValueTypeStr requires a string, got %T", v)
+		}
+		// Allocated copy — NOT convert.StringToBytes, whose unsafe zero-copy
+		// slice aliases the string's read-only backing memory and must not be
+		// handed out as a mutable []byte. An empty string is a value (not null),
+		// so it encodes to a non-nil empty slice; only a nil `v` (handled above)
+		// encodes to a nil raw, which DecodeTagValue reads back as null.
+		if len(s) == 0 {
+			return []byte{}, nil
+		}
+		return []byte(s), nil
+	case valuetype.ValueTypeInt64, valuetype.ValueTypeTimestamp:
+		i, ok := v.(int64)
+		if !ok {
+			return nil, fmt.Errorf("EncodeTagValue: value type %d requires an int64, got %T", vt, v)
+		}
+		return convert.Int64ToBytes(i), nil
+	case valuetype.ValueTypeFloat64:
+		f, ok := v.(float64)
+		if !ok {
+			return nil, fmt.Errorf("EncodeTagValue: ValueTypeFloat64 requires a float64, got %T", v)
+		}
+		return convert.Float64ToBytes(f), nil
+	case valuetype.ValueTypeBinaryData:
+		b, ok := v.([]byte)
+		if !ok {
+			return nil, fmt.Errorf("EncodeTagValue: ValueTypeBinaryData requires a []byte, got %T", v)
+		}
+		// make (not append to a nil slice) so a present-but-empty []byte
+		// yields a non-nil empty result rather than nil (which decodes as null).
+		out := make([]byte, len(b))
+		copy(out, b)
+		return out, nil
+	case valuetype.ValueTypeStrArr:
+		arr, ok := v.([]string)
+		if !ok {
+			return nil, fmt.Errorf("EncodeTagValue: ValueTypeStrArr requires a []string, got %T", v)
+		}
+		// Start from a non-nil empty slice so an empty []string encodes to a
+		// non-nil empty result (present, not null), consistent with []int64.
+		dst := []byte{}
+		for _, s := range arr {
+			dst = vararray.MarshalVarArray(dst, convert.StringToBytes(s))
+		}
+		return dst, nil
+	case valuetype.ValueTypeInt64Arr:
+		arr, ok := v.([]int64)
+		if !ok {
+			return nil, fmt.Errorf("EncodeTagValue: ValueTypeInt64Arr requires a []int64, got %T", v)
+		}
+		dst := make([]byte, 0, len(arr)*int64Width)
+		for _, i := range arr {
+			dst = append(dst, convert.Int64ToBytes(i)...)
+		}
+		return dst, nil
+	default:
+		return nil, fmt.Errorf("EncodeTagValue: unsupported value type: %d", vt)
+	}
+}

--- a/pkg/pipeline/sdk/encode_test.go
+++ b/pkg/pipeline/sdk/encode_test.go
@@ -1,0 +1,156 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package sdk_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pbv1 "github.com/apache/skywalking-banyandb/pkg/pb/v1"
+	"github.com/apache/skywalking-banyandb/pkg/pipeline/sdk"
+)
+
+// TestEncodeTagValueRoundTrip proves EncodeTagValue is the true inverse of
+// DecodeTagValue for every valuetype.ValueType: encode a raw Go value, decode
+// the result, and assert the decoded Value equals the original input.
+func TestEncodeTagValueRoundTrip(t *testing.T) {
+	tests := []struct {
+		goVal  any
+		verify func(*testing.T, sdk.Value)
+		name   string
+		vt     pbv1.ValueType
+	}{
+		{
+			name: "str", vt: pbv1.ValueTypeStr, goVal: "PostgreSQL",
+			verify: func(t *testing.T, v sdk.Value) { assert.Equal(t, "PostgreSQL", v.Str()) },
+		},
+		{
+			name: "int64", vt: pbv1.ValueTypeInt64, goVal: int64(-42),
+			verify: func(t *testing.T, v sdk.Value) { assert.Equal(t, int64(-42), v.Int64()) },
+		},
+		{
+			name: "timestamp", vt: pbv1.ValueTypeTimestamp, goVal: int64(1_700_000_000_000_000_000),
+			verify: func(t *testing.T, v sdk.Value) {
+				assert.Equal(t, int64(1_700_000_000_000_000_000), v.Int64())
+			},
+		},
+		{
+			name: "float64", vt: pbv1.ValueTypeFloat64, goVal: 3.5,
+			verify: func(t *testing.T, v sdk.Value) { assert.InDelta(t, 3.5, v.Float64(), 1e-9) },
+		},
+		{
+			name: "binary", vt: pbv1.ValueTypeBinaryData, goVal: []byte{0x01, 0x02, 0x03},
+			verify: func(t *testing.T, v sdk.Value) { assert.Equal(t, []byte{0x01, 0x02, 0x03}, v.Bytes()) },
+		},
+		{
+			name: "str_arr", vt: pbv1.ValueTypeStrArr, goVal: []string{"a", "bb", "ccc"},
+			verify: func(t *testing.T, v sdk.Value) { assert.Equal(t, []string{"a", "bb", "ccc"}, v.StrArr()) },
+		},
+		{
+			name: "str_arr_with_delimiters", vt: pbv1.ValueTypeStrArr, goVal: []string{"a|b", `c\d`, ""},
+			verify: func(t *testing.T, v sdk.Value) { assert.Equal(t, []string{"a|b", `c\d`, ""}, v.StrArr()) },
+		},
+		{
+			name: "int64_arr", vt: pbv1.ValueTypeInt64Arr, goVal: []int64{1, -2, 3},
+			verify: func(t *testing.T, v sdk.Value) { assert.Equal(t, []int64{1, -2, 3}, v.Int64Arr()) },
+		},
+		{
+			name: "nil_is_null", vt: pbv1.ValueTypeStr, goVal: nil,
+			verify: func(t *testing.T, v sdk.Value) { assert.True(t, v.IsNull()) },
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw, encErr := sdk.EncodeTagValue(tt.vt, tt.goVal)
+			require.NoError(t, encErr)
+			decoded, decErr := sdk.DecodeTagValue(tt.vt, raw)
+			require.NoError(t, decErr)
+			assert.Equal(t, tt.vt, decoded.ValueType())
+			tt.verify(t, decoded)
+		})
+	}
+}
+
+// TestEncodeTagValueTypeMismatch asserts a Go value whose type does not match
+// vt is rejected rather than silently mis-encoded.
+func TestEncodeTagValueTypeMismatch(t *testing.T) {
+	tests := []struct {
+		goVal any
+		name  string
+		vt    pbv1.ValueType
+	}{
+		{name: "str_wants_string", vt: pbv1.ValueTypeStr, goVal: 42},
+		{name: "int64_wants_int64", vt: pbv1.ValueTypeInt64, goVal: "42"},
+		{name: "timestamp_wants_int64", vt: pbv1.ValueTypeTimestamp, goVal: 42},
+		{name: "float64_wants_float64", vt: pbv1.ValueTypeFloat64, goVal: int64(1)},
+		{name: "binary_wants_bytes", vt: pbv1.ValueTypeBinaryData, goVal: "not bytes"},
+		{name: "str_arr_wants_slice", vt: pbv1.ValueTypeStrArr, goVal: "not a slice"},
+		{name: "int64_arr_wants_slice", vt: pbv1.ValueTypeInt64Arr, goVal: []string{"1"}},
+		{name: "unsupported_value_type", vt: pbv1.ValueType(255), goVal: "x"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := sdk.EncodeTagValue(tt.vt, tt.goVal)
+			require.Error(t, err)
+		})
+	}
+}
+
+// TestEncodeTagValueNilAlwaysNull proves a nil Go value encodes to a nil raw
+// value (the native "tag absent" representation) regardless of vt.
+func TestEncodeTagValueNilAlwaysNull(t *testing.T) {
+	for _, vt := range []pbv1.ValueType{
+		pbv1.ValueTypeStr, pbv1.ValueTypeInt64, pbv1.ValueTypeFloat64,
+		pbv1.ValueTypeBinaryData, pbv1.ValueTypeStrArr, pbv1.ValueTypeInt64Arr, pbv1.ValueTypeTimestamp,
+	} {
+		raw, err := sdk.EncodeTagValue(vt, nil)
+		require.NoError(t, err)
+		assert.Nil(t, raw)
+	}
+}
+
+// TestEncodeTagValueEmptyCollectionsAreNotNull proves that a present-but-empty
+// collection ([]byte{}, []string{}, []int64{}) encodes to a NON-nil raw value
+// consistently across all three types, so it decodes back as an empty (not
+// null) value — distinguishing "tag present, empty" from "tag absent". Only a
+// genuinely nil Go value (covered by TestEncodeTagValueNilAlwaysNull) is null.
+func TestEncodeTagValueEmptyCollectionsAreNotNull(t *testing.T) {
+	cases := []struct {
+		goVal any
+		name  string
+		vt    pbv1.ValueType
+	}{
+		{name: "empty_bytes", vt: pbv1.ValueTypeBinaryData, goVal: []byte{}},
+		{name: "empty_str_arr", vt: pbv1.ValueTypeStrArr, goVal: []string{}},
+		{name: "empty_int64_arr", vt: pbv1.ValueTypeInt64Arr, goVal: []int64{}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, encErr := sdk.EncodeTagValue(tc.vt, tc.goVal)
+			require.NoError(t, encErr)
+			assert.NotNil(t, raw, "an empty collection must encode to a non-nil raw value")
+
+			decoded, decErr := sdk.DecodeTagValue(tc.vt, raw)
+			require.NoError(t, decErr)
+			assert.False(t, decoded.IsNull(), "an empty collection must decode as present (not null)")
+			assert.Equal(t, tc.vt, decoded.ValueType())
+		})
+	}
+}

--- a/pkg/pipeline/sdk/loader.go
+++ b/pkg/pipeline/sdk/loader.go
@@ -1,0 +1,90 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package sdk
+
+import (
+	"fmt"
+	"plugin"
+)
+
+// OpenSampler opens the .so at path, verifies its exported ABIVersion symbol
+// matches this package's ABIVersion, looks up the constructor symbol, and
+// calls it with cfg (the canonical JSON encoding of the plugin's config).
+//
+// This is the ONE loader-contract implementation: banyand/trace's host loader
+// delegates here, pkg/pipeline/sdk/sdktest.LoadSO calls it directly to drive a
+// real .so offline, and any future toolchain-authoritative CLI validate/decide
+// command would call it too — so every caller runs the exact same code path,
+// never a hand-rolled mirror that can silently drift from the host.
+//
+// A panic while opening the plugin or while running its constructor is
+// recovered and returned as an error; OpenSampler itself never panics.
+func OpenSampler(path, symbol string, cfg []byte) (Sampler, error) {
+	var p *plugin.Plugin
+	var openErr error
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				openErr = fmt.Errorf("panic opening plugin %q: %v", path, r)
+			}
+		}()
+		p, openErr = plugin.Open(path)
+	}()
+	if openErr != nil {
+		return nil, fmt.Errorf("cannot open plugin %q: %w", path, openErr)
+	}
+
+	abiSym, lookupErr := p.Lookup("ABIVersion")
+	if lookupErr != nil {
+		return nil, fmt.Errorf("plugin %q missing ABIVersion symbol: %w", path, lookupErr)
+	}
+	pluginABI, ok := abiSym.(*int)
+	if !ok {
+		return nil, fmt.Errorf("plugin %q ABIVersion has wrong type", path)
+	}
+	if *pluginABI != ABIVersion {
+		return nil, fmt.Errorf("plugin %q ABI version %d does not match engine %d", path, *pluginABI, ABIVersion)
+	}
+
+	ctorSym, lookupErr := p.Lookup(symbol)
+	if lookupErr != nil {
+		return nil, fmt.Errorf("plugin %q missing symbol %q: %w", path, symbol, lookupErr)
+	}
+	ctor, ok := ctorSym.(func([]byte) (Sampler, error))
+	if !ok {
+		return nil, fmt.Errorf("plugin %q symbol %q has wrong type", path, symbol)
+	}
+
+	var sampler Sampler
+	var ctorErr error
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				ctorErr = fmt.Errorf("panic in plugin %q constructor: %v", path, r)
+			}
+		}()
+		sampler, ctorErr = ctor(cfg)
+	}()
+	if ctorErr != nil {
+		return nil, fmt.Errorf("plugin %q constructor failed: %w", path, ctorErr)
+	}
+	if sampler == nil {
+		return nil, fmt.Errorf("plugin %q constructor returned nil sampler", path)
+	}
+	return sampler, nil
+}

--- a/pkg/pipeline/sdk/sdktest/chain.go
+++ b/pkg/pipeline/sdk/sdktest/chain.go
@@ -1,0 +1,49 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package sdktest
+
+import "github.com/apache/skywalking-banyandb/pkg/pipeline/sdk"
+
+// ChainBypass pairs a bypassed link's index (position in the samplers slice
+// passed to RunChain) with the reason it was bypassed.
+type ChainBypass struct {
+	sdk.BypassInfo
+	// Idx is the bypassed link's index in the samplers slice.
+	Idx int
+}
+
+// ChainReport records every link RunChain's underlying sdk.EvaluateChain
+// bypassed, in evaluation order.
+type ChainReport struct {
+	Bypassed []ChainBypass
+}
+
+// RunChain evaluates samplers over batch via the shared sdk.EvaluateChain —
+// the exact AND-aggregation + per-link panic/error/length-mismatch fail-open
+// logic the real engine's merge chain runs — recording every bypassed link
+// into the returned ChainReport instead of logging it. This makes the chain
+// harness golden-file friendly and gives a plugin author the same
+// "why was this link skipped" visibility the host's WARN log carries, without
+// a cluster.
+func RunChain(samplers []sdk.Sampler, batch *sdk.TraceBatch) (sdk.Verdict, ChainReport) {
+	var report ChainReport
+	verdict := sdk.EvaluateChain(samplers, batch, func(idx int, info sdk.BypassInfo) {
+		report.Bypassed = append(report.Bypassed, ChainBypass{Idx: idx, BypassInfo: info})
+	})
+	return verdict, report
+}

--- a/pkg/pipeline/sdk/sdktest/chain_harness_test.go
+++ b/pkg/pipeline/sdk/sdktest/chain_harness_test.go
@@ -1,0 +1,105 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package sdktest_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/apache/skywalking-banyandb/pkg/pipeline/sdk"
+	"github.com/apache/skywalking-banyandb/pkg/pipeline/sdk/sdktest"
+)
+
+// chainHarnessSampler is a minimal, configurable sdk.Sampler for exercising
+// RunChain's bypass-recording behavior.
+type chainHarnessSampler struct {
+	dropIDs   map[string]struct{}
+	panicNow  bool
+	errNow    bool
+	wrongSize bool
+}
+
+func (f *chainHarnessSampler) Kind() sdk.Kind          { return sdk.KindSampler }
+func (f *chainHarnessSampler) Project() sdk.Projection { return sdk.Projection{} }
+func (f *chainHarnessSampler) Close() error            { return nil }
+func (f *chainHarnessSampler) Decide(batch *sdk.TraceBatch) (sdk.Verdict, error) {
+	if f.panicNow {
+		panic("boom")
+	}
+	if f.errNow {
+		return sdk.Verdict{}, fmt.Errorf("sampler error")
+	}
+	if f.wrongSize {
+		return sdk.Verdict{Keep: []bool{true}}, nil
+	}
+	keep := make([]bool, len(batch.Traces))
+	for i := range batch.Traces {
+		_, drop := f.dropIDs[batch.Traces[i].TraceID]
+		keep[i] = !drop
+	}
+	return sdk.Verdict{Keep: keep}, nil
+}
+
+func TestRunChain_Conjunction(t *testing.T) {
+	a, err := sdktest.NewTrace("a").Build()
+	require.NoError(t, err)
+	b, err := sdktest.NewTrace("b").Build()
+	require.NoError(t, err)
+	batch := sdktest.Batch(a, b)
+
+	s1 := &chainHarnessSampler{dropIDs: map[string]struct{}{"a": {}}}
+	verdict, report := sdktest.RunChain([]sdk.Sampler{s1}, batch)
+	assert.Equal(t, []bool{false, true}, verdict.Keep)
+	assert.Empty(t, report.Bypassed)
+}
+
+func TestRunChain_RecordsBypassReasons(t *testing.T) {
+	trace, err := sdktest.NewTrace("a").Build()
+	require.NoError(t, err)
+	batch := sdktest.Batch(trace)
+
+	samplers := []sdk.Sampler{
+		&chainHarnessSampler{errNow: true},
+		&chainHarnessSampler{panicNow: true},
+		&chainHarnessSampler{},
+	}
+	verdict, report := sdktest.RunChain(samplers, batch)
+	assert.Equal(t, []bool{true}, verdict.Keep, "both failing links bypass; the healthy link keeps everything")
+	require.Len(t, report.Bypassed, 2)
+	assert.Equal(t, 0, report.Bypassed[0].Idx)
+	assert.Equal(t, sdk.BypassReasonDecideError, report.Bypassed[0].Reason)
+	assert.Equal(t, 1, report.Bypassed[1].Idx)
+	assert.Equal(t, sdk.BypassReasonPanic, report.Bypassed[1].Reason)
+}
+
+func TestRunChain_LengthMismatchRecorded(t *testing.T) {
+	a, err := sdktest.NewTrace("a").Build()
+	require.NoError(t, err)
+	b, err := sdktest.NewTrace("b").Build()
+	require.NoError(t, err)
+	batch := sdktest.Batch(a, b)
+
+	_, report := sdktest.RunChain([]sdk.Sampler{&chainHarnessSampler{wrongSize: true}}, batch)
+	require.Len(t, report.Bypassed, 1)
+	assert.Equal(t, sdk.BypassReasonLengthMismatch, report.Bypassed[0].Reason)
+	assert.Equal(t, 1, report.Bypassed[0].Got)
+	assert.Equal(t, 2, report.Bypassed[0].Want)
+}

--- a/pkg/pipeline/sdk/sdktest/fixture.go
+++ b/pkg/pipeline/sdk/sdktest/fixture.go
@@ -1,0 +1,230 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package sdktest is an offline test kit for pkg/pipeline/sdk sampler
+// plugins: a fixture builder, a differential projection-guard runner, a
+// chain harness, and a real-.so loader — all without a database or a
+// cluster. It depends only on pkg/pipeline/sdk and the SDK-blessed leaves
+// (pkg/pb/v1/valuetype transitively via sdk); it never imports banyand/trace,
+// a logger, or a meter (see importgraph_test.go).
+//
+// Every marshaling and loader-contract operation here goes through the
+// exported pkg/pipeline/sdk helpers (EncodeTagValue, OpenSampler,
+// EvaluateChain) — the same functions the real engine uses — so this kit
+// cannot silently drift from production behavior; see
+// pkg/pipeline/sdk/sdktest's conformance test in banyand/trace for the golden
+// check that keeps it that way.
+package sdktest
+
+import (
+	"fmt"
+
+	"github.com/apache/skywalking-banyandb/pkg/pb/v1/valuetype"
+	"github.com/apache/skywalking-banyandb/pkg/pipeline/sdk"
+)
+
+// TraceBuilder builds one sdk.TraceBlock fixture, fluently. Create one with
+// NewTrace, add tags/spans, then call Build.
+type TraceBuilder struct {
+	err      error
+	tagVals  map[string][]any
+	tagVT    map[string]valuetype.ValueType
+	id       string
+	tagOrder []string
+	spanIDs  []string
+	spans    [][]byte
+	minTS    int64
+	maxTS    int64
+}
+
+// NewTrace starts a fixture for the trace identified by id.
+func NewTrace(id string) *TraceBuilder {
+	return &TraceBuilder{
+		id:      id,
+		tagVals: make(map[string][]any),
+		tagVT:   make(map[string]valuetype.ValueType),
+	}
+}
+
+// Tag sets a tag value, inferring its ValueType from goVal's Go type (string,
+// int64, float64, []byte, []string, or []int64). Because int64 backs both
+// ValueTypeInt64 and ValueTypeTimestamp, and []byte could mean
+// ValueTypeBinaryData, Tag always infers the more common Int64/none-binary
+// reading; call TagAs to disambiguate a Timestamp or to be explicit.
+//
+// Calling Tag (or TagAs) more than once for the same name appends a
+// per-row value to that tag's column (row i gets the i'th call's value); a
+// single call broadcasts that one value to every row of the trace. Rows are
+// otherwise established by SpanID/Span calls, or default to a single row.
+func (b *TraceBuilder) Tag(name string, goVal any) *TraceBuilder {
+	vt, inferErr := inferValueType(goVal)
+	if inferErr != nil {
+		if b.err == nil {
+			b.err = fmt.Errorf("tag %q: %w", name, inferErr)
+		}
+		return b
+	}
+	return b.TagAs(name, vt, goVal)
+}
+
+// TagAs sets a tag value with an explicit ValueType, disambiguating cases
+// Tag cannot infer (ValueTypeTimestamp vs plain int64) or is required for a
+// consistently-typed column across multiple rows. See Tag for the
+// broadcast-vs-per-row append semantics.
+func (b *TraceBuilder) TagAs(name string, vt valuetype.ValueType, goVal any) *TraceBuilder {
+	if existingVT, exists := b.tagVT[name]; exists && existingVT != vt {
+		if b.err == nil {
+			b.err = fmt.Errorf("tag %q: value type changed from %d to %d across calls", name, existingVT, vt)
+		}
+		return b
+	}
+	if _, exists := b.tagVT[name]; !exists {
+		b.tagOrder = append(b.tagOrder, name)
+	}
+	b.tagVT[name] = vt
+	b.tagVals[name] = append(b.tagVals[name], goVal)
+	return b
+}
+
+// SpanID appends one row to the span-id column.
+func (b *TraceBuilder) SpanID(id string) *TraceBuilder {
+	b.spanIDs = append(b.spanIDs, id)
+	return b
+}
+
+// Span appends one row to the span-body column.
+func (b *TraceBuilder) Span(body []byte) *TraceBuilder {
+	b.spans = append(b.spans, body)
+	return b
+}
+
+// TS sets the trace's intrinsic MinTS/MaxTS (unix nanoseconds).
+func (b *TraceBuilder) TS(minTS, maxTS int64) *TraceBuilder {
+	b.minTS = minTS
+	b.maxTS = maxTS
+	return b
+}
+
+// Build assembles the fixture into an sdk.TraceBlock, encoding every tag
+// value via sdk.EncodeTagValue (the same encoder the offline tools and, via
+// its DecodeTagValue inverse, the real engine's decode path both trust). It
+// returns the first error recorded by Tag/TagAs, if any, or an encode error.
+func (b *TraceBuilder) Build() (sdk.TraceBlock, error) {
+	if b.err != nil {
+		return sdk.TraceBlock{}, b.err
+	}
+	rows := 1
+	if len(b.spanIDs) > rows {
+		rows = len(b.spanIDs)
+	}
+	if len(b.spans) > rows {
+		rows = len(b.spans)
+	}
+	for _, name := range b.tagOrder {
+		if n := len(b.tagVals[name]); n > rows {
+			rows = n
+		}
+	}
+
+	block := sdk.TraceBlock{TraceID: b.id, MinTS: b.minTS, MaxTS: b.maxTS}
+	if len(b.spanIDs) > 0 {
+		block.SpanIDs = padStrings(b.spanIDs, rows)
+	}
+	if len(b.spans) > 0 {
+		block.Spans = padBytes(b.spans, rows)
+	}
+	for _, name := range b.tagOrder {
+		vals := b.tagVals[name]
+		vt := b.tagVT[name]
+		col := sdk.TagColumn{Name: name, ValueType: vt, Values: make([][]byte, rows)}
+		for i := 0; i < rows; i++ {
+			v := rowValue(vals, i)
+			raw, encErr := sdk.EncodeTagValue(vt, v)
+			if encErr != nil {
+				return sdk.TraceBlock{}, fmt.Errorf("tag %q row %d: %w", name, i, encErr)
+			}
+			col.Values[i] = raw
+		}
+		block.Tags = append(block.Tags, col)
+	}
+	return block, nil
+}
+
+// rowValue returns vals[i] if present, the sole broadcast value when only one
+// was given, or nil (encodes to a null/absent tag on that row).
+func rowValue(vals []any, i int) any {
+	switch {
+	case len(vals) == 1:
+		return vals[0]
+	case i < len(vals):
+		return vals[i]
+	default:
+		return nil
+	}
+}
+
+// inferValueType maps a Go value's concrete type to the corresponding
+// valuetype.ValueType. nil and unsupported types return an error; the caller
+// (Tag) should fall back to TagAs.
+func inferValueType(goVal any) (valuetype.ValueType, error) {
+	switch goVal.(type) {
+	case string:
+		return valuetype.ValueTypeStr, nil
+	case int64:
+		return valuetype.ValueTypeInt64, nil
+	case float64:
+		return valuetype.ValueTypeFloat64, nil
+	case []byte:
+		return valuetype.ValueTypeBinaryData, nil
+	case []string:
+		return valuetype.ValueTypeStrArr, nil
+	case []int64:
+		return valuetype.ValueTypeInt64Arr, nil
+	case nil:
+		return valuetype.ValueTypeUnknown, fmt.Errorf("cannot infer value type from a nil value; use TagAs")
+	default:
+		return valuetype.ValueTypeUnknown, fmt.Errorf("cannot infer value type from %T; use TagAs", goVal)
+	}
+}
+
+// padStrings returns vals unchanged if it already has at least n elements,
+// otherwise a new right-padded (with "") copy of length n.
+func padStrings(vals []string, n int) []string {
+	if len(vals) >= n {
+		return vals
+	}
+	out := make([]string, n)
+	copy(out, vals)
+	return out
+}
+
+// padBytes returns vals unchanged if it already has at least n elements,
+// otherwise a new right-padded (with nil) copy of length n.
+func padBytes(vals [][]byte, n int) [][]byte {
+	if len(vals) >= n {
+		return vals
+	}
+	out := make([][]byte, n)
+	copy(out, vals)
+	return out
+}
+
+// Batch assembles a *sdk.TraceBatch from one or more built TraceBlocks — a
+// convenience for tests that would otherwise write out the literal struct.
+func Batch(blocks ...sdk.TraceBlock) *sdk.TraceBatch {
+	return &sdk.TraceBatch{Traces: blocks}
+}

--- a/pkg/pipeline/sdk/sdktest/fixture_test.go
+++ b/pkg/pipeline/sdk/sdktest/fixture_test.go
@@ -1,0 +1,139 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package sdktest_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/apache/skywalking-banyandb/pkg/pb/v1/valuetype"
+	"github.com/apache/skywalking-banyandb/pkg/pipeline/sdk/sdktest"
+)
+
+func TestTraceBuilder_SingleRowBroadcast(t *testing.T) {
+	block, err := sdktest.NewTrace("t1").
+		Tag("duration", int64(120)).
+		Tag("status", "success").
+		TS(100, 200).
+		Build()
+	require.NoError(t, err)
+
+	require.Equal(t, "t1", block.TraceID)
+	assert.Equal(t, int64(100), block.MinTS)
+	assert.Equal(t, int64(200), block.MaxTS)
+
+	durCol := block.Tag("duration")
+	require.NotNil(t, durCol)
+	durVal, decErr := durCol.At(0)
+	require.NoError(t, decErr)
+	assert.Equal(t, int64(120), durVal.Int64())
+
+	statusCol := block.Tag("status")
+	require.NotNil(t, statusCol)
+	statusVal, decErr := statusCol.At(0)
+	require.NoError(t, decErr)
+	assert.Equal(t, "success", statusVal.Str())
+}
+
+func TestTraceBuilder_MultiRowViaSpanID(t *testing.T) {
+	block, err := sdktest.NewTrace("t1").
+		SpanID("s1").
+		SpanID("s2").
+		SpanID("s3").
+		Tag("duration", int64(50)). // broadcast to all 3 rows
+		Build()
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"s1", "s2", "s3"}, block.SpanIDs)
+	durCol := block.Tag("duration")
+	require.NotNil(t, durCol)
+	require.Len(t, durCol.Values, 3)
+	for i := range 3 {
+		v, decErr := durCol.At(i)
+		require.NoError(t, decErr)
+		assert.Equal(t, int64(50), v.Int64())
+	}
+}
+
+func TestTraceBuilder_MultiRowPerRowTagValues(t *testing.T) {
+	block, err := sdktest.NewTrace("t1").
+		SpanID("s1").
+		SpanID("s2").
+		Tag("status", "ok").
+		Tag("status", "error").
+		Build()
+	require.NoError(t, err)
+
+	statusCol := block.Tag("status")
+	require.NotNil(t, statusCol)
+	v0, decErr := statusCol.At(0)
+	require.NoError(t, decErr)
+	assert.Equal(t, "ok", v0.Str())
+	v1, decErr := statusCol.At(1)
+	require.NoError(t, decErr)
+	assert.Equal(t, "error", v1.Str())
+}
+
+func TestTraceBuilder_TagAsDisambiguatesTimestamp(t *testing.T) {
+	block, err := sdktest.NewTrace("t1").
+		TagAs("startedAt", valuetype.ValueTypeTimestamp, int64(1_700_000_000_000_000_000)).
+		Build()
+	require.NoError(t, err)
+
+	col := block.Tag("startedAt")
+	require.NotNil(t, col)
+	assert.Equal(t, valuetype.ValueTypeTimestamp, col.ValueType)
+	v, decErr := col.At(0)
+	require.NoError(t, decErr)
+	assert.Equal(t, int64(1_700_000_000_000_000_000), v.Int64())
+}
+
+func TestTraceBuilder_InferenceErrorSurfacesAtBuild(t *testing.T) {
+	_, err := sdktest.NewTrace("t1").Tag("bad", nil).Build()
+	require.Error(t, err, "nil value cannot be inferred; TagAs is required")
+}
+
+func TestTraceBuilder_TypeMismatchSurfacesAtBuild(t *testing.T) {
+	_, err := sdktest.NewTrace("t1").
+		TagAs("duration", valuetype.ValueTypeInt64, "not an int64").
+		Build()
+	require.Error(t, err)
+}
+
+func TestTraceBuilder_Span(t *testing.T) {
+	block, err := sdktest.NewTrace("t1").
+		Span([]byte("span-body-1")).
+		Span([]byte("span-body-2")).
+		Build()
+	require.NoError(t, err)
+	require.Equal(t, [][]byte{[]byte("span-body-1"), []byte("span-body-2")}, block.Spans)
+}
+
+func TestBatch(t *testing.T) {
+	b1, err := sdktest.NewTrace("a").Build()
+	require.NoError(t, err)
+	b2, err := sdktest.NewTrace("b").Build()
+	require.NoError(t, err)
+
+	batch := sdktest.Batch(b1, b2)
+	require.Len(t, batch.Traces, 2)
+	assert.Equal(t, "a", batch.Traces[0].TraceID)
+	assert.Equal(t, "b", batch.Traces[1].TraceID)
+}

--- a/pkg/pipeline/sdk/sdktest/importgraph_test.go
+++ b/pkg/pipeline/sdk/sdktest/importgraph_test.go
@@ -1,0 +1,87 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package sdktest_test
+
+import (
+	"bufio"
+	"bytes"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestSDKTestImportGraph asserts that pkg/pipeline/sdk/sdktest — the offline
+// dev-toolkit package plugin authors depend on for their own tests — has NO
+// transitive dependency on banyand/* (the engine internals it exists to test
+// against without a cluster) or on any logging/meter package. This is a
+// dedicated denylist for sdktest: pkg/pipeline/sdk's own importgraph_test.go
+// only covers pkg/pipeline/sdk itself, and sdktest's dependency-purity is a
+// design property in its own right (it must stay usable from a plugin
+// author's own _test.go, which has no access to banyand-internal packages).
+func TestSDKTestImportGraph(t *testing.T) {
+	goPath, lookErr := exec.LookPath("go")
+	if lookErr != nil {
+		t.Skip("go binary not on PATH; skipping import-graph check")
+	}
+
+	forbidden := []string{
+		"github.com/apache/skywalking-banyandb/banyand",
+		"github.com/rs/zerolog",
+		"go.uber.org/zap",
+		"github.com/apache/skywalking-banyandb/pkg/logger",
+		"github.com/apache/skywalking-banyandb/pkg/meter",
+		// pkg/pb/v1 is heavy (it imports pkg/logger); sdktest must reach
+		// ValueType via pkg/pb/v1/valuetype (through pkg/pipeline/sdk) instead.
+		"github.com/apache/skywalking-banyandb/pkg/pb/v1",
+	}
+
+	deps := listDeps(t, goPath, "github.com/apache/skywalking-banyandb/pkg/pipeline/sdk/sdktest")
+
+	for _, banned := range forbidden {
+		if deps[banned] {
+			t.Errorf("pkg/pipeline/sdk/sdktest transitively imports forbidden package %q; "+
+				"the offline dev toolkit must stay usable outside the banyand module tree", banned)
+		}
+		for dep := range deps {
+			if dep == "github.com/apache/skywalking-banyandb/pkg/pb/v1/valuetype" {
+				continue
+			}
+			if strings.HasPrefix(dep, banned+"/") {
+				t.Errorf("pkg/pipeline/sdk/sdktest transitively imports forbidden package %q", dep)
+			}
+		}
+	}
+}
+
+// listDeps returns the full transitive import set of pkg as a set (map to bool).
+func listDeps(t *testing.T, goPath, pkg string) map[string]bool {
+	t.Helper()
+	cmd := exec.Command(goPath, "list", "-deps", pkg)
+	out, runErr := cmd.Output()
+	if runErr != nil {
+		t.Fatalf("go list -deps %s failed: %v", pkg, runErr)
+	}
+	deps := make(map[string]bool)
+	sc := bufio.NewScanner(bytes.NewReader(out))
+	for sc.Scan() {
+		if line := strings.TrimSpace(sc.Text()); line != "" {
+			deps[line] = true
+		}
+	}
+	return deps
+}

--- a/pkg/pipeline/sdk/sdktest/loader.go
+++ b/pkg/pipeline/sdk/sdktest/loader.go
@@ -1,0 +1,32 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package sdktest
+
+import "github.com/apache/skywalking-banyandb/pkg/pipeline/sdk"
+
+// LoadSO drives a REAL, loaded .so in-process: it opens path, verifies its
+// ABIVersion symbol, looks up symbol (the constructor), and calls it with
+// cfg. It is a thin pass-through to the shared sdk.OpenSampler — the exact
+// loader-contract implementation the host runs — NOT the unexported
+// banyand/trace.newSamplerFromPlugin var, which lives in a different package
+// tree and is unreachable from here. A plugin author can therefore drive
+// their built .so through the identical open/ABI-check/construct sequence the
+// server uses, offline, before ever deploying it.
+func LoadSO(path, symbol string, cfg []byte) (sdk.Sampler, error) {
+	return sdk.OpenSampler(path, symbol, cfg)
+}

--- a/pkg/pipeline/sdk/sdktest/loader_test.go
+++ b/pkg/pipeline/sdk/sdktest/loader_test.go
@@ -1,0 +1,123 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package sdktest_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/apache/skywalking-banyandb/pkg/pipeline/sdk/sdktest"
+)
+
+// seedPluginPkgPath is the path to the graduated first-party seed plugin,
+// relative to this file's directory (pkg/pipeline/sdk/sdktest).
+const seedPluginPkgPath = "../../../../plugins/skywalking/latencystatussampler"
+
+// isToolchainMismatch reports whether err is the Go runtime's rejection of a
+// .so whose build context differs from the host's (compiler version skew).
+func isToolchainMismatch(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "different version of package") ||
+		strings.Contains(msg, "plugin was built with a different version")
+}
+
+// buildSeedPlugin compiles the latencystatussampler seed plugin into dir and
+// returns the absolute path to the resulting .so, skipping the test with an
+// actionable message when the build is not possible (no C toolchain, no Go).
+func buildSeedPlugin(t *testing.T, dir string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("Go plugins are not supported on Windows")
+	}
+
+	goExe, lookErr := exec.LookPath("go")
+	if lookErr != nil {
+		t.Skip("LoadSO test skipped: 'go' binary not found in PATH")
+	}
+
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Skip("LoadSO test skipped: cannot determine source file path via runtime.Caller")
+	}
+	absPluginDir := filepath.Clean(filepath.Join(filepath.Dir(thisFile), seedPluginPkgPath))
+
+	soPath := filepath.Join(dir, "latencystatussampler.so")
+	// Do NOT pass -trimpath: go test is not built with -trimpath, and
+	// plugin.Open requires the host and plugin to share the same package path
+	// encoding — mirrors banyand/trace's buildTestPlugin rationale exactly.
+	cmd := exec.Command(goExe, "build", "-buildmode=plugin", "-o", soPath, absPluginDir)
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=1")
+	out, buildErr := cmd.CombinedOutput()
+	if buildErr != nil {
+		t.Skipf("LoadSO test skipped: cannot build .so (CGO may be unavailable): %v\n%s", buildErr, out)
+	}
+	return soPath
+}
+
+// TestLoadSO_SeedPlugin drives the real, graduated latencystatussampler seed
+// plugin (plugins/skywalking/latencystatussampler) through sdktest.LoadSO and
+// sdktest.Run — the seed's proof-of-use via the offline dev toolkit. It
+// exercises both the drop case (duration below threshold and status ==
+// successValue) and the fail-open keep case (unrelated status), and confirms
+// the differential projection guard reports no divergence for this
+// well-behaved sampler (it reads exactly what it projects).
+func TestLoadSO_SeedPlugin(t *testing.T) {
+	tmpDir, mkErr := os.MkdirTemp("", "sdktest-seed-*")
+	require.NoError(t, mkErr)
+	defer os.RemoveAll(tmpDir)
+
+	soPath := buildSeedPlugin(t, tmpDir)
+
+	sampler, loadErr := sdktest.LoadSO(soPath, "NewSampler", []byte(`{"thresholdMs":300,"successValue":"success"}`))
+	if isToolchainMismatch(loadErr) {
+		t.Skipf("LoadSO test skipped: host cannot load a freshly built plugin (toolchain mismatch): %v", loadErr)
+	}
+	require.NoError(t, loadErr)
+	require.NotNil(t, sampler)
+	defer sampler.Close() //nolint:errcheck // best-effort cleanup in a test.
+
+	dropTrace, buildErr := sdktest.NewTrace("dropped").
+		Tag("duration", int64(100)).
+		Tag("status", "success").
+		Build()
+	require.NoError(t, buildErr)
+
+	keepTrace, buildErr := sdktest.NewTrace("kept").
+		Tag("duration", int64(100)).
+		Tag("status", "failure").
+		Build()
+	require.NoError(t, buildErr)
+
+	batch := sdktest.Batch(dropTrace, keepTrace)
+	verdict, report := sdktest.Run(sampler, batch)
+	require.NoError(t, report.Err)
+	require.NoError(t, report.ProjectionErr)
+	require.Empty(t, report.ProjectionDivergedIDs,
+		"latencystatussampler only reads what it projects; the differential guard must report no divergence")
+	require.Equal(t, []bool{false, true}, verdict.Keep,
+		"the below-threshold+success trace must be dropped, the other kept")
+}

--- a/pkg/pipeline/sdk/sdktest/runner.go
+++ b/pkg/pipeline/sdk/sdktest/runner.go
@@ -1,0 +1,159 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package sdktest
+
+import "github.com/apache/skywalking-banyandb/pkg/pipeline/sdk"
+
+// Report is the outcome of a differential Run: the primary Decide error (if
+// any) plus, when the sampler's decision depended on a column it never
+// projected, the trace IDs where the projected-only and all-columns runs
+// disagreed.
+type Report struct {
+	// Err is the error sampler.Decide(batch) returned on the primary
+	// (all-columns) run, if any.
+	Err error
+	// ProjectionErr is the error sampler.Decide returned on the secondary
+	// (projected-only) run, if any. Kept separate from Err so a projection-run
+	// failure never masks the primary Verdict/Err.
+	ProjectionErr error
+	// ProjectionDivergedIDs holds the trace IDs where the projected-only and
+	// all-columns verdicts disagreed. Non-empty means the sampler's Decide
+	// reads a column it never declared in Project() — the #1 root cause of
+	// "unexpected data is being sampled" in production, where the engine
+	// decodes ONLY the declared projection.
+	ProjectionDivergedIDs []string
+}
+
+// Run executes sampler.Decide(batch) and returns its Verdict, plus a Report
+// carrying the differential projection guard's result.
+//
+// Decide is opaque: TraceBlock.Tag returns nil for a column the caller never
+// populated, faithfully reproducing what the real engine hands a plugin (the
+// engine decodes and materializes only the columns the plugin's Project()
+// declared) — so an unprojected-column read cannot be *observed* directly,
+// only its effect on the verdict. Run therefore calls Decide a SECOND time on
+// a batch built with only the columns sampler.Project() actually requested,
+// and flags any trace whose verdict differs between the two runs.
+func Run(sampler sdk.Sampler, batch *sdk.TraceBatch) (sdk.Verdict, Report) {
+	// Each Decide runs over its OWN deep copy, and neither shares backing
+	// arrays with the caller's batch. This is load-bearing, not defensive:
+	// DecodeTagValue's str-array path decodes IN PLACE
+	// (vararray.UnmarshalVarArray mutates its src slice), so if the two runs
+	// shared a TagColumn's Values, run 1 would corrupt run 2's input and the
+	// guard would report a spurious "projection divergence". Mirrors the real
+	// engine, which hands every Decide a fresh deep copy from its pooled
+	// buffers (assembleTraceBlock).
+	allColumns := copyProjectedBatch(batch, nil)
+	verdict, err := sampler.Decide(allColumns)
+	report := Report{Err: err}
+
+	proj := sampler.Project()
+	projected := copyProjectedBatch(batch, &proj)
+	projVerdict, projErr := sampler.Decide(projected)
+	report.ProjectionErr = projErr
+
+	if err == nil && projErr == nil && len(verdict.Keep) == len(projVerdict.Keep) {
+		for i := range verdict.Keep {
+			if verdict.Keep[i] != projVerdict.Keep[i] {
+				report.ProjectionDivergedIDs = append(report.ProjectionDivergedIDs, batch.Traces[i].TraceID)
+			}
+		}
+	}
+	return verdict, report
+}
+
+// copyProjectedBatch returns a DEEP copy of batch. When proj is nil every
+// column is copied (the "all columns" run); when proj is non-nil the copy is
+// filtered to that projection, mirroring the real engine's assembleTraceBlock
+// name-selection exactly (banyand/trace/pipeline_chain.go): intrinsic columns
+// (TraceID, MinTS, MaxTS) are always present; for each name in proj.Tags (in
+// that order) the FIRST source tag column with a matching Name is taken and
+// the search for that name stops there — so a fixture with more than one
+// column sharing a name (the #1126 multi-type-same-tag case) projects
+// identically to production, not merely deduplicated. SpanIDs/Spans are
+// included only when proj.SpanIDs/proj.Spans is true. Every TagColumn.Values
+// element and every Spans element is deep-copied (nil stays nil), so the
+// returned batch never aliases the source's backing arrays.
+func copyProjectedBatch(batch *sdk.TraceBatch, proj *sdk.Projection) *sdk.TraceBatch {
+	out := &sdk.TraceBatch{Traces: make([]sdk.TraceBlock, len(batch.Traces))}
+	for i := range batch.Traces {
+		src := &batch.Traces[i]
+		dst := sdk.TraceBlock{TraceID: src.TraceID, MinTS: src.MinTS, MaxTS: src.MaxTS}
+		if proj == nil {
+			for _, tag := range src.Tags {
+				dst.Tags = append(dst.Tags, copyTagColumn(tag))
+			}
+			dst.SpanIDs = copyStrings(src.SpanIDs)
+			dst.Spans = copyByteSlices(src.Spans)
+		} else {
+			for _, name := range proj.Tags {
+				for _, tag := range src.Tags {
+					if tag.Name != name {
+						continue
+					}
+					dst.Tags = append(dst.Tags, copyTagColumn(tag))
+					break
+				}
+			}
+			if proj.SpanIDs {
+				dst.SpanIDs = copyStrings(src.SpanIDs)
+			}
+			if proj.Spans {
+				dst.Spans = copyByteSlices(src.Spans)
+			}
+		}
+		out.Traces[i] = dst
+	}
+	return out
+}
+
+// copyTagColumn deep-copies a TagColumn, mirroring assembleTraceBlock: each
+// row's []byte is copied, and a nil row stays nil.
+func copyTagColumn(src sdk.TagColumn) sdk.TagColumn {
+	values := make([][]byte, len(src.Values))
+	for i, v := range src.Values {
+		if v != nil {
+			values[i] = append([]byte(nil), v...)
+		}
+	}
+	return sdk.TagColumn{Name: src.Name, ValueType: src.ValueType, Values: values}
+}
+
+// copyStrings returns a copy of src (nil stays nil).
+func copyStrings(src []string) []string {
+	if src == nil {
+		return nil
+	}
+	out := make([]string, len(src))
+	copy(out, src)
+	return out
+}
+
+// copyByteSlices deep-copies a [][]byte (nil outer stays nil, nil rows stay nil).
+func copyByteSlices(src [][]byte) [][]byte {
+	if src == nil {
+		return nil
+	}
+	out := make([][]byte, len(src))
+	for i, v := range src {
+		if v != nil {
+			out[i] = append([]byte(nil), v...)
+		}
+	}
+	return out
+}

--- a/pkg/pipeline/sdk/sdktest/runner_test.go
+++ b/pkg/pipeline/sdk/sdktest/runner_test.go
@@ -1,0 +1,180 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package sdktest_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/apache/skywalking-banyandb/pkg/pipeline/sdk"
+	"github.com/apache/skywalking-banyandb/pkg/pipeline/sdk/sdktest"
+)
+
+// honestSampler projects "duration" and reads only "duration" — its verdict
+// must be identical whether or not "status" is also present in the batch.
+type honestSampler struct{}
+
+func (honestSampler) Kind() sdk.Kind          { return sdk.KindSampler }
+func (honestSampler) Project() sdk.Projection { return sdk.Projection{Tags: []string{"duration"}} }
+func (honestSampler) Close() error            { return nil }
+func (honestSampler) Decide(batch *sdk.TraceBatch) (sdk.Verdict, error) {
+	keep := make([]bool, len(batch.Traces))
+	for i := range batch.Traces {
+		keep[i] = true
+		col := batch.Traces[i].Tag("duration")
+		if col == nil {
+			continue
+		}
+		v, err := col.At(0)
+		if err == nil && !v.IsNull() && v.Int64() < 100 {
+			keep[i] = false
+		}
+	}
+	return sdk.Verdict{Keep: keep}, nil
+}
+
+// dishonestSampler projects ONLY "duration" but its Decide also reads
+// "status" — a column it never declared. In production the engine would not
+// materialize "status" for this sampler, so its real-world decision would
+// differ from what this fixture (which carries "status") produces.
+type dishonestSampler struct{}
+
+func (dishonestSampler) Kind() sdk.Kind          { return sdk.KindSampler }
+func (dishonestSampler) Project() sdk.Projection { return sdk.Projection{Tags: []string{"duration"}} }
+func (dishonestSampler) Close() error            { return nil }
+func (dishonestSampler) Decide(batch *sdk.TraceBatch) (sdk.Verdict, error) {
+	keep := make([]bool, len(batch.Traces))
+	for i := range batch.Traces {
+		keep[i] = true
+		// Reads "status" despite never projecting it.
+		if col := batch.Traces[i].Tag("status"); col != nil {
+			if v, err := col.At(0); err == nil && !v.IsNull() && v.Str() == "error" {
+				keep[i] = false
+			}
+		}
+	}
+	return sdk.Verdict{Keep: keep}, nil
+}
+
+func TestRun_HonestSamplerNoDivergence(t *testing.T) {
+	block, err := sdktest.NewTrace("t1").Tag("duration", int64(50)).Tag("status", "success").Build()
+	require.NoError(t, err)
+	batch := sdktest.Batch(block)
+
+	verdict, report := sdktest.Run(honestSampler{}, batch)
+	require.NoError(t, report.Err)
+	require.NoError(t, report.ProjectionErr)
+	assert.Empty(t, report.ProjectionDivergedIDs, "a sampler that only reads its own projection must never diverge")
+	assert.Equal(t, []bool{false}, verdict.Keep)
+}
+
+func TestRun_DishonestSamplerFlagged(t *testing.T) {
+	block, err := sdktest.NewTrace("t1").Tag("duration", int64(500)).Tag("status", "error").Build()
+	require.NoError(t, err)
+	batch := sdktest.Batch(block)
+
+	verdict, report := sdktest.Run(dishonestSampler{}, batch)
+	require.NoError(t, report.Err)
+	require.NoError(t, report.ProjectionErr)
+	require.Contains(t, report.ProjectionDivergedIDs, "t1",
+		"a sampler that reads an unprojected column must be flagged by the differential guard")
+	// The primary (all-columns) run sees "status"=="error" and drops the trace.
+	assert.Equal(t, []bool{false}, verdict.Keep)
+}
+
+func TestRun_DecideErrorPropagates(t *testing.T) {
+	block, err := sdktest.NewTrace("t1").Build()
+	require.NoError(t, err)
+	batch := sdktest.Batch(block)
+
+	erroringSampler := erroringSamplerType{}
+	_, report := sdktest.Run(erroringSampler, batch)
+	require.Error(t, report.Err)
+}
+
+// escapedStrArrSampler is an HONEST sampler: it projects "labels" and reads
+// only "labels". It drops a trace whose first label element equals "a|b".
+type escapedStrArrSampler struct{}
+
+func (escapedStrArrSampler) Kind() sdk.Kind          { return sdk.KindSampler }
+func (escapedStrArrSampler) Project() sdk.Projection { return sdk.Projection{Tags: []string{"labels"}} }
+func (escapedStrArrSampler) Close() error            { return nil }
+func (escapedStrArrSampler) Decide(batch *sdk.TraceBatch) (sdk.Verdict, error) {
+	keep := make([]bool, len(batch.Traces))
+	for i := range batch.Traces {
+		keep[i] = true
+		col := batch.Traces[i].Tag("labels")
+		if col == nil {
+			continue
+		}
+		v, decErr := col.At(0)
+		if decErr != nil || v.IsNull() {
+			continue
+		}
+		arr := v.StrArr()
+		if len(arr) > 0 && arr[0] == "a|b" {
+			keep[i] = false
+		}
+	}
+	return sdk.Verdict{Keep: keep}, nil
+}
+
+// TestRun_EscapedStrArrayNoFalseDivergence is the regression guard for the
+// shared-backing-array bug: DecodeTagValue's str-array path decodes IN PLACE
+// (vararray.UnmarshalVarArray mutates its src), so if Run's two Decide calls
+// shared a TagColumn's Values, the first run would corrupt the escaped
+// str-array element the second run reads, producing a spurious "projection
+// divergence" and a wrong verdict on the second run. With per-run deep copies
+// the honest sampler decides identically both times and the guard reports no
+// divergence. The elements deliberately contain the delimiter '|' and escape
+// '\' bytes, which are exactly what UnmarshalVarArray rewrites in place.
+func TestRun_EscapedStrArrayNoFalseDivergence(t *testing.T) {
+	block, err := sdktest.NewTrace("t1").Tag("labels", []string{"a|b", `c\d`, "e|f"}).Build()
+	require.NoError(t, err)
+	batch := sdktest.Batch(block)
+
+	verdict, report := sdktest.Run(escapedStrArrSampler{}, batch)
+	require.NoError(t, report.Err)
+	require.NoError(t, report.ProjectionErr)
+	assert.Empty(t, report.ProjectionDivergedIDs,
+		"an honest sampler reading an escaped str-array must not be flagged (no shared-backing corruption)")
+	assert.Equal(t, []bool{false}, verdict.Keep, "labels[0]==\"a|b\" must drop the trace on both runs")
+
+	// The caller's batch must be untouched by Run (both Decide runs use deep
+	// copies): re-decoding labels[0] from the original still yields "a|b".
+	col := batch.Traces[0].Tag("labels")
+	require.NotNil(t, col)
+	v, decErr := col.At(0)
+	require.NoError(t, decErr)
+	require.Equal(t, "a|b", v.StrArr()[0], "Run must not mutate the caller's batch backing arrays")
+}
+
+type erroringSamplerType struct{}
+
+func (erroringSamplerType) Kind() sdk.Kind          { return sdk.KindSampler }
+func (erroringSamplerType) Project() sdk.Projection { return sdk.Projection{} }
+func (erroringSamplerType) Close() error            { return nil }
+func (erroringSamplerType) Decide(*sdk.TraceBatch) (sdk.Verdict, error) {
+	return sdk.Verdict{}, assertError{}
+}
+
+type assertError struct{}
+
+func (assertError) Error() string { return "decide failed" }

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,0 +1,133 @@
+# Trace-pipeline sampler plugins
+
+This directory is the in-repo source home for SkyWalking-maintained
+post-trace-pipeline sampler plugins. Every plugin here is a first-class Go
+package: it participates in `go build ./...`, `go vet`, `golangci-lint`, and
+the license-header check, and it is compiled into the `-plugins` variant of
+the `banyand` server image (see `docs/operation/plugins.md`).
+
+```
+plugins/
+  README.md                             # this file
+  skywalking/
+    latencystatussampler/main.go        # seed: package main; NewSampler; ABIVersion
+```
+
+The `skywalking/` namespace holds plugins maintained by the SkyWalking
+project itself. A future third-party vendor would get its own sibling
+namespace (e.g. `plugins/acme/`) — but see the "Third-party plugins" section
+below: this repo only *documents* and *builds* first-party plugins; a
+third-party `.so` is built and shipped by its own vendor, not committed here.
+
+This is only the **source** layout. At runtime, the first-party `.so` files
+built here are shipped in a carrier image (the `-plugins-carrier`-tagged image
+on the same `apache/skywalking-banyandb` repo) and **mounted** into the
+plugin-capable `-plugins` host image at `/plugins` (the trusted plugin
+directory, empty in the host image); third-party `.so` files are mounted at
+the reserved subdirectory `/plugins/thirdparty` — see
+`docs/operation/plugins.md`.
+
+## The plugin contract
+
+A plugin is a `package main` built with `go build -buildmode=plugin` that
+exports exactly two symbols, defined by `pkg/pipeline/sdk`:
+
+```go
+var  ABIVersion = sdk.ABIVersion             // re-export, unchanged
+func NewSampler(config []byte) (sdk.Sampler, error)
+func main() {}                               // required by -buildmode=plugin
+```
+
+- `ABIVersion` must equal the host's compiled `sdk.ABIVersion` *exactly*. A
+  mismatch is a fail-fast load error (never silent corruption).
+- `NewSampler` is the constructor the engine looks up by default; a
+  `SamplerPlugin.symbol` in the group's pipeline config can override the
+  symbol name for a plugin package that exports more than one sampler.
+- `config` is the canonical JSON encoding of the `SamplerPlugin.config`
+  `google.protobuf.Struct`; the plugin unmarshals it into its own typed
+  config.
+- The `sdk.Sampler` interface (`Kind`, `Project`, `Decide`, `Close`) and the
+  vectorized `sdk.TraceBatch`/`sdk.TraceBlock` types are the full contract —
+  see the package doc on `pkg/pipeline/sdk` for the authoritative reference.
+
+## ABI / toolchain lock (read this before building for production)
+
+A Go plugin is loaded via `plugin.Open`, which requires the `.so` and the
+host process to share the **exact same**:
+
+- Go toolchain version (this repo pins `go 1.25.8` via `go.mod`; `GOTOOLCHAIN=auto`
+  resolves it identically in CI, in the `-plugins` Docker builder stage, and
+  in a local `make build-plugins`),
+- `pkg/pipeline/sdk` package build (and its full transitive module graph),
+- CGO mode (`CGO_ENABLED=1`) and race-detector mode (`-race` or not),
+- and a compatible libc (the `-plugins` runtime image is
+  `gcr.io/distroless/base-debian12` and its builder stage is
+  `golang:1.25-bookworm` — both Debian 12/bookworm, same glibc 2.36, for
+  exactly this reason).
+
+Any drift and `plugin.Open` rejects the `.so` outright ("different version of
+package …"). This is by design: mismatch is always safe and loud, never
+silent. For the first-party plugins in this directory, parity is guaranteed
+by lockstep — the `-plugins` Dockerfile builder base compiles the host binary
+and every plugin `.so` from the same commit in the same CI run, and the host
+image (`skywalking-banyandb:<tag>-plugins`) and the carrier image
+(`skywalking-banyandb:<tag>-plugins-carrier`, same repo) are published in
+lockstep (see `docs/operation/plugins.md`). Always deploy the carrier at the
+host's tag + `-carrier`; do not build a first-party `.so` on a different
+machine/toolchain and expect it to load.
+
+## Building locally
+
+Requires a C toolchain (`gcc` or `clang`) because Go plugins require
+`CGO_ENABLED=1`. Go plugins are not supported on Windows.
+
+```sh
+make build-plugins        # builds every plugins/<vendor>/<name>/main.go into
+                           # $(PLUGIN_OUTPUT_DIR) (default build/bin/plugins)
+```
+
+This reuses the same `-trimpath` flags as `make build-trace-pipeline-server`
+(root `Makefile`), matching the flags the `-plugins` Docker builder stage
+uses, so a locally built `.so` loads into a locally built
+`build-trace-pipeline-server` binary — but NOT necessarily into the released
+`-plugins` image (which is built by its own Dockerfile stage; see the
+toolchain-lock note above).
+
+## Deploying (first-party)
+
+Every plugin under this directory is built into the
+`apache/skywalking-banyandb:<tag>-plugins-carrier` **carrier** image, which is
+**mounted** at `/plugins` into the plugin-capable
+`apache/skywalking-banyandb:<tag>-plugins` **host** image (whose `/plugins` is
+empty). An operator enables plugin hosting on the **data node** (the role that
+runs merge/finalize) with two flags:
+
+```
+-trace-pipeline-native-plugin-enabled=true
+-trace-pipeline-trusted-plugin-dir=/plugins
+```
+
+then references a plugin by filename in the group's pipeline config, e.g.
+`SamplerPlugin.path = "latencystatussampler.so"`. See
+`docs/operation/plugins.md` for the full deployment guide (image-volume and
+initContainer mount mechanisms, third-party plugins, and Kubernetes examples).
+
+## Adding a new first-party plugin
+
+1. Create `plugins/skywalking/<name>/main.go` implementing `sdk.Sampler`
+   (`ABIVersion`, `NewSampler`, empty `main()`).
+2. Add a `_test.go` using `pkg/pipeline/sdk/sdktest` to verify `Decide`
+   offline (no `.so`, no cluster) before ever building a `.so` — see
+   `pkg/pipeline/sdk/sdktest` and the seed plugin's test for the pattern.
+3. `make build-plugins` locally to confirm it compiles as a plugin.
+4. The carrier image picks up any new `plugins/*/*/main.go` automatically (the
+   builder stage globs the directory) — no Dockerfile change needed for a new
+   plugin, only for a new *toolchain* requirement.
+
+## Third-party plugins
+
+Third-party/operator plugins are **not** stored in this repository. An
+operator builds their `.so` against the pinned SDK + toolchain published for
+each release (see `docs/operation/plugins.md`) and mounts it at the reserved
+subdirectory `/plugins/thirdparty`, keeping the first-party carrier mounted at
+`/plugins`.

--- a/plugins/skywalking/latencystatussampler/main.go
+++ b/plugins/skywalking/latencystatussampler/main.go
@@ -1,0 +1,183 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Command latencystatussampler is a first-party post-trace sampler plugin
+// that drops a trace when its duration (in milliseconds, read from the
+// "duration" tag) is below a configured threshold AND its "status" tag
+// equals a configured success value. All other traces are kept. The sampler
+// fails open: if either column is absent, nil, or fails to decode, the trace
+// is retained.
+//
+// Build it as a Go plugin (see plugins/README.md for the full contract and
+// toolchain-lock requirements):
+//
+//	make build-plugins
+//
+// or directly:
+//
+//	CGO_ENABLED=1 go build -buildmode=plugin -trimpath \
+//	  -o latencystatussampler.so \
+//	  ./plugins/skywalking/latencystatussampler
+//
+// Config JSON (from SamplerPlugin.config Struct):
+//
+//	{ "thresholdMs": 500, "successValue": "success" }
+//
+// Both fields are optional; defaults are 500 and "success" respectively.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/apache/skywalking-banyandb/pkg/pb/v1/valuetype"
+	"github.com/apache/skywalking-banyandb/pkg/pipeline/sdk"
+)
+
+// ABIVersion re-exports the SDK ABI version. The engine refuses to load the
+// plugin unless this equals its own compiled sdk.ABIVersion.
+var ABIVersion = sdk.ABIVersion
+
+// Default sampler thresholds, applied only when the config omits the field.
+const (
+	defaultThresholdMs  = 500
+	defaultSuccessValue = "success"
+)
+
+// samplerConfig is the JSON shape the operator sets in SamplerPlugin.config.
+// The fields are pointers so a defaulted value is distinguishable from an
+// explicitly-configured zero: {"thresholdMs":0} means "the duration test can
+// never fire" and must be honored verbatim, whereas an omitted thresholdMs
+// takes the default. A nil field gets the default; a present field — including
+// 0 or "" — is used as-is.
+type samplerConfig struct {
+	SuccessValue *string `json:"successValue"`
+	ThresholdMs  *int64  `json:"thresholdMs"`
+}
+
+// latencyStatusSampler drops a trace when duration < thresholdMs && status ==
+// successValue, and keeps everything else (fail-open on missing/null columns).
+type latencyStatusSampler struct {
+	successValue string
+	thresholdMs  int64
+}
+
+// NewSampler is the constructor symbol the engine looks up. It parses the
+// operator config and returns a ready sampler. An empty or missing config is
+// accepted and yields the default thresholds; an explicitly-set zero value is
+// honored (not overridden).
+func NewSampler(configJSON []byte) (sdk.Sampler, error) {
+	var cfg samplerConfig
+	if len(configJSON) > 0 {
+		if unmarshalErr := json.Unmarshal(configJSON, &cfg); unmarshalErr != nil {
+			return nil, fmt.Errorf("latencystatussampler: invalid config JSON: %w", unmarshalErr)
+		}
+	}
+	sampler := &latencyStatusSampler{
+		thresholdMs:  defaultThresholdMs,
+		successValue: defaultSuccessValue,
+	}
+	if cfg.ThresholdMs != nil {
+		sampler.thresholdMs = *cfg.ThresholdMs
+	}
+	if cfg.SuccessValue != nil {
+		sampler.successValue = *cfg.SuccessValue
+	}
+	return sampler, nil
+}
+
+// Kind reports the sampler kind, satisfying the generic sdk.Plugin interface.
+func (s *latencyStatusSampler) Kind() sdk.Kind { return sdk.KindSampler }
+
+// Project declares the two tag columns this sampler reads: "duration" (INT64,
+// milliseconds) and "status" (STRING). Span bodies and span IDs are not read.
+func (s *latencyStatusSampler) Project() sdk.Projection {
+	return sdk.Projection{Tags: []string{"duration", "status"}}
+}
+
+// Close releases resources; this sampler holds none.
+func (s *latencyStatusSampler) Close() error { return nil }
+
+// Decide returns a keep-mask aligned to batch.Traces. The batch is read-only.
+// A trace is dropped only when BOTH of the following hold for row 0:
+//   - duration column is present, non-nil, decodable, and < thresholdMs
+//   - status column is present, non-nil, decodable, and == successValue
+//
+// Any failure to satisfy either condition results in the trace being kept
+// (fail-open).
+func (s *latencyStatusSampler) Decide(batch *sdk.TraceBatch) (sdk.Verdict, error) {
+	keep := make([]bool, len(batch.Traces))
+	for i := range batch.Traces {
+		keep[i] = s.keepTrace(&batch.Traces[i])
+	}
+	return sdk.Verdict{Keep: keep}, nil
+}
+
+// keepTrace returns false (drop) only when both the duration and status
+// conditions are conclusively met. It returns true (keep) on any ambiguity.
+func (s *latencyStatusSampler) keepTrace(b *sdk.TraceBlock) bool {
+	durCol := b.Tag("duration")
+	if durCol == nil || len(durCol.Values) == 0 {
+		return true // fail open: duration column absent
+	}
+	statusCol := b.Tag("status")
+	if statusCol == nil || len(statusCol.Values) == 0 {
+		return true // fail open: status column absent
+	}
+
+	durVal, durErr := durCol.At(0)
+	if durErr != nil {
+		return true // fail open: decode error
+	}
+	if durVal.IsNull() {
+		return true // fail open: null duration
+	}
+
+	statusVal, statusErr := statusCol.At(0)
+	if statusErr != nil {
+		return true // fail open: decode error
+	}
+	if statusVal.IsNull() {
+		return true // fail open: null status
+	}
+
+	// Decode duration as int64 milliseconds.
+	var durationMs int64
+	switch durVal.ValueType() {
+	case valuetype.ValueTypeInt64:
+		durationMs = durVal.Int64()
+	default:
+		return true // fail open: unexpected duration type
+	}
+
+	// Decode status as string.
+	var statusStr string
+	switch statusVal.ValueType() {
+	case valuetype.ValueTypeStr:
+		statusStr = statusVal.Str()
+	default:
+		return true // fail open: unexpected status type
+	}
+
+	// Drop only when both conditions are conclusively met.
+	if durationMs < s.thresholdMs && statusStr == s.successValue {
+		return false
+	}
+	return true
+}
+
+func main() {}

--- a/plugins/skywalking/latencystatussampler/main_test.go
+++ b/plugins/skywalking/latencystatussampler/main_test.go
@@ -1,0 +1,119 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// This test file verifies Decide directly against the sdktest fixture kit —
+// no .so build, no cluster — exactly the offline verify-before-you-build-a-.so
+// workflow plugins/README.md recommends for a new plugin. Being package main
+// (a same-directory white-box test), it can construct latencyStatusSampler
+// directly rather than going through NewSampler+plugin.Open.
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/apache/skywalking-banyandb/pkg/pipeline/sdk/sdktest"
+)
+
+func TestLatencyStatusSampler_Decide(t *testing.T) {
+	sampler, err := NewSampler([]byte(`{"thresholdMs":300,"successValue":"success"}`))
+	require.NoError(t, err)
+
+	dropped, buildErr := sdktest.NewTrace("dropped").
+		Tag("duration", int64(100)).
+		Tag("status", "success").
+		Build()
+	require.NoError(t, buildErr)
+
+	keptWrongStatus, buildErr := sdktest.NewTrace("kept-wrong-status").
+		Tag("duration", int64(100)).
+		Tag("status", "failure").
+		Build()
+	require.NoError(t, buildErr)
+
+	keptTooSlow, buildErr := sdktest.NewTrace("kept-too-slow").
+		Tag("duration", int64(500)).
+		Tag("status", "success").
+		Build()
+	require.NoError(t, buildErr)
+
+	keptNoColumns, buildErr := sdktest.NewTrace("kept-no-columns").Build()
+	require.NoError(t, buildErr)
+
+	batch := sdktest.Batch(dropped, keptWrongStatus, keptTooSlow, keptNoColumns)
+	verdict, report := sdktest.Run(sampler, batch)
+	require.NoError(t, report.Err)
+	require.NoError(t, report.ProjectionErr)
+	assert.Empty(t, report.ProjectionDivergedIDs,
+		"latencystatussampler must only read the columns it projects (duration, status)")
+	require.Equal(t, []bool{false, true, true, true}, verdict.Keep)
+}
+
+func TestLatencyStatusSampler_DefaultsAndInvalidConfig(t *testing.T) {
+	// Empty config uses the documented defaults (thresholdMs=500, successValue="success").
+	sampler, err := NewSampler(nil)
+	require.NoError(t, err)
+	s, ok := sampler.(*latencyStatusSampler)
+	require.True(t, ok)
+	assert.Equal(t, int64(defaultThresholdMs), s.thresholdMs)
+	assert.Equal(t, defaultSuccessValue, s.successValue)
+
+	// An empty JSON object still yields the defaults (no field present).
+	sampler, err = NewSampler([]byte(`{}`))
+	require.NoError(t, err)
+	s, ok = sampler.(*latencyStatusSampler)
+	require.True(t, ok)
+	assert.Equal(t, int64(defaultThresholdMs), s.thresholdMs)
+	assert.Equal(t, defaultSuccessValue, s.successValue)
+
+	// Malformed JSON must fail open at construction (no sampler registered).
+	_, err = NewSampler([]byte(`{"thresholdMs": "not-a-number"}`))
+	require.Error(t, err)
+}
+
+// TestLatencyStatusSampler_ExplicitZeroValuesHonored proves an explicitly
+// configured zero (thresholdMs:0 / successValue:"") is used verbatim, not
+// silently overridden by the default — the reason samplerConfig uses pointer
+// fields. thresholdMs:0 makes the "duration < threshold" test unsatisfiable,
+// so nothing is ever dropped on the duration criterion.
+func TestLatencyStatusSampler_ExplicitZeroValuesHonored(t *testing.T) {
+	sampler, err := NewSampler([]byte(`{"thresholdMs":0,"successValue":""}`))
+	require.NoError(t, err)
+	s, ok := sampler.(*latencyStatusSampler)
+	require.True(t, ok)
+	assert.Equal(t, int64(0), s.thresholdMs, "explicit thresholdMs:0 must not be overridden by the default")
+	assert.Equal(t, "", s.successValue, "explicit successValue:\"\" must not be overridden by the default")
+
+	// With thresholdMs=0, a would-otherwise-drop trace (duration 100, matching
+	// status) is KEPT: 100 < 0 is false, so the drop condition never holds.
+	block, buildErr := sdktest.NewTrace("t1").Tag("duration", int64(100)).Tag("status", "").Build()
+	require.NoError(t, buildErr)
+	verdict, report := sdktest.Run(sampler, sdktest.Batch(block))
+	require.NoError(t, report.Err)
+	assert.Equal(t, []bool{true}, verdict.Keep, "thresholdMs:0 must keep everything on the duration test")
+}
+
+func TestLatencyStatusSampler_Project(t *testing.T) {
+	sampler, err := NewSampler(nil)
+	require.NoError(t, err)
+	proj := sampler.Project()
+	assert.ElementsMatch(t, []string{"duration", "status"}, proj.Tags)
+	assert.False(t, proj.SpanIDs)
+	assert.False(t, proj.Spans)
+}

--- a/scripts/build/docker.mk
+++ b/scripts/build/docker.mk
@@ -33,6 +33,37 @@ ifeq ($(BINARYTYPE),slim)
 	TAG := $(TAG)-slim
 endif
 
+# banyand/Dockerfile has a "-plugins" builder stage (BINARYTYPE=plugins) whose
+# COPY --from=reporoot reaches the full repo module (go.mod lives one
+# directory above banyand/, this project's own build context), plus a later
+# final-plugins stage. Both properties require touching every banyand build,
+# not just BINARYTYPE=plugins:
+#   - buildx/BuildKit resolves EVERY named build context referenced anywhere
+#     in a Dockerfile while parsing it, BEFORE pruning stages unreached by
+#     --target — so "reporoot" must be supplied even for a static/slim build,
+#     or buildx tries to resolve it as a registry image and fails. Supplying
+#     it is harmless: the default target's build graph never references it.
+#   - without an explicit --target, docker/buildx builds the LAST stage in
+#     the file, which is final-plugins (defined after final for the
+#     BINARYTYPE=plugins case) — so the default/slim build must pin
+#     --target final explicitly to stay on the static/busybox path.
+# Guarded by NAME (set per-project Makefile) so other projects' plain
+# single-stage Dockerfiles are unaffected.
+ifeq ($(NAME),banyand)
+	DOCKER_BUILD_ARGS := $(DOCKER_BUILD_ARGS) --build-context reporoot=..
+	ifeq ($(BINARYTYPE),plugins)
+		TAG := $(TAG)-plugins
+		# GO_LINK_VERSION (from base.mk, included before this file by the
+		# banyand Makefile) carries the version-stamp `-X` ldflags. The
+		# static/slim binaries get it via `make release`; the -plugins host
+		# binary is compiled inside the Dockerfile, so pass it through as a
+		# build-arg. Double-quoted because the value contains spaces.
+		DOCKER_BUILD_ARGS := $(DOCKER_BUILD_ARGS) --target final-plugins --build-arg "GO_LINK_VERSION=$(GO_LINK_VERSION)"
+	else
+		DOCKER_BUILD_ARGS := $(DOCKER_BUILD_ARGS) --target final
+	endif
+endif
+
 IMG := $(HUB)/$(IMG_NAME):$(TAG)
 
 # Disable cache in CI environment
@@ -49,4 +80,35 @@ docker docker.push:
 	@echo "$(DOCKER_TYPE) $(IMG) with platform $(PLATFORMS)"
 	@pwd
 	time docker buildx build $(DOCKER_BUILD_ARGS) --platform $(PLATFORMS) $(LOAD_OR_PUSH) -t $(IMG) -f Dockerfile --provenance=false --build-arg BINARYTYPE=$(BINARYTYPE) .
+
+# --- Plugin carrier image (banyand only; see docs/operation/plugins.md, DD2) ---
+# The carrier holds ONLY the built .so files, compiled in the SAME Dockerfile
+# builder base (build-plugins-base) / same commit as the -plugins HOST binary,
+# so the host<->.so toolchain parity plugin.Open demands holds by lockstep.
+# It lives on the SAME repo as every other banyand image, distinguished only by
+# the "-plugins-carrier" TAG suffix: $(HUB)/$(IMG_NAME):$(TAG)-plugins-carrier
+# (the host image is $(TAG)-plugins). MUST be invoked WITHOUT BINARYTYPE=plugins
+# so the base TAG is not itself suffixed, e.g.:
+#   TAG=<sha> PLATFORMS=linux/amd64,linux/arm64 make -C banyand docker.plugins-carrier.push
+# It builds --target final-carrier and needs the same "reporoot" named context
+# as the host build (to reach the repo module); those flags are set explicitly
+# here rather than reusing DOCKER_BUILD_ARGS, which pins --target final.
+ifeq ($(NAME),banyand)
+PLUGINS_CARRIER_IMG := $(HUB)/$(IMG_NAME):$(TAG)-plugins-carrier
+CARRIER_BUILD_ARGS := --build-context reporoot=.. --target final-carrier
+ifeq (true,$(CI))
+	CARRIER_BUILD_ARGS := $(CARRIER_BUILD_ARGS) --no-cache
+endif
+
+docker.plugins-carrier: LOAD_OR_PUSH = --load
+docker.plugins-carrier: DOCKER_TYPE = "Build"
+docker.plugins-carrier.push: LOAD_OR_PUSH = --push
+docker.plugins-carrier.push: DOCKER_TYPE = "Push"
+
+.PHONY: docker.plugins-carrier docker.plugins-carrier.push
+docker.plugins-carrier docker.plugins-carrier.push:
+	@echo "$(DOCKER_TYPE) $(PLUGINS_CARRIER_IMG) with platform $(PLATFORMS)"
+	@pwd
+	time docker buildx build $(CARRIER_BUILD_ARGS) --platform $(PLATFORMS) $(LOAD_OR_PUSH) -t $(PLUGINS_CARRIER_IMG) -f Dockerfile --provenance=false .
+endif
 

--- a/test/plugin-sidecar/Makefile
+++ b/test/plugin-sidecar/Makefile
@@ -1,0 +1,24 @@
+# Licensed to Apache Software Foundation (ASF) under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Apache Software Foundation (ASF) licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Plugin-sidecar SHIP GATE: prove the CGO "-plugins" host image + carrier-mount
+# design works in real Kubernetes (kind). banyandb images only. See run.sh.
+
+.PHONY: e2e-plugin-sidecar
+e2e-plugin-sidecar: ## Run the kind-based plugin-sidecar ship gate (builds images if absent, creates/destroys a kind cluster)
+	./run.sh

--- a/test/plugin-sidecar/README.md
+++ b/test/plugin-sidecar/README.md
@@ -1,0 +1,91 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Plugin-sidecar ship gate (kind)
+
+A self-contained [kind](https://kind.sigs.k8s.io/) test that proves the
+trace-pipeline plugin packaging works in **real Kubernetes** before the PR
+ships. banyandb images ONLY — no OAP, no producer/consumer, no traffic
+generator.
+
+## What it proves
+
+Deploys a **standalone** BanyanDB (the standalone role is `ROLE_DATA`, which
+hosts plugins) from the CGO/dynamic **`-plugins` host image** (distroless
+base), and delivers the `.so` from the **`-plugins-carrier`-tagged carrier
+image** (same `apache/skywalking-banyandb` repo) via an **initContainer + a
+shared `emptyDir` mounted at `/plugins`** (the version-agnostic path; the
+busybox carrier provides `cp`). On Kubernetes ≥1.31 an OCI image volume is the
+alternative — noted in `banyandb-standalone.yaml`, with the initContainer path
+being the one that runs.
+
+Required assertions (the gate):
+
+- **(a)** the banyand pod reaches **Ready** — the CGO/dynamic host actually
+  boots in-cluster;
+- **(b)** `latencystatussampler.so` was delivered into the shared `/plugins`
+  volume — verified from the carrier `install-plugins` initContainer's log
+  (the distroless host container has no shell to `exec ls` into);
+- **(c)** a group whose trace pipeline references
+  `SamplerPlugin.path=latencystatussampler.so` is registered, and the data node
+  **loads it with no failure** — `plugin.Open` succeeded on the mounted `.so`.
+  Evidence: the fail-open ERROR (`sampler plugin load failed; keeping previous
+  good set`) is **absent**, and `banyandb_trace_pipeline_sampler_active_count{group="test-trace-pipeline"} > 0`.
+  The group/schema/pipeline are registered through the **property schema
+  registry** (`register/main.go`, port 17916) — the store the data node's trace
+  schemaRepo watches to fire the pipeline reconcile. (The GroupRegistryService
+  HTTP/gRPC endpoint writes a different store that the pipeline reconcile does
+  not observe, and its HTTP gateway also drops the nested pipeline field.)
+
+The end-to-end DROP behavior (drop-eligible vs keep trace over a merge) is
+already covered by the in-process `trace_pipeline` integration suite
+(`test/integration/standalone/pipeline`) against the same artifacts; this gate
+scopes to what only real Kubernetes can prove.
+
+## Run
+
+```sh
+make -C test/plugin-sidecar e2e-plugin-sidecar
+```
+
+Builds the amd64 `-plugins` host + carrier images if they are not already
+present, creates a kind cluster, `kind load`s BOTH images (same tag =
+lockstep parity), applies the manifest, runs the assertions, and tears the
+cluster down (always, even on failure, unless `KEEP_CLUSTER=true`).
+
+Knobs: `TAG`, `HOST_IMAGE`, `CARRIER_IMAGE`, `SKIP_BUILD=true`,
+`KEEP_CLUSTER=true`.
+
+Runtime note: the standalone data node's property-schema client warms up
+before it first syncs a freshly-registered group, so assertion (c) waits for
+the pipeline reconcile. The plugin load itself is instant once the reconcile
+fires, but the cold-start reconcile latency on kind is highly variable
+(observed ~4.5-10 min across runs; instant on an already-warm node) — this is
+standalone schema-sync warmup, orthogonal to the plugin packaging/mount the
+gate proves. The (c) poll therefore waits up to ~15 min (a genuine load
+FAILURE fails fast regardless). Total gate runtime is ~7-18 min depending on
+how quickly the cold node's schema sync settles.
+
+## Files
+
+- `kind.yaml` — single-node kind cluster (node image 1.30.x).
+- `banyandb-standalone.yaml` — the standalone Pod: carrier initContainer →
+  `emptyDir` at `/plugins` → host container with the two plugin flags.
+  `${HOST_IMAGE}`/`${CARRIER_IMAGE}` are substituted by `run.sh`.
+- `register/main.go` — a tiny helper that writes the trace group + schema +
+  pipeline through the property schema registry client (assertion c).
+- `run.sh` — the driver; `Makefile` — the `e2e-plugin-sidecar` target.

--- a/test/plugin-sidecar/banyandb-standalone.yaml
+++ b/test/plugin-sidecar/banyandb-standalone.yaml
@@ -1,0 +1,81 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Standalone BanyanDB (data-node role → hosts plugins) proving the
+# CGO "-plugins" host image + carrier-mount design works in real Kubernetes.
+#
+# Plugin delivery = the busybox CARRIER image as an initContainer that copies
+# its /plugins/*.so into a shared emptyDir mounted at /plugins in the main
+# container. This is the version-agnostic path (works on any Kubernetes;
+# busybox gives us `cp`). On Kubernetes >= 1.31 an OCI image volume mounting
+# the carrier read-only at /plugins is the alternative (no initContainer, no
+# copy) — see docs/operation/plugins.md; the initContainer path is the one
+# exercised by this gate.
+#
+# ${HOST_IMAGE} / ${CARRIER_IMAGE} are substituted by run.sh (envsubst) and
+# loaded into the kind node via `kind load docker-image`, so imagePullPolicy is
+# IfNotPresent (never reach out to a registry).
+apiVersion: v1
+kind: Pod
+metadata:
+  name: banyandb-plugin
+  labels:
+    app: banyandb-plugin
+spec:
+  initContainers:
+    # The first-party carrier (busybox-based) populates the shared /plugins
+    # volume. Same tag as the host image → lockstep toolchain parity.
+    - name: install-plugins
+      image: ${CARRIER_IMAGE}
+      imagePullPolicy: IfNotPresent
+      command: ["sh", "-c", "cp /plugins/*.so /shared/ && ls -l /shared"]
+      volumeMounts:
+        - name: plugins
+          mountPath: /shared
+  containers:
+    - name: banyandb
+      # The CGO/dynamic, plugin-capable host image (gcr.io/distroless/base-debian12).
+      image: ${HOST_IMAGE}
+      imagePullPolicy: IfNotPresent
+      args:
+        - standalone
+        - --trace-pipeline-native-plugin-enabled=true
+        - --trace-pipeline-trusted-plugin-dir=/plugins
+        # merge grace 0 (harmless for the load assertion).
+        - --trace-pipeline-merge-grace-default=0
+        # Shorten the data node's property-schema sync interval (default 30s) so
+        # that once its schema client finishes its (~60s hardcoded) init-wait,
+        # the registered group pipeline reconciles promptly on the next sync.
+        - --schema-property-client-sync-interval=2s
+      ports:
+        - name: grpc
+          containerPort: 17912
+        - name: http
+          containerPort: 17913
+        - name: metrics
+          containerPort: 2121
+      readinessProbe:
+        httpGet:
+          path: /api/healthz
+          port: 17913
+        initialDelaySeconds: 5
+        periodSeconds: 3
+        failureThreshold: 60
+      volumeMounts:
+        - name: plugins
+          mountPath: /plugins
+  volumes:
+    - name: plugins
+      emptyDir: {}

--- a/test/plugin-sidecar/kind.yaml
+++ b/test/plugin-sidecar/kind.yaml
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Single-node kind cluster for the plugin-sidecar SHIP GATE. The banyandb HTTP
+# (17913) and metrics (2121) ports are reached via `kubectl port-forward` in
+# run.sh, so no extraPortMappings are required here. Node image is pinned to
+# 1.30.x (kind v0.23.0's default), matching the version used elsewhere in the
+# repo (test/e2e-v2 setup, FODC E2E CI).
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane

--- a/test/plugin-sidecar/register/main.go
+++ b/test/plugin-sidecar/register/main.go
@@ -1,0 +1,227 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Command register creates the trace group + schema and attaches a trace
+// pipeline (a single latency-status sampler) so a standalone data node
+// reconciles it and calls plugin.Open on the carrier-mounted .so. It is used
+// by the plugin-sidecar kind ship gate to drive assertion (c).
+//
+// It writes through the PROPERTY schema registry client (the same path
+// test/cases/tracepipeline's PreloadSchemaViaProperty uses), NOT the
+// GroupRegistryService HTTP/gRPC endpoint: only the property schema store is
+// watched by the data node's trace schemaRepo, so only writes through it fire
+// the KindGroup reconcile that loads the plugin. The property store also
+// round-trips the nested pipeline field (the HTTP gateway does not).
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/pkg/errors"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	commonv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/common/v1"
+	databasev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
+	"github.com/apache/skywalking-banyandb/banyand/metadata/schema"
+	"github.com/apache/skywalking-banyandb/banyand/metadata/schema/property"
+	"github.com/apache/skywalking-banyandb/banyand/observability"
+)
+
+func main() {
+	propAddr := flag.String("property-schema-addr", "localhost:17916",
+		"banyandb property-schema gRPC address (PropertySchemaGrpcAddress)")
+	nodeName := flag.String("node-name", "banyandb-plugin:17912", "target data node name (schema server identity)")
+	group := flag.String("group", "test-trace-pipeline", "target trace group")
+	soName := flag.String("so", "latencystatussampler.so", "trusted-dir-relative .so path")
+	threshold := flag.Float64("threshold-ms", 500, "latency sampler thresholdMs")
+	successValue := flag.String("success-value", "success", "latency sampler successValue")
+	flag.Parse()
+
+	if err := run(*propAddr, *nodeName, *group, *soName, *threshold, *successValue); err != nil {
+		fmt.Fprintf(os.Stderr, "register: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("registered pipeline on group %q referencing %q (via property schema registry)\n", *group, *soName)
+}
+
+// nodeRegistry implements schema.Node: it advertises exactly one ROLE_META
+// schema server at the given property-schema gRPC address.
+type nodeRegistry struct {
+	nodes []*databasev1.Node
+}
+
+func (r *nodeRegistry) ListNode(_ context.Context, role databasev1.Role) ([]*databasev1.Node, error) {
+	var out []*databasev1.Node
+	for _, n := range r.nodes {
+		for _, nr := range n.GetRoles() {
+			if nr == role {
+				out = append(out, n)
+				break
+			}
+		}
+	}
+	return out, nil
+}
+func (r *nodeRegistry) RegisterNode(_ context.Context, _ *databasev1.Node, _ bool) error { return nil }
+func (r *nodeRegistry) GetNode(_ context.Context, name string) (*databasev1.Node, error) {
+	// This register helper's SchemaRegistryClient only exercises ListNode; return
+	// an explicit error rather than an ambiguous (nil, nil) so any future call
+	// path fails fast instead of silently treating it as a successful nil lookup.
+	return nil, errors.Errorf("nodeRegistry.GetNode(%q): not implemented (register helper only requires ListNode)", name)
+}
+func (r *nodeRegistry) UpdateNode(_ context.Context, _ *databasev1.Node) error { return nil }
+
+func run(propAddr, nodeName, group, soName string, threshold float64, successValue string) error {
+	reg, regErr := property.NewSchemaRegistryClient(&property.ClientConfig{
+		OMR:         observability.BypassRegistry,
+		GRPCTimeout: 10 * time.Second,
+		NodeRegistry: &nodeRegistry{nodes: []*databasev1.Node{{
+			Metadata:                  &commonv1.Metadata{Name: nodeName},
+			Roles:                     []databasev1.Role{databasev1.Role_ROLE_META},
+			PropertySchemaGrpcAddress: propAddr,
+		}}},
+	})
+	if regErr != nil {
+		return errors.Wrap(regErr, "new property schema registry client")
+	}
+	defer func() { _ = reg.Close() }()
+
+	// Wait for the schema server node to become active.
+	deadline := time.Now().Add(30 * time.Second)
+	for len(reg.ActiveNodeNames()) == 0 {
+		if time.Now().After(deadline) {
+			return errors.New("no active property schema server node within 30s")
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	ctx := context.Background()
+
+	// Mirror the proven integration-test sequence
+	// (PreloadSchemaViaProperty + RegisterSamplerRuntime): first create the
+	// group WITHOUT the pipeline, then attach the pipeline via UpdateGroup. The
+	// pipeline is delivered on the group-UPDATE watch event, which is the path
+	// that reliably fires the data node's reconcilePipeline (create-with-pipeline
+	// does not).
+	base := &commonv1.Group{
+		Metadata: &commonv1.Metadata{Name: group},
+		Catalog:  commonv1.Catalog_CATALOG_TRACE,
+		ResourceOpts: &commonv1.ResourceOpts{
+			ShardNum:        1,
+			SegmentInterval: &commonv1.IntervalRule{Unit: commonv1.IntervalRule_UNIT_DAY, Num: 1},
+			Ttl:             &commonv1.IntervalRule{Unit: commonv1.IntervalRule_UNIT_DAY, Num: 3},
+		},
+	}
+	if _, createErr := reg.CreateGroup(ctx, base); createErr != nil && !errors.Is(createErr, schema.ErrGRPCAlreadyExists) {
+		return errors.Wrap(createErr, "create group")
+	}
+
+	// Create the trace schema (harmless if already present); mirrors
+	// test/cases/tracepipeline/testdata/traces/filter.json.
+	trace := traceSchema(group)
+	if _, traceErr := reg.CreateTrace(ctx, trace); traceErr != nil && !errors.Is(traceErr, schema.ErrGRPCAlreadyExists) {
+		return errors.Wrap(traceErr, "create trace schema")
+	}
+
+	// Wait for the freshly-created group to propagate to (and be established
+	// on) the data node before attaching the pipeline — mirrors the
+	// integration suite's waitForSchemaSync between PreloadSchemaViaProperty
+	// and RegisterSamplerRuntime. Without this settle, the pipeline UpdateGroup
+	// races the group create and the data node's reconcilePipeline does not
+	// fire for it.
+	syncDeadline := time.Now().Add(30 * time.Second)
+	for {
+		got, getErr := reg.GetGroup(ctx, group)
+		if getErr == nil && got != nil {
+			break
+		}
+		if time.Now().After(syncDeadline) {
+			return errors.New("group did not become visible within 30s")
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	time.Sleep(3 * time.Second)
+
+	// Attach the pipeline via UpdateGroup → fires reconcilePipeline → plugin.Open.
+	pc, pcErr := pipelineConfig(soName, threshold, successValue)
+	if pcErr != nil {
+		return errors.Wrap(pcErr, "build pipeline config")
+	}
+	withPipeline := &commonv1.Group{
+		Metadata:     &commonv1.Metadata{Name: group},
+		Catalog:      commonv1.Catalog_CATALOG_TRACE,
+		ResourceOpts: base.ResourceOpts,
+		Pipeline:     pc,
+	}
+	if _, updateErr := reg.UpdateGroup(ctx, withPipeline); updateErr != nil {
+		return errors.Wrap(updateErr, "update group with pipeline")
+	}
+	return nil
+}
+
+func pipelineConfig(soName string, threshold float64, successValue string) (*commonv1.TracePipelineConfig, error) {
+	cfgStruct, err := structpb.NewStruct(map[string]any{
+		"thresholdMs":  threshold,
+		"successValue": successValue,
+	})
+	if err != nil {
+		// NewStruct fails on non-finite numbers (NaN/Inf); fail fast rather than
+		// silently shipping a nil config Struct (which would fall back to plugin
+		// defaults with no signal).
+		return nil, errors.Wrap(err, "structpb.NewStruct(sampler config)")
+	}
+	return &commonv1.TracePipelineConfig{
+		Enabled:       true,
+		EnabledEvents: []commonv1.PipelineEvent{commonv1.PipelineEvent_PIPELINE_EVENT_MERGE},
+		Plugins: []*commonv1.Plugin{
+			{
+				Name: "latency-status",
+				Kind: &commonv1.Plugin_Sampler{
+					Sampler: &commonv1.SamplerPlugin{
+						Path:       soName,
+						AbiVersion: 1,
+						Config:     cfgStruct,
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+func traceSchema(group string) *databasev1.Trace {
+	strTag := func(name string) *databasev1.TraceTagSpec {
+		return &databasev1.TraceTagSpec{Name: name, Type: databasev1.TagType_TAG_TYPE_STRING}
+	}
+	return &databasev1.Trace{
+		Metadata: &commonv1.Metadata{Name: "filter", Group: group},
+		Tags: []*databasev1.TraceTagSpec{
+			strTag("trace_id"),
+			strTag("span_id"),
+			{Name: "timestamp", Type: databasev1.TagType_TAG_TYPE_TIMESTAMP},
+			strTag("service_id"),
+			{Name: "duration", Type: databasev1.TagType_TAG_TYPE_INT},
+			strTag("status"),
+		},
+		TraceIdTagName:   "trace_id",
+		SpanIdTagName:    "span_id",
+		TimestampTagName: "timestamp",
+	}
+}

--- a/test/plugin-sidecar/run.sh
+++ b/test/plugin-sidecar/run.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SHIP GATE: prove the CGO "-plugins" host image + carrier-mount design works
+# in REAL Kubernetes (kind). banyandb images ONLY — no OAP, no producer, no
+# traffic generator.
+#
+# Flow: create kind cluster -> (build if needed) -> kind load BOTH images ->
+#       kubectl apply standalone (carrier initContainer -> emptyDir /plugins)
+#       -> wait Ready -> assertions -> teardown (always).
+#
+# Required assertions (the gate):
+#   (a) banyand pod reaches Ready              (CGO/dynamic host boots in-cluster)
+#   (b) /plugins/latencystatussampler.so present in the banyand container
+#   (c) register a group whose pipeline references latencystatussampler.so and
+#       assert the data node LOADS it with NO failure (plugin.Open succeeded):
+#         - the fail-open ERROR is ABSENT, AND
+#         - sampler_active_count{group}>0 (a positive load-success signal).
+# Stretch: write a drop-eligible + a keep trace, await merge, assert the
+#          eligible one is dropped (best-effort; does not fail the gate).
+#
+# Env knobs:
+#   TAG            image tag (default: latest)
+#   HOST_IMAGE     default: apache/skywalking-banyandb:${TAG}-plugins
+#   CARRIER_IMAGE  default: apache/skywalking-banyandb:${TAG}-plugins-carrier
+#   SKIP_BUILD     if "true", do not build images (assume present / to be loaded)
+#   KEEP_CLUSTER   if "true", do not delete the kind cluster on exit (debugging)
+#
+# NOTE on the "stretch" (write a drop-eligible + keep trace, merge, assert the
+# eligible one is dropped): that end-to-end DROP behavior is already proven by
+# the in-process trace_pipeline integration suite
+# (test/integration/standalone/pipeline), which boots the SAME "-plugins" host
+# binary + carrier .so via --trace-pipeline-trusted-plugin-dir and asserts the
+# sampler drops the eligible trace on merge. This kind gate deliberately scopes
+# to what only real Kubernetes can prove — the CGO host boots as a pod and the
+# carrier-mounted .so is loadable in-cluster (assertions a/b/c) — rather than
+# re-deriving the drop logic (which needs the trace-write path, not available
+# via bydbctl) more flakily over a port-forward.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+CLUSTER="${CLUSTER:-banyandb-plugin-sidecar}"
+TAG="${TAG:-latest}"
+HOST_IMAGE="${HOST_IMAGE:-apache/skywalking-banyandb:${TAG}-plugins}"
+CARRIER_IMAGE="${CARRIER_IMAGE:-apache/skywalking-banyandb:${TAG}-plugins-carrier}"
+SKIP_BUILD="${SKIP_BUILD:-false}"
+KEEP_CLUSTER="${KEEP_CLUSTER:-false}"
+RUN_STRETCH="${RUN_STRETCH:-true}"
+
+POD="banyandb-plugin"
+GROUP="test-trace-pipeline"
+KCTX="kind-${CLUSTER}"
+PF_PID=""
+
+log()  { echo -e "\n=== $* ==="; }
+fail() { echo "GATE FAILURE: $*" >&2; exit 1; }
+
+cleanup() {
+  local rc=$?
+  if [[ -n "${PF_PID}" ]]; then kill "${PF_PID}" 2>/dev/null || true; fi
+  if [[ "${rc}" -ne 0 ]]; then
+    log "FAILURE diagnostics (rc=${rc})"
+    kubectl --context "${KCTX}" get pods -o wide 2>/dev/null || true
+    kubectl --context "${KCTX}" describe pod "${POD}" 2>/dev/null | tail -40 || true
+    echo "--- banyandb container logs (tail) ---"
+    kubectl --context "${KCTX}" logs "${POD}" -c banyandb 2>/dev/null | tail -60 || true
+    echo "--- install-plugins initContainer logs ---"
+    kubectl --context "${KCTX}" logs "${POD}" -c install-plugins 2>/dev/null | tail -20 || true
+  fi
+  if [[ "${KEEP_CLUSTER}" != "true" ]]; then
+    log "Deleting kind cluster ${CLUSTER}"
+    kind delete cluster --name "${CLUSTER}" 2>/dev/null || true
+  fi
+  exit "${rc}"
+}
+trap cleanup EXIT
+
+build_images() {
+  if [[ "${SKIP_BUILD}" == "true" ]]; then
+    log "SKIP_BUILD=true — assuming ${HOST_IMAGE} and ${CARRIER_IMAGE} already exist"
+    return
+  fi
+  if docker image inspect "${HOST_IMAGE}" >/dev/null 2>&1 && \
+     docker image inspect "${CARRIER_IMAGE}" >/dev/null 2>&1; then
+    log "Reusing existing images ${HOST_IMAGE} and ${CARRIER_IMAGE}"
+    return
+  fi
+  log "Building companion static binaries + plugin host + carrier images (amd64)"
+  ( cd "${REPO_ROOT}" && PLATFORMS=linux/amd64 make -C banyand release )
+  ( cd "${REPO_ROOT}" && PLATFORMS=linux/amd64 TAG="${TAG}" BINARYTYPE=plugins make -C banyand docker )
+  ( cd "${REPO_ROOT}" && PLATFORMS=linux/amd64 TAG="${TAG}" make -C banyand docker.plugins-carrier )
+}
+
+main() {
+  command -v kind >/dev/null    || fail "kind not found on PATH"
+  command -v kubectl >/dev/null || fail "kubectl not found on PATH"
+  command -v envsubst >/dev/null || fail "envsubst not found on PATH (install gettext-base)"
+  command -v go >/dev/null || fail "go not found on PATH (needed to run the pipeline register helper)"
+
+  # Defensive: kill only OUR stale kubectl port-forwards — ones targeting this
+  # test's pod ("pod/${POD}") — left by a prior run, so the ephemeral-port
+  # forwards below can always bind. Narrowed (not every `port-forward`) so a
+  # developer's unrelated port-forwards on the same machine are left alone.
+  for p in $(pgrep -x kubectl 2>/dev/null || true); do
+    cmd="$(tr '\0' ' ' < "/proc/$p/cmdline" 2>/dev/null)"
+    case "$cmd" in
+      *port-forward*"pod/${POD}"*) kill "$p" 2>/dev/null || true ;;
+    esac
+  done
+
+  build_images
+
+  log "Creating kind cluster ${CLUSTER}"
+  kind create cluster --name "${CLUSTER}" --config "${SCRIPT_DIR}/kind.yaml" --wait 180s
+
+  log "Loading BOTH plugin images into kind (lockstep, same tag)"
+  kind load docker-image "${HOST_IMAGE}" --name "${CLUSTER}"
+  kind load docker-image "${CARRIER_IMAGE}" --name "${CLUSTER}"
+
+  log "Deploying standalone banyandb (carrier initContainer -> emptyDir /plugins)"
+  HOST_IMAGE="${HOST_IMAGE}" CARRIER_IMAGE="${CARRIER_IMAGE}" \
+    envsubst '${HOST_IMAGE} ${CARRIER_IMAGE}' < "${SCRIPT_DIR}/banyandb-standalone.yaml" \
+    | kubectl --context "${KCTX}" apply -f -
+
+  # ---- Assertion (a): pod reaches Ready (CGO/dynamic host boots) ----
+  log "Assertion (a): waiting for pod/${POD} to become Ready"
+  kubectl --context "${KCTX}" wait --for=condition=Ready "pod/${POD}" --timeout=240s \
+    || fail "(a) pod ${POD} did not become Ready — the CGO host image failed to boot in-cluster"
+  kubectl --context "${KCTX}" get pods -o wide
+  echo "(a) PASS: banyandb pod (CGO/dynamic -plugins host image) is Ready"
+
+  # ---- Assertion (b): the carrier delivered the .so into the shared /plugins ----
+  # The host (banyandb) container is distroless — it has NO shell, so we cannot
+  # `kubectl exec ... ls` into it. Instead verify delivery from the carrier
+  # initContainer's own log: it runs `cp /plugins/*.so /shared/ && ls -l /shared`
+  # into the emptyDir the host mounts at /plugins, so its log lists the .so it
+  # placed there.
+  log "Assertion (b): latencystatussampler.so delivered to the shared /plugins by the carrier initContainer"
+  local initlog
+  initlog="$(kubectl --context "${KCTX}" logs "${POD}" -c install-plugins 2>/dev/null || true)"
+  echo "${initlog}"
+  echo "${initlog}" | grep -q "latencystatussampler.so" \
+    || fail "(b) install-plugins initContainer log does not show latencystatussampler.so — the carrier did not populate the shared volume"
+  echo "(b) PASS: latencystatussampler.so delivered to the shared /plugins volume (per the carrier initContainer log)"
+
+  # ---- Assertion (c): register the pipeline; assert the data node LOADS it ----
+  # Registered through the property schema registry (the store the data node's
+  # trace schemaRepo watches), NOT the GroupRegistryService HTTP/gRPC endpoint
+  # (whose store the pipeline reconcile does not observe, and whose HTTP gateway
+  # drops the nested pipeline field). Each port-forward uses a fresh EPHEMERAL
+  # local port and is torn down after use, so a stale forward from a prior run
+  # can never block the bind (the failure that previously wedged the poll).
+  local reg_lport=$(( (RANDOM % 10000) + 40000 ))
+  local met_lport=$(( (RANDOM % 10000) + 30000 ))
+
+  log "Assertion (c): registering group + pipeline referencing latencystatussampler.so (property schema :17916 via local ${reg_lport})"
+  kubectl --context "${KCTX}" port-forward "pod/${POD}" "${reg_lport}:17916" >/tmp/pf-reg.log 2>&1 &
+  local reg_pf=$!
+  # Wire into the EXIT cleanup trap so an early exit between here and the kill
+  # below (e.g. `go build` failing under `set -e`) still reaps this forward.
+  PF_PID="${reg_pf}"
+  sleep 4
+  local register_bin="${RUNNER_TEMP:-/tmp}/plugin-sidecar-register"
+  ( cd "${REPO_ROOT}" && go build -o "${register_bin}" ./test/plugin-sidecar/register )
+  "${register_bin}" \
+    --property-schema-addr "localhost:${reg_lport}" \
+    --node-name "${POD}:17912" \
+    --group "${GROUP}" \
+    --so latencystatussampler.so \
+    || { kill "${reg_pf}" 2>/dev/null || true; PF_PID=""; fail "register helper failed"; }
+  kill "${reg_pf}" 2>/dev/null || true
+  # Forward is dead; clear PF_PID so cleanup doesn't act on a stale PID (the
+  # metrics forward below sets PF_PID to its own PID next).
+  PF_PID=""
+
+  log "Port-forwarding metrics :2121 via local ${met_lport}"
+  kubectl --context "${KCTX}" port-forward "pod/${POD}" "${met_lport}:2121" >/tmp/pf-metrics.log 2>&1 &
+  PF_PID=$!
+  local up="false"
+  for _ in $(seq 1 30); do
+    if curl -fsS "http://localhost:${met_lport}/metrics" >/dev/null 2>&1; then up="true"; break; fi
+    sleep 1
+  done
+  [[ "${up}" == "true" ]] || { cat /tmp/pf-metrics.log 2>/dev/null || true; fail "metrics port-forward to :2121 did not come up"; }
+
+  # The standalone data node's property-schema client warms up before it syncs
+  # a freshly-registered group (a hardcoded ~60s init-wait plus additional
+  # standalone metadata warmup). The plugin ALWAYS loads once the reconcile
+  # fires — that is instant — but the cold-start reconcile latency is highly
+  # variable on kind (observed ~4.5-10 min across runs; instant on an already
+  # warm node). This wait is purely that standalone schema-sync warmup, wholly
+  # orthogonal to the plugin packaging/mount this gate proves. Poll up to
+  # ~15 min to reliably cover the observed worst case with margin (the isolated
+  # CI job's timeout is 60 min). A genuine load FAILURE (fail-open ERROR /
+  # incLoadFailed) fails FAST below regardless of this budget.
+  log "Assertion (c): waiting for the data node to load the sampler (standalone schema-sync warmup; can take several minutes)"
+  local loaded="false"
+  for i in $(seq 1 900); do
+    # Negative signal: the fail-open ERROR must NOT appear.
+    if kubectl --context "${KCTX}" logs "${POD}" -c banyandb 2>/dev/null \
+        | grep -q "sampler plugin load failed"; then
+      echo "--- load-failure log line found ---"
+      kubectl --context "${KCTX}" logs "${POD}" -c banyandb | grep "sampler plugin load failed" | tail -5
+      fail "(c) data node logged a sampler LOAD FAILURE — plugin.Open rejected the mounted .so (parity broken)"
+    fi
+    # Positive signal: sampler_active_count{group} > 0.
+    local active
+    active="$(curl -fsS http://localhost:${met_lport}/metrics 2>/dev/null \
+      | grep '^banyandb_trace_pipeline_sampler_active_count' \
+      | grep "group=\"${GROUP}\"" || true)"
+    if [[ -n "${active}" ]]; then
+      local val="${active##* }"
+      if awk "BEGIN{exit !(${val}>0)}" 2>/dev/null; then
+        echo "metric: ${active} (after ~${i}s)"
+        loaded="true"
+        break
+      fi
+    fi
+    (( i % 30 == 0 )) && echo "(c) ${i}s elapsed, waiting for reconcile..."
+    sleep 1
+  done
+
+  # Final negative-signal check regardless of timing.
+  if kubectl --context "${KCTX}" logs "${POD}" -c banyandb 2>/dev/null | grep -q "sampler plugin load failed"; then
+    fail "(c) data node logged a sampler LOAD FAILURE after reconcile"
+  fi
+  [[ "${loaded}" == "true" ]] \
+    || fail "(c) sampler_active_count{group=${GROUP}} never became >0 — the pipeline did not load the plugin"
+
+  echo "(c) PASS: plugin.Open succeeded on the carrier-mounted .so in real K8s"
+  echo "         - fail-open ERROR ABSENT; sampler_active_count{group=${GROUP}}>0"
+  echo "--- load-success metrics ---"
+  curl -fsS http://localhost:${met_lport}/metrics 2>/dev/null \
+    | grep -E '^banyandb_trace_pipeline_sampler_(active_count|register_total|load_failed)' | grep "${GROUP}" || true
+
+  log "SHIP GATE PASSED: (a) Ready, (b) .so mounted, (c) plugin loaded in real Kubernetes"
+}
+
+main "$@"


### PR DESCRIPTION
Part of apache/skywalking#13634

## What this delivers

PR1 of the trace-pipeline plugin packaging & developer-tooling work:

- **Packaging** — an in-repo `plugins/skywalking/` source home; a CGO/dynamic, slim (no-UI) `-plugins` **host** image on `gcr.io/distroless/base-debian12` (empty `/plugins`) and a busybox `-plugins-carrier` **carrier** image (the `.so`), both under the single `apache/skywalking-banyandb` repo distinguished by tag, built lockstep at the same `<sha>`. Plugins are delivered by **mounting** the carrier at `/plugins` (OCI image-volume or initContainer). The default static image is unchanged (asserted in CI).
- **Dev toolkit** — additive SDK helpers (`EncodeTagValue`/`OpenSampler`/`EvaluateChain`+`BypassInfo`; no ABI bump) with a behavior-preserving engine refactor; the `pkg/pipeline/sdk/sdktest` offline kit (fixture builder + differential projection guard + chain harness); a conformance golden test.
- **Kind ship-gate** — `test/plugin-sidecar` proves the CGO host + carrier-mount works in real Kubernetes (banyandb images only); runs in CI on plugin-touching PRs.
- **CI** — a separate, isolated job in `publish-docker.yml` builds/pushes both plugin images (multi-arch) on `main`.

## Documentation

- **Development Guide (start here):** [docs/operation/plugins-development.md](https://github.com/hanahmily/skywalking-banyandb/blob/plugin-packaging/docs/operation/plugins-development.md)
- **Packaging & Deployment:** [docs/operation/plugins.md](https://github.com/hanahmily/skywalking-banyandb/blob/plugin-packaging/docs/operation/plugins.md)
- **Debugging (offline):** [docs/operation/plugins-debugging.md](https://github.com/hanahmily/skywalking-banyandb/blob/plugin-packaging/docs/operation/plugins-debugging.md)
- **Plugin contract / source home:** [plugins/README.md](https://github.com/hanahmily/skywalking-banyandb/blob/plugin-packaging/plugins/README.md)

## Verification

- `make lint`, `make check` green; `go build ./...`; `banyand/trace` suite (plain + `-race`); sdk/sdktest/plugins; conformance golden test.
- Kind ship-gate **PASSED** on the distroless+slim host (pod boots, carrier delivers the `.so`, plugin loads).
