### PR TITLE
canopy: Pipelines — TopN aggregation CRUD + Top-N query console

### DIFF
--- a/canopy/docs/pipelines-design.md
+++ b/canopy/docs/pipelines-design.md
@@ -1,0 +1,149 @@
+<!--
+  Licensed to Apache Software Foundation (ASF) under one or more contributor
+  license agreements. See the NOTICE file distributed with this work for
+  additional information regarding copyright ownership. Apache Software
+  Foundation (ASF) licenses this file to you under the Apache License,
+  Version 2.0 (the "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  License for the specific language governing permissions and limitations
+  under the License.
+-->
+
+# Pipelines + Pipelines/TopN — design
+
+Pipelines are continuous processing that maintains derived results over stored
+data. v1 has **one** pipeline type — **TopN** — where each "pipeline" is a
+`TopNAggregation` schema. Grounded in
+`.handoff-import/banyandb/project/screenshots-pipelines/` and the BanyanDB
+`database/v1` TopNAggregationRegistryService (`rpc.proto` ~L698).
+
+## 0. Port the handoff source — don't rebuild
+
+The handoff already ships the whole feature. **Port these three files** (JSX +
+window-globals → ES-module TSX); the only real change is swapping mock data /
+`window` navigation for the live registry API + react-router.
+
+| Handoff file | → Canopy | What it gives us |
+|---|---|---|
+| `pipelines.jsx` | `web/src/pages/PipelinesPage.tsx` | `PipelinesOverview` (stats tiles + "Pipeline types" cards + Recent), `PIPELINE_TYPES`, `PipelineTypeNotFound`. |
+| `topn-page.jsx` | `web/src/pipelines/TopNList.tsx` + `TopNDetail.tsx` | `TopNList` (filter by name/group/source/direction + aggregation cards), `TopNDetail` (source/ranking/group-by/criteria + **Run Top-N query**), `RankBadge`, criteria chips. |
+| `topn-form.jsx` | `web/src/pipelines/TopNForms.tsx` | `TopNFormModal` (create/edit), `DeleteTopNModal`, `validateTopN`, `TopNSelect`, `TopNChipPicker` (group-by tags), `CriteriaEditor` (flat ANDed `{tag,op,value}` list). Reuses M3 `Field`/`Modal`. |
+
+**Do NOT port** `topn-results.jsx` — it's the leaderboard result view, already
+shipped in M4 as `web/src/query/results/TopNResultView.tsx`. Styling comes from
+the existing `canopy.css` (the pipelines/topn classes are in the shared theme).
+
+## 1. The model
+
+A TopN pipeline is a **`TopNAggregation`** (schema.proto `TopNAggregation`):
+
+```
+metadata:          { group, name }          # identity (name immutable)
+source_measure:    { group, name }          # the measure it ranks
+field_name:        string                   # the ranked field
+field_value_sort:  model.v1.Sort            # SORT_DESC | SORT_ASC | SORT_UNSPECIFIED
+group_by_tag_names:[string]
+criteria:          model.v1.Criteria        # optional filter (flat AND list in the UI)
+counters_number:   int32                    # e.g. 1000
+lru_size:          int32                    # e.g. 10
+```
+
+**Direction ⇄ sort** (port `RankBadge` verbatim): `topN` = `SORT_DESC` (largest
+first), `bottomN` = `SORT_ASC` (smallest first), `both` = `SORT_UNSPECIFIED`.
+The `criteria` uses the same `model.v1.Criteria` as measure/property queries,
+but the form edits it as a **flat ANDed condition list** (the handoff's simpler
+`CriteriaEditor`), not the recursive WHERE tree.
+
+## 2. API — `database/v1` TopNAggregationRegistryService (`~L698`)
+
+`List` already exists in canopy (`api.ts` `listTopNAggregations`); **add the rest**:
+
+```
+List    GET    /api/v1/topn-agg/schema/lists/{group}     (exists)
+Get     GET    /api/v1/topn-agg/schema/{group}/{name}
+Create  POST   /api/v1/topn-agg/schema                    body: { topNAggregation: {...} }
+Update  PUT    /api/v1/topn-agg/schema/{group}/{name}     body: { topNAggregation: {...} }
+Delete  DELETE /api/v1/topn-agg/schema/{group}/{name}
+```
+
+Add to `DataSource` + `ApiDataSource`: `getTopNAggregation`, `createTopNAggregation`,
+`updateTopNAggregation`, `deleteTopNAggregation`. Extend the `TopNAggregationSchema`
+DTO (`shared/src/api-dto.ts`) to carry the full shape above (source_measure,
+field_value_sort, group_by_tag_names, criteria, counters_number, lru_size).
+Note the response key is `topNAggregation` (camelCase, per the existing List).
+
+## 3. Routes & sidebar
+
+- `/pipelines` — `PipelinesOverview` (exists only as a "Coming soon" stub today).
+- `/pipelines/topn` — `TopNList` across all measure groups.
+- `/pipelines/topn/:group/:name` — `TopNDetail`.
+- **Sidebar:** Pipelines is a flat link today. Extend it (minimal, like Property's
+  `PropertyNav`) to `Pipelines → TopN (aggregation count)`. The screenshots show
+  only `Pipelines → TopN` (one level), so this is simpler than Property's tree.
+
+## 4. Reuse (don't re-port)
+
+- **Forms:** M3 `Field` / `Modal` / dirty-guard / focus-trap / type-to-confirm
+  delete (the `TopNFormModal` already targets `Field`/`Modal`).
+- **Measure metadata:** the source-group / source-measure / ranked-field pickers
+  are populated from the existing `listGroups` + `listResourcesInGroup('measures')`
+  + the measure's field names — canopy already fetches these for the query builder.
+- **Run Top-N query:** `TopNDetail`'s button deep-links to the M4 TopN query
+  console. Reuse the **existing** navigation-state seed already wired from
+  `GroupPage` ("Query this resource"): `navigate('/query', { state: seed })` with
+  `{ catalog: 'topn', group, resource: aggName }`; `QueryConsole` already consumes
+  that seed and dispatches TopN queries to `/v1/measure/topn` (M4, SF5). Do NOT
+  build a new query path.
+- **Leaderboard view:** `TopNResultView` (M4) renders the run — nothing new.
+- **Criteria tag options:** the source measure's tag names (from its schema),
+  same source the query builder already uses.
+
+## 5. Adaptations during the port
+
+1. **Mock → live.** `PipelinesOverview`/`TopNList`/`TopNDetail` read a mock
+   `groups` prop; replace with `listGroups` (filtered to measure groups) +
+   `listTopNAggregations` per group (or aggregate across groups for the "all
+   groups" list). `TopNFormModal.onSubmit` → create/update; `DeleteTopNModal` →
+   delete. Counts (overview "N aggregations", "groups in use") derive from the
+   list calls.
+2. **window nav → react-router.** `onNavigate` → `useNavigate`; the detail
+   "Run Top-N query" → navigate to `/query` with the seed state.
+3. **Read-only role** hides New/Edit/Delete (align with the BFF 403), same as the
+   other CRUD pages.
+
+## 6. Validation (advisory; server authoritative)
+
+Port `validateTopN` (name pattern, required source measure + ranked field,
+counters/lru numeric bounds, criteria rows have tag+value) as a tested pure
+function. Client checks are UX-only — a server rejection must still surface.
+
+## 7. Testing (new framework)
+
+- **Unit:** `validateTopN`; the direction⇄sort mapping; `CriteriaEditor`
+  serialization; `TopNList`/`TopNDetail` render from a fixture aggregation.
+- **E2E** `e2e/tests/pipelines.spec.ts` `@e2e @pipelines @seed` + a `PipelinesPage`
+  POM: overview → TopN list → create aggregation (over a seeded measure) → detail
+  renders it → edit → delete. Seed the source measure + aggregation via the
+  registry over HTTP (`SeedFactory.createTopNAggregation`, add it). Runs live via
+  a temp NOAUTH BFF (as the M4/property e2e did) — verify green before claiming.
+
+## 8. Build order
+
+1. Data layer: `TopNAggregationSchema` DTO (full shape) + Get/Create/Update/Delete
+   in DataSource + `api.ts`; `SeedFactory.createTopNAggregation`.
+2. Port `topn-form.jsx` → `TopNForms.tsx` (onSubmit → create/update; reuse M3
+   Field/Modal; port `CriteriaEditor`, `TopNChipPicker`, `validateTopN`).
+3. Port `topn-page.jsx` → `TopNList.tsx` + `TopNDetail.tsx` (live data; Run-query
+   deep-link).
+4. Port `pipelines.jsx` → `PipelinesPage.tsx`; wire `/pipelines`, `/pipelines/topn`,
+   `/pipelines/topn/:group/:name` routes; minimal Pipelines→TopN sidebar nav.
+5. Unit tests + e2e `pipelines.spec.ts` + POM; run live and confirm green.
+
+Mirrors the Property MP shape: port the handoff, swap mock→live registry, reuse
+M3 forms + M4 TopN query, verify against a live seeded BanyanDB.

--- a/canopy/e2e/framework/fixtures.ts
+++ b/canopy/e2e/framework/fixtures.ts
@@ -34,6 +34,7 @@ import { SchemaPage } from './pages/SchemaPage.js';
 import { IndexRulePage } from './pages/IndexRulePage.js';
 import { LifecyclePage } from './pages/LifecyclePage.js';
 import { PropertyPage } from './pages/PropertyPage.js';
+import { PipelinesPage } from './pages/PipelinesPage.js';
 import { SeedFactory } from './seed/factory.js';
 
 type AppFixtures = {
@@ -44,6 +45,7 @@ type AppFixtures = {
   indexRulePage: IndexRulePage;
   lifecyclePage: LifecyclePage;
   propertyPage: PropertyPage;
+  pipelinesPage: PipelinesPage;
   seed: SeedFactory;
 };
 
@@ -68,6 +70,9 @@ export const test = base.extend<AppFixtures>({
   },
   propertyPage: async ({ page }, use) => {
     await use(new PropertyPage(page));
+  },
+  pipelinesPage: async ({ page }, use) => {
+    await use(new PipelinesPage(page));
   },
   seed: async ({ request }, use) => {
     const factory = new SeedFactory(request);

--- a/canopy/e2e/framework/pages/PipelinesPage.ts
+++ b/canopy/e2e/framework/pages/PipelinesPage.ts
@@ -1,0 +1,234 @@
+/*
+ * Licensed to Apache Software Foundation (ASF) under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Apache Software Foundation (ASF) licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// PipelinesPage — page object for the Pipelines surfaces (docs/pipelines-design.md):
+// the generic overview (/pipelines), the cross-group TopN list
+// (/pipelines/topn — TopNList.tsx), the TopN detail page
+// (/pipelines/topn/:group/:name — TopNDetail.tsx) and their create/edit/
+// delete modals (TopNForms.tsx).
+//
+// Locators mirror the other *Page.ts conventions: modals are role="dialog"
+// named by their title, filters are native <select>s reached by their
+// aria-label, and the two markup gaps this milestone found (no stable handle
+// for a TopNList row, and duplicate accessible-name text across the detail
+// page's meta-chip row vs. its Ranking block) were closed with a
+// data-testid="topn-row" and a role="region" landmark respectively, rather
+// than falling back to a CSS/XPath selector.
+
+import { expect, type Locator, type Page } from '@playwright/test';
+import { BasePage } from './BasePage.js';
+
+export type TopNRank = 'topN' | 'bottomN' | 'both';
+
+const RANK_SORT: Record<TopNRank, string> = {
+  topN: 'SORT_DESC',
+  bottomN: 'SORT_ASC',
+  both: 'SORT_UNSPECIFIED',
+};
+
+export interface CreateTopNOpts {
+  readonly name: string;
+  readonly sourceMeasure: string;
+  readonly fieldName: string;
+  readonly rank?: TopNRank;
+  readonly groupByTags?: readonly string[];
+}
+
+export interface EditTopNOpts {
+  readonly fieldName?: string;
+  readonly rank?: TopNRank;
+  readonly countersNumber?: number;
+}
+
+export class PipelinesPage extends BasePage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  // ── Navigation ─────────────────────────────────────────────────────────────
+  async gotoOverview(): Promise<void> {
+    await this.page.goto('/pipelines');
+    await expect(this.page.getByRole('heading', { level: 1, name: 'Pipelines' })).toBeVisible();
+  }
+
+  async gotoList(): Promise<void> {
+    await this.page.goto('/pipelines/topn');
+    await expect(this.page.getByRole('heading', { level: 1, name: 'TopN' })).toBeVisible();
+  }
+
+  async gotoDetail(group: string, name: string): Promise<void> {
+    await this.page.goto(`/pipelines/topn/${group}/${name}`);
+    await expect(this.page.getByRole('heading', { level: 1, name })).toBeVisible();
+  }
+
+  // The app shell's <main> landmark. The Sidebar (docs/pipelines-design.md §3)
+  // has its own always-visible "TopN" nav button, so any locator matching on
+  // the "TopN" label must be scoped to main content — otherwise it's a
+  // strict-mode violation (two "TopN" buttons on screen at once).
+  main(): Locator {
+    return this.page.getByRole('main');
+  }
+
+  // ── Overview ─────────────────────────────────────────────────────────────
+  topNTypeCard(): Locator {
+    return this.main().getByRole('button', { name: /TopN/ });
+  }
+
+  async openTopNType(): Promise<void> {
+    await this.topNTypeCard().click();
+    await expect(this.page.getByRole('heading', { level: 1, name: 'TopN' })).toBeVisible();
+  }
+
+  // ── List filters ───────────────────────────────────────────────────────────
+  nameFilter(): Locator {
+    return this.page.getByPlaceholder('Filter by name');
+  }
+
+  groupFilter(): Locator {
+    return this.page.getByLabel('Group', { exact: true });
+  }
+
+  sourceFilter(): Locator {
+    return this.page.getByLabel('Source', { exact: true });
+  }
+
+  rankFilter(): Locator {
+    return this.page.getByLabel('Rank', { exact: true });
+  }
+
+  // ── List rows ──────────────────────────────────────────────────────────────
+  row(name: string): Locator {
+    return this.page.getByTestId('topn-row').filter({ hasText: name });
+  }
+
+  async openRow(name: string): Promise<void> {
+    await this.row(name).click();
+  }
+
+  newAggregationButton(): Locator {
+    return this.page.getByRole('button', { name: 'New aggregation' });
+  }
+
+  dialog(name: string | RegExp): Locator {
+    return this.page.getByRole('dialog', { name });
+  }
+
+  // ── Create / edit / delete (list page) ──────────────────────────────────────
+  async createAggregation(opts: CreateTopNOpts): Promise<void> {
+    await this.newAggregationButton().click();
+    const dlg = this.dialog('Create TopN aggregation');
+    await expect(dlg).toBeVisible();
+    await dlg.getByPlaceholder('service_cpm_minute_topn').fill(opts.name);
+    await this.fillAggregationForm(dlg, opts);
+    await dlg.getByRole('button', { name: 'Create aggregation' }).click();
+    await expect(dlg).not.toBeVisible();
+  }
+
+  // Shared fill logic for source measure / ranked field / rank direction /
+  // group-by tags, used by both create (via createAggregation) and edit.
+  //
+  // Combobox.tsx renders its option listbox through a React portal into
+  // document.body (DropdownPanel), so the <li role="option"> elements are NOT
+  // DOM descendants of the dialog — `dlg.getByRole('option', ...)` never
+  // resolves and hangs until timeout. Options must be looked up page-scoped;
+  // the combobox input itself stays dialog-scoped since it isn't portaled.
+  private async fillAggregationForm(
+    dlg: Locator,
+    opts: { sourceMeasure?: string; fieldName?: string; rank?: TopNRank; groupByTags?: readonly string[] },
+  ): Promise<void> {
+    if (opts.sourceMeasure) {
+      await dlg.getByRole('combobox', { name: 'Source measure' }).fill(opts.sourceMeasure);
+      await this.page.getByRole('option', { name: opts.sourceMeasure }).click();
+    }
+    if (opts.fieldName) {
+      await dlg.getByRole('combobox', { name: 'Ranked field' }).fill(opts.fieldName);
+      await this.page.getByRole('option', { name: opts.fieldName }).click();
+    }
+    if (opts.rank) {
+      await dlg.getByRole('button', { name: new RegExp(RANK_SORT[opts.rank]) }).click();
+    }
+    for (const tag of opts.groupByTags ?? []) {
+      await dlg.getByRole('combobox', { name: 'Group by tags' }).fill(tag);
+      await this.page.getByRole('option', { name: tag }).click();
+    }
+  }
+
+  editButton(): Locator {
+    return this.page.getByRole('button', { name: 'Edit' });
+  }
+
+  deleteButton(): Locator {
+    return this.page.getByRole('button', { name: 'Delete' });
+  }
+
+  async openEdit(): Promise<Locator> {
+    await this.editButton().click();
+    const dlg = this.dialog('Edit TopN aggregation');
+    await expect(dlg).toBeVisible();
+    return dlg;
+  }
+
+  async editAggregation(opts: EditTopNOpts): Promise<void> {
+    const dlg = await this.openEdit();
+    await this.fillAggregationForm(dlg, opts);
+    if (opts.countersNumber != null) {
+      await dlg.getByLabel('Counters number').fill(String(opts.countersNumber));
+    }
+    await dlg.getByRole('button', { name: 'Save changes' }).click();
+    await expect(dlg).not.toBeVisible();
+  }
+
+  async deleteAggregation(name: string): Promise<void> {
+    await this.deleteButton().click();
+    const dlg = this.dialog('Delete TopN aggregation');
+    await expect(dlg).toBeVisible();
+    await dlg.getByRole('textbox').fill(name);
+    await dlg.getByRole('button', { name: 'Delete aggregation' }).click();
+    await expect(dlg).not.toBeVisible();
+  }
+
+  // ── Detail page ──────────────────────────────────────────────────────────
+  // The rank/sort/field/counters meta-chip row — scoped via its own region
+  // landmark since "SORT_DESC"/"1000"/etc. recur verbatim in the Ranking
+  // block further down the page (a same-name collision, the exact pitfall
+  // TESTING.md calls out for unscoped getByLabel/getByText).
+  summaryRegion(): Locator {
+    return this.page.getByRole('region', { name: 'TopN aggregation summary' });
+  }
+
+  // The Group-by-tags chip block — also its own region landmark, since a
+  // bare single-letter tag name like "id" has no reliable text-node boundary
+  // to target directly (it sits beside a "1." ordinal chip with no
+  // whitespace separator in the accessible text).
+  groupByRegion(): Locator {
+    return this.page.getByRole('region', { name: 'Group by tags' });
+  }
+
+  runQueryButton(): Locator {
+    return this.page.getByRole('button', { name: /Run Top-N query/i });
+  }
+
+  // Named by its exact "Open {group}/{name}" title — a bare /^Open /
+  // regex also matches the unrelated "Run Top-N query" button (title="Open
+  // the Query console pre-filled to rank this measure"), a second instance
+  // of the same collision pattern this milestone kept running into.
+  sourceMeasureLink(group: string, name: string): Locator {
+    return this.page.getByTitle(`Open ${group}/${name}`, { exact: true });
+  }
+}

--- a/canopy/e2e/framework/seed/factory.ts
+++ b/canopy/e2e/framework/seed/factory.ts
@@ -218,6 +218,38 @@ export class SeedFactory {
     });
   }
 
+  // Create a TopNAggregation over `sourceMeasure` (in the SAME group, per
+  // schema.proto — a topn-agg is registered inside a measure group and ranks
+  // one of that group's measures). Returns the aggregation name. The source
+  // measure must already exist (create it with createMeasure first).
+  async createTopNAggregation(
+    group: string,
+    sourceMeasureName: string,
+    fieldName: string,
+    prefix = 'topn',
+    opts: { readonly fieldValueSort?: 'SORT_DESC' | 'SORT_ASC' | 'SORT_UNSPECIFIED'; readonly groupByTagNames?: readonly string[] } = {},
+  ): Promise<string> {
+    const name = this.uniqueName(prefix);
+    const res = await this.request.post('/api/v1/topn-agg/schema', {
+      data: {
+        topNAggregation: {
+          metadata: { name, group },
+          sourceMeasure: { group, name: sourceMeasureName },
+          fieldName,
+          fieldValueSort: opts.fieldValueSort ?? 'SORT_DESC',
+          groupByTagNames: opts.groupByTagNames ?? [],
+          countersNumber: 1000,
+          lruSize: 10,
+        },
+      },
+    });
+    if (!res.ok()) {
+      throw new Error(`seed createTopNAggregation(${group}/${name}) failed: ${res.status()} ${await res.text()}`);
+    }
+    this.createdResources.push({ path: `/api/v1/topn-agg/schema/${encodeURIComponent(group)}/${encodeURIComponent(name)}` });
+    return name;
+  }
+
   // Create an index rule over `tags` in `group`. Returns the rule name.
   async createIndexRule(group: string, tags: readonly string[], prefix = 'rule', type: IndexRuleType = 'TYPE_TREE'): Promise<string> {
     const name = this.uniqueName(prefix);

--- a/canopy/e2e/tests/pipelines.spec.ts
+++ b/canopy/e2e/tests/pipelines.spec.ts
@@ -1,0 +1,107 @@
+/*
+ * Licensed to Apache Software Foundation (ASF) under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Apache Software Foundation (ASF) licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// pipelines.spec.ts — Pipelines + Pipelines/TopN journey (docs/pipelines-design.md):
+// overview -> TopN list -> create a TopNAggregation over a seeded measure ->
+// detail renders it (rank/sort/field/counters/group-by) -> edit -> delete.
+// The source measure is seeded via SeedFactory.createMeasure (schema-only,
+// over HTTP) since a topn-agg's sourceMeasure must exist first; the
+// aggregation itself is created/edited/deleted through the real UI, not the
+// seed factory, so this spec exercises TopNForms.tsx end-to-end.
+
+import { test, expect } from '../framework/fixtures.js';
+
+test.describe('Pipelines + TopN CRUD @e2e @pipelines @seed', () => {
+  test('the Pipelines overview links into the TopN list', async ({ pipelinesPage }) => {
+    await pipelinesPage.gotoOverview();
+    await pipelinesPage.openTopNType();
+    await expect(pipelinesPage.page).toHaveURL(/\/pipelines\/topn$/);
+  });
+
+  test('create -> detail -> edit -> delete a TopN aggregation over a seeded measure', async ({ pipelinesPage, seed }) => {
+    const group = await seed.createGroup('e2e-topn');
+    const measure = await seed.createMeasure(group, 'm', ['value', 'count']);
+
+    await pipelinesPage.gotoList();
+    // Scope the list + the "New aggregation" CTA to this group, so the create
+    // modal locks Identity/Group to it and pre-fills Source group to match —
+    // a TopNAggregation must live in the same group as the measure it ranks.
+    await pipelinesPage.groupFilter().selectOption(group);
+
+    const name = seed.uniqueName('e2e-topn-agg');
+    await pipelinesPage.createAggregation({
+      name,
+      sourceMeasure: measure,
+      fieldName: 'value',
+      rank: 'bottomN',
+      groupByTags: ['id'],
+    });
+    seed.trackResource(`/api/v1/topn-agg/schema/${encodeURIComponent(group)}/${encodeURIComponent(name)}`);
+
+    // Create navigates straight to the new aggregation's detail page.
+    await expect(pipelinesPage.page).toHaveURL(new RegExp(`/pipelines/topn/${group}/${name}$`));
+
+    const summary = pipelinesPage.summaryRegion();
+    await expect(summary.getByText('bottomN')).toBeVisible();
+    await expect(summary.getByText('SORT_ASC')).toBeVisible();
+    await expect(summary.getByText('value', { exact: true })).toBeVisible();
+    await expect(summary.getByText('1000')).toBeVisible(); // default counters_number
+    await expect(pipelinesPage.sourceMeasureLink(group, measure)).toBeVisible();
+    await expect(pipelinesPage.groupByRegion()).toContainText('id'); // group-by tag chip
+
+    // Edit: swap the ranked field + direction, bump counters.
+    await pipelinesPage.editAggregation({ fieldName: 'count', rank: 'topN', countersNumber: 500 });
+    await expect(summary.getByText('topN')).toBeVisible();
+    await expect(summary.getByText('SORT_DESC')).toBeVisible();
+    await expect(summary.getByText('count', { exact: true })).toBeVisible();
+    await expect(summary.getByText('500')).toBeVisible();
+
+    // The edit is visible from the cross-group list too.
+    await pipelinesPage.gotoList();
+    await expect(pipelinesPage.row(name)).toBeVisible();
+    await expect(pipelinesPage.row(name)).toContainText('topN');
+
+    // Delete from the detail page — type-to-confirm, then back on the list.
+    await pipelinesPage.gotoDetail(group, name);
+    await pipelinesPage.deleteAggregation(name);
+    await expect(pipelinesPage.page).toHaveURL(/\/pipelines\/topn$/);
+    await expect(pipelinesPage.row(name)).toHaveCount(0);
+  });
+
+  test('filters the TopN list by name and rank direction', async ({ pipelinesPage, seed }) => {
+    const group = await seed.createGroup('e2e-topn');
+    const measure = await seed.createMeasure(group, 'm', ['value']);
+    const topName = await seed.createTopNAggregation(group, measure, 'value', 'e2e-top', { fieldValueSort: 'SORT_DESC' });
+    const bottomName = await seed.createTopNAggregation(group, measure, 'value', 'e2e-bottom', { fieldValueSort: 'SORT_ASC' });
+
+    await pipelinesPage.gotoList();
+    await pipelinesPage.groupFilter().selectOption(group);
+    await expect(pipelinesPage.row(topName)).toBeVisible();
+    await expect(pipelinesPage.row(bottomName)).toBeVisible();
+
+    await pipelinesPage.nameFilter().fill('e2e-bottom');
+    await expect(pipelinesPage.row(bottomName)).toBeVisible();
+    await expect(pipelinesPage.row(topName)).toHaveCount(0);
+
+    await pipelinesPage.nameFilter().fill('');
+    await pipelinesPage.rankFilter().selectOption('SORT_DESC');
+    await expect(pipelinesPage.row(topName)).toBeVisible();
+    await expect(pipelinesPage.row(bottomName)).toHaveCount(0);
+  });
+});

--- a/canopy/shared/src/api-dto.ts
+++ b/canopy/shared/src/api-dto.ts
@@ -289,10 +289,18 @@ export interface TopNQueryResponse {
 // TopNAggregation schema — BanyanDB's precomputed leaderboard definition.
 // Wire shape (per the v0.x liaison) is camelCase protojson:
 //   { metadata: {group, name}, sourceMeasure: {group, name}, fieldName,
-//     fieldValueSort: 'SORT_ASC'|'SORT_DESC', groupByTagNames: string[],
+//     fieldValueSort: 'SORT_DESC'|'SORT_ASC'|'SORT_UNSPECIFIED', groupByTagNames: string[],
 //     criteria, countersNumber, lruSize, updatedAt, createdAt }
-// Sourced from GET /api/v1/topn-agg/schema/lists/{group}. The list response
-// repeats under the `topNAggregation` key.
+// (schema.proto TopNAggregation, database/v1 TopNAggregationRegistryService,
+// rpc.proto ~L698). Direction<->sort: topN=SORT_DESC, bottomN=SORT_ASC,
+// both=SORT_UNSPECIFIED.
+//
+// List/Get source from GET /api/v1/topn-agg/schema/{lists/{group}|{group}/{name}}.
+// Create/Update are POST /topn-agg/schema and PUT .../{group}/{name}, both with
+// body/response key `topNAggregation`; the registry's write RPCs return only
+// `{modRevision}` (see rpc.proto TopNAggregationRegistryServiceCreateResponse),
+// so api.ts echoes the submitted payload back like it does for
+// IndexRuleBinding/Property writes.
 //
 // Unlike the per-resource schemas (Measure/Stream/Trace), TopNAggregation does
 // not carry tagFamilies directly — only the names of the entity tags it
@@ -302,8 +310,14 @@ export interface TopNAggregationSchema {
   readonly metadata: { readonly name: string; readonly group: string };
   readonly sourceMeasure?: { readonly name: string; readonly group: string };
   readonly fieldName?: string;
-  readonly fieldValueSort?: 'SORT_ASC' | 'SORT_DESC';
+  readonly fieldValueSort?: 'SORT_DESC' | 'SORT_ASC' | 'SORT_UNSPECIFIED';
   readonly groupByTagNames?: readonly string[];
+  // model.v1.Criteria — the same recursive condition/logical-expression tree
+  // as PropertyCriteria below (both wrap model.v1.Criteria verbatim). The
+  // TopN form UI only ever *builds* a flat AND chain of `condition` nodes,
+  // but a schema created another way could carry a richer tree, so the type
+  // stays the full recursive shape rather than a flat array.
+  readonly criteria?: PropertyCriteria;
   readonly countersNumber?: number;
   readonly lruSize?: number;
   readonly createdAt?: string;
@@ -312,6 +326,16 @@ export interface TopNAggregationSchema {
 
 export interface TopNAggregationListResponse {
   readonly topNAggregation: readonly TopNAggregationSchema[];
+}
+
+export interface CreateTopNAggregationRequest {
+  readonly topNAggregation: Omit<TopNAggregationSchema, 'metadata' | 'createdAt' | 'updatedAt'> & {
+    readonly metadata: { readonly name: string; readonly group: string };
+  };
+}
+
+export interface UpdateTopNAggregationRequest {
+  readonly topNAggregation: TopNAggregationSchema;
 }
 
 // Property schema (collection) CRUD — `database/v1` PropertyRegistryService.

--- a/canopy/web/src/App.tsx
+++ b/canopy/web/src/App.tsx
@@ -28,6 +28,9 @@ import { TypeOverviewPage } from './pages/TypeOverviewPage.js';
 import { GroupPage } from './pages/GroupPage.js';
 import { ResourceDetailPage } from './pages/ResourceDetailPage.js';
 import { PropertyDetailPage } from './pages/PropertyDetailPage.js';
+import { PipelinesPage } from './pages/PipelinesPage.js';
+import { TopNList } from './pipelines/TopNList.js';
+import { TopNDetail } from './pipelines/TopNDetail.js';
 import { GroupForm } from './components/GroupForm.js';
 import { MeasureForm } from './components/MeasureForm.js';
 import { StreamForm } from './components/StreamForm.js';
@@ -511,6 +514,11 @@ function PropertyDetailRoute() {
   return <PropertyDetailPage groupName={group} propName={name} />;
 }
 
+function TopNDetailRoute() {
+  const { group = '', name = '' } = useParams<{ group: string; name: string }>();
+  return <TopNDetail groupName={group} aggName={name} />;
+}
+
 function AppContent() {
   const { session, loading } = useAuth();
 
@@ -542,7 +550,9 @@ function AppContent() {
         <Route path="/properties/:group/:name" element={<PropertyDetailRoute />} />
         <Route path="/properties/:group" element={<PropertiesGroupRoute />} />
         <Route path="/properties" element={<PropertiesOverviewRoute />} />
-        <Route path="/pipelines/*" element={<div className="page-body"><h1 className="page-title">Pipelines</h1><p className="page-meta">Coming soon.</p></div>} />
+        <Route path="/pipelines/topn/:group/:name" element={<TopNDetailRoute />} />
+        <Route path="/pipelines/topn" element={<TopNList />} />
+        <Route path="/pipelines" element={<PipelinesPage />} />
         <Route path="/query" element={<QueryRoute />} />
         <Route path="*" element={<div className="page-body"><h1 className="page-title">Not found</h1></div>} />
       </Routes>

--- a/canopy/web/src/components/Sidebar.tsx
+++ b/canopy/web/src/components/Sidebar.tsx
@@ -27,7 +27,7 @@ import { apiDataSource } from '../data/api.js';
 import {
   IconHome, IconMetadata, IconMeasures, IconStreams, IconTraces,
   IconProperties, IconPipelines, IconQuery, IconChevron, IconCollapse, IconSignOut,
-  IconShield, IconViewer, IconIndex, IconGroup,
+  IconShield, IconViewer, IconIndex, IconGroup, IconTopN,
 } from './icons.js';
 
 /** One property group's row + its lazily-fetched collection list (fetched
@@ -314,6 +314,7 @@ export function Sidebar({ collapsed, onToggleCollapse }: SidebarProps) {
   const [streamsOpen, setStreamsOpen] = useState(false);
   const [tracesOpen, setTracesOpen] = useState(false);
   const [propertiesOpen, setPropertiesOpen] = useState(false);
+  const [pipelinesOpen, setPipelinesOpen] = useState(false);
   // Per-group "Index" sub-row expansion. Empty by default — every Index is
   // folded so the sidebar doesn't grow noisy when there are many groups. The
   // active group's Index is auto-added below; users can fold/unfold manually
@@ -360,6 +361,24 @@ export function Sidebar({ collapsed, onToggleCollapse }: SidebarProps) {
   const streamGroups  = useMemo(() => groups.filter((g) => g.catalog === 'CATALOG_STREAM'),  [groups]);
   const traceGroups   = useMemo(() => groups.filter((g) => g.catalog === 'CATALOG_TRACE'),   [groups]);
   const propertyGroups = useMemo(() => groups.filter((g) => g.catalog === 'CATALOG_PROPERTY'), [groups]);
+  const measureGroupNames = useMemo(() => measureGroups.map((g) => g.name), [measureGroups]);
+
+  // Total TopN aggregation count, across every measure group — drives the
+  // "Pipelines -> TopN (N)" badge. Pipelines is a flat one-level nav (per
+  // docs/pipelines-design.md §3), so this is the only count the sidebar needs
+  // (a second pipeline type would add its own count the same way).
+  const [topNCount, setTopNCount] = useState(0);
+  useEffect(() => {
+    if (measureGroupNames.length === 0) { setTopNCount(0); return; }
+    let cancelled = false;
+    Promise.allSettled(measureGroupNames.map((g) => apiDataSource.listTopNAggregations(g))).then((results) => {
+      if (cancelled) return;
+      let total = 0;
+      for (const r of results) if (r.status === 'fulfilled') total += r.value.length;
+      setTopNCount(total);
+    });
+    return () => { cancelled = true; };
+  }, [measureGroupNames]);
 
   const active = location.pathname;
 
@@ -371,6 +390,7 @@ export function Sidebar({ collapsed, onToggleCollapse }: SidebarProps) {
     if (active.startsWith('/metadata/streams'))  setStreamsOpen(true);
     if (active.startsWith('/metadata/traces'))   setTracesOpen(true);
     if (active.startsWith('/properties/'))       setPropertiesOpen(true);
+    if (active.startsWith('/pipelines/'))         setPipelinesOpen(true);
   }, [active]);
 
   // When the URL lands on a group's Index page, unfold that group's Index
@@ -537,19 +557,50 @@ export function Sidebar({ collapsed, onToggleCollapse }: SidebarProps) {
           collapsed={collapsed}
         />
 
-        {/* Pipelines */}
+        {/* Pipelines — flat one-level nav: Pipelines -> TopN (count). Simpler
+            than Property's group-expanding tree since v1 has exactly one
+            pipeline type (docs/pipelines-design.md §3). */}
         <div className="nav-node">
           <div className="nav-rowline">
             <button
-              className={'nav-row lvl-0' + (active.startsWith('/pipelines') ? ' is-active' : '')}
-              style={{ paddingLeft: 12 }}
-              onClick={() => navigate('/pipelines')}
+              className={'nav-row lvl-0' + (active.startsWith('/pipelines') ? ' has-active' : '')}
+              style={{ paddingLeft: 12, paddingRight: collapsed ? 12 : 32 }}
+              onClick={() => { if (!collapsed) setPipelinesOpen((o) => !o); navigate('/pipelines'); }}
+              aria-expanded={pipelinesOpen}
               title="Pipelines"
             >
               <span className="nav-ico"><IconPipelines /></span>
               <span className="nav-label">Pipelines</span>
             </button>
+            {!collapsed && (
+              <button
+                type="button"
+                className="nav-chev-btn"
+                aria-label={(pipelinesOpen ? 'Collapse' : 'Expand') + ' Pipelines'}
+                aria-expanded={pipelinesOpen}
+                onClick={() => setPipelinesOpen((o) => !o)}
+              >
+                <span className={'nav-chev' + (pipelinesOpen ? ' is-open' : '')}><IconChevron /></span>
+              </button>
+            )}
           </div>
+          {pipelinesOpen && (
+            <div className="nav-sub is-open">
+              <div className="nav-sub-inner">
+                <span className="nav-guide" style={{ left: 21 }} />
+                <button
+                  className={'nav-row lvl-1' + (active.startsWith('/pipelines/topn') ? ' is-active' : '')}
+                  style={{ paddingLeft: 28 }}
+                  onClick={() => navigate('/pipelines/topn')}
+                  title="TopN"
+                >
+                  <span className="nav-ico"><IconTopN size={16} /></span>
+                  <span className="nav-label">TopN</span>
+                  <span className="nav-count">{topNCount}</span>
+                </button>
+              </div>
+            </div>
+          )}
         </div>
 
         {/* Query */}

--- a/canopy/web/src/components/icons.tsx
+++ b/canopy/web/src/components/icons.tsx
@@ -271,3 +271,33 @@ export function IconEmpty({ size = 18 }: IconProps) {
     </Ic>
   );
 }
+
+// Ranked-bars glyph — used for the Pipelines/TopN surfaces (rank badges,
+// list rows, the TopN pipeline-type card). Matches the outline already used
+// locally in TopNResultView.tsx's leaderboard toolbar.
+export function IconTopN({ size = 18 }: IconProps) {
+  return (
+    <Ic size={size}>
+      <rect x="3.5" y="5" width="4.2" height="15" rx="1" />
+      <rect x="9.9" y="9.5" width="4.2" height="10.5" rx="1" />
+      <rect x="16.3" y="14" width="4.2" height="6" rx="1" />
+    </Ic>
+  );
+}
+
+export function IconSort({ size = 18 }: IconProps) {
+  return (
+    <Ic size={size}>
+      <path d="M7 4v16M7 20l-3-3M7 20l3-3" />
+      <path d="M17 20V4M17 4l-3 3M17 4l3 3" />
+    </Ic>
+  );
+}
+
+export function IconFilter({ size = 18 }: IconProps) {
+  return (
+    <Ic size={size}>
+      <path d="M4 5h16l-6 7.5V18l-4 2v-7.5L4 5Z" />
+    </Ic>
+  );
+}

--- a/canopy/web/src/data/DataSource.ts
+++ b/canopy/web/src/data/DataSource.ts
@@ -31,6 +31,7 @@ import type {
   QueryRequest, QueryResponse,
   StreamSchema, MeasureSchema, TraceSchema, PropertySchema, Group,
   IndexRuleSchema, IndexRuleBindingSchema, TopNAggregationSchema,
+  CreateTopNAggregationRequest, UpdateTopNAggregationRequest,
   CreatePropertySchemaRequest, PropertyApplyRequest, PropertyApplyResponse,
   PropertyQueryRequest, PropertyDocument,
 } from 'canopy-shared';
@@ -46,11 +47,14 @@ export interface DataSource {
   listResourcesInGroup(type: string, group: string): Promise<(StreamSchema | MeasureSchema | TraceSchema | PropertySchema)[]>;
   getResource(type: string, group: string, name: string): Promise<StreamSchema | MeasureSchema | TraceSchema | PropertySchema>;
 
-  // TopNAggregation (Top-N schema) — read
-  // Returns the precomputed leaderboard definitions registered under the
-  // given group. The query builder's FROM row uses this list (instead of
+  // TopNAggregation (Top-N schema) — the Pipelines/TopN CRUD surface.
+  // listTopNAggregations also backs the query builder's FROM row (instead of
   // the measure list) when the user is composing a Top-N query.
   listTopNAggregations(group: string): Promise<TopNAggregationSchema[]>;
+  getTopNAggregation(group: string, name: string): Promise<TopNAggregationSchema>;
+  createTopNAggregation(req: CreateTopNAggregationRequest): Promise<TopNAggregationSchema>;
+  updateTopNAggregation(group: string, name: string, req: UpdateTopNAggregationRequest): Promise<TopNAggregationSchema>;
+  deleteTopNAggregation(group: string, name: string): Promise<void>;
 
   // Stream CRUD
   createStream(req: CreateStreamRequest): Promise<StreamSchema>;

--- a/canopy/web/src/data/api.ts
+++ b/canopy/web/src/data/api.ts
@@ -26,6 +26,7 @@ import type {
   CreateIndexRuleRequest, UpdateIndexRuleRequest, IndexRuleSchema,
   CreateIndexRuleBindingRequest, UpdateIndexRuleBindingRequest, IndexRuleBindingSchema,
   PropertySchema, TopNAggregationSchema,
+  CreateTopNAggregationRequest, UpdateTopNAggregationRequest,
   QueryRequest, QueryResponse, TopNQueryResponse,
   CreatePropertySchemaRequest, PropertyApplyRequest, PropertyApplyResponse,
   PropertyQueryRequest, PropertyQueryResponse, PropertyDocument, PropertyDocTag,
@@ -201,6 +202,35 @@ export class ApiDataSource implements DataSource {
     return (data.topNAggregation ?? [])
       .slice()
       .sort((a, b) => a.metadata.name.localeCompare(b.metadata.name));
+  }
+
+  async getTopNAggregation(group: string, name: string): Promise<TopNAggregationSchema> {
+    const data = await apiFetch<{ topNAggregation: TopNAggregationSchema }>(
+      `/api/v1/topn-agg/schema/${encodeURIComponent(group)}/${encodeURIComponent(name)}`,
+    );
+    return data.topNAggregation;
+  }
+
+  async createTopNAggregation(req: CreateTopNAggregationRequest): Promise<TopNAggregationSchema> {
+    // TopNAggregationRegistryService.Create returns only {modRevision} (see
+    // rpc.proto) — same write-response shape as IndexRuleBinding/Property.
+    // Echo the request payload back rather than decoding a missing body.
+    await apiFetch<{ modRevision?: string }>('/api/v1/topn-agg/schema', {
+      method: 'POST', headers: JSON_HEADERS, body: JSON.stringify(req),
+    });
+    return req.topNAggregation as unknown as TopNAggregationSchema;
+  }
+
+  async updateTopNAggregation(group: string, name: string, req: UpdateTopNAggregationRequest): Promise<TopNAggregationSchema> {
+    await apiFetch<{ modRevision?: string }>(
+      `/api/v1/topn-agg/schema/${encodeURIComponent(group)}/${encodeURIComponent(name)}`,
+      { method: 'PUT', headers: JSON_HEADERS, body: JSON.stringify(req) },
+    );
+    return req.topNAggregation;
+  }
+
+  async deleteTopNAggregation(group: string, name: string): Promise<void> {
+    await apiFetch<void>(`/api/v1/topn-agg/schema/${encodeURIComponent(group)}/${encodeURIComponent(name)}`, { method: 'DELETE' });
   }
 
   // ── Stream CRUD ──────────────────────────────────────────────────────────

--- a/canopy/web/src/pages/PipelinesPage.tsx
+++ b/canopy/web/src/pages/PipelinesPage.tsx
@@ -30,7 +30,7 @@
 // the handoff's comment describes, without changing this file's structure.
 
 import React, { useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useQuery } from '@tanstack/react-query';
 
 import type { TopNAggregationSchema } from 'canopy-shared';

--- a/canopy/web/src/pages/PipelinesPage.tsx
+++ b/canopy/web/src/pages/PipelinesPage.tsx
@@ -1,0 +1,193 @@
+/*
+ * Licensed to Apache Software Foundation (ASF) under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Apache Software Foundation (ASF) licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// PipelinesPage.tsx — the generic Pipelines section overview (/pipelines).
+// Ported from .handoff-import/banyandb/project/pipelines.jsx (window-global
+// JSX -> ES module TSX).
+//
+// The handoff drives the overview off a `PIPELINE_TYPES` registry so adding a
+// future pipeline type (e.g. tail-sampling) means appending one entry rather
+// than touching this page. v1 has exactly one type — TopN — so this port
+// keeps that registry shape (see PIPELINE_TYPES below) but resolves it
+// directly against the live registry (listGroups + listTopNAggregations)
+// instead of a mock `groups` prop; a second type can plug in the same way
+// the handoff's comment describes, without changing this file's structure.
+
+import React, { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+
+import type { TopNAggregationSchema } from 'canopy-shared';
+import { apiDataSource } from '../data/api.js';
+import { IconPipelines, IconTopN, IconArrowRight, IconGroup } from '../components/icons.js';
+import { RankBadge } from '../pipelines/topn-shared.js';
+
+interface PipelineItem {
+  readonly name: string;
+  readonly group: string;
+  readonly path: string;
+  readonly meta: React.ReactNode;
+}
+
+// Registry entry contract (mirrors the handoff's PIPELINE_TYPES doc comment):
+// key/label/icon/noun(Plural)/desc describe the type; `items` is the flat
+// list of every pipeline instance of this type, already resolved live.
+interface PipelineTypeEntry {
+  readonly key: string;
+  readonly label: string;
+  readonly icon: React.ComponentType<{ size?: number }>;
+  readonly noun: string;
+  readonly nounPlural: string;
+  readonly desc: string;
+  readonly items: readonly PipelineItem[];
+}
+
+function useTopNPipelineType(): PipelineTypeEntry {
+  const { data: groupsData } = useQuery({ queryKey: ['groups'], queryFn: () => apiDataSource.listGroups() });
+  const measureGroupNames = useMemo(
+    () => (groupsData?.groups ?? []).filter((g) => g.catalog === 'CATALOG_MEASURE').map((g) => g.name),
+    [groupsData],
+  );
+
+  const [aggsByGroup, setAggsByGroup] = useState<ReadonlyMap<string, readonly TopNAggregationSchema[]>>(new Map());
+  useEffect(() => {
+    if (measureGroupNames.length === 0) { setAggsByGroup(new Map()); return; }
+    let cancelled = false;
+    Promise.allSettled(
+      measureGroupNames.map((g) => apiDataSource.listTopNAggregations(g).then((aggs) => ({ group: g, aggs }))),
+    ).then((results) => {
+      if (cancelled) return;
+      const next = new Map<string, readonly TopNAggregationSchema[]>();
+      for (const r of results) if (r.status === 'fulfilled') next.set(r.value.group, r.value.aggs);
+      setAggsByGroup(next);
+    });
+    return () => { cancelled = true; };
+  }, [measureGroupNames]);
+
+  const items = useMemo<PipelineItem[]>(() => {
+    const out: PipelineItem[] = [];
+    for (const [group, aggs] of aggsByGroup) {
+      for (const a of aggs) {
+        out.push({
+          name: a.metadata.name,
+          group,
+          path: `/pipelines/topn/${group}/${a.metadata.name}`,
+          meta: <RankBadge sort={a.fieldValueSort} />,
+        });
+      }
+    }
+    return out;
+  }, [aggsByGroup]);
+
+  return {
+    key: 'topn',
+    label: 'TopN',
+    icon: IconTopN,
+    noun: 'aggregation',
+    nounPlural: 'aggregations',
+    desc: 'Maintains ranked counters over a measure field — Top N (largest), Bottom N (smallest), or both — optionally grouped by tags and filtered by criteria.',
+    items,
+  };
+}
+
+export function PipelinesPage() {
+  const navigate = useNavigate();
+  const topn = useTopNPipelineType();
+  const byType = useMemo(() => [topn], [topn]);
+
+  const all = useMemo(() => byType.flatMap((pt) => pt.items.map((it) => ({ pt, it }))), [byType]);
+  const total = all.length;
+  const groupsInUse = useMemo(() => new Set(all.map((x) => x.it.group)).size, [all]);
+  const featured = all.slice(0, 4);
+
+  return (
+    <div className="page-body">
+      <header className="page-head">
+        <h1 className="page-title">Pipelines</h1>
+        <p className="page-meta">Continuous processing that maintains derived results over stored data.</p>
+      </header>
+
+      <div className="pipe-intro">
+        <p className="pipe-lead">
+          Pipelines run continuously over stored data to maintain derived results — computed as data arrives,
+          so they are ready at query time instead of being computed on demand. Each pipeline type produces a
+          different kind of derived result.
+        </p>
+      </div>
+
+      <div className="pipe-stats">
+        <div className="pipe-stat">
+          <span className="pipe-stat-v">{total}</span>
+          <span className="pipe-stat-k">pipeline{total !== 1 ? 's' : ''}</span>
+        </div>
+        <div className="pipe-stat">
+          <span className="pipe-stat-v">{byType.length}</span>
+          <span className="pipe-stat-k">pipeline type{byType.length !== 1 ? 's' : ''}</span>
+        </div>
+        <div className="pipe-stat">
+          <span className="pipe-stat-v">{groupsInUse}</span>
+          <span className="pipe-stat-k">group{groupsInUse !== 1 ? 's' : ''} in use</span>
+        </div>
+      </div>
+
+      <div className="detail-h" style={{ marginTop: 4 }}><IconPipelines size={15} /> Pipeline types</div>
+      <div className="pipe-kinds">
+        {byType.map((pt) => {
+          const Icon = pt.icon;
+          return (
+            <button key={pt.key} className="pipe-kind" onClick={() => navigate(`/pipelines/${pt.key}`)}>
+              <span className="pipe-kind-ico"><Icon size={20} /></span>
+              <span className="pipe-kind-body">
+                <span className="pipe-kind-name">{pt.label}</span>
+                <span className="pipe-kind-desc">{pt.desc}</span>
+                <span className="pipe-kind-stat mono">{pt.items.length} {pt.items.length === 1 ? pt.noun : pt.nounPlural}</span>
+              </span>
+              <span className="pipe-kind-go"><IconArrowRight size={16} /></span>
+            </button>
+          );
+        })}
+      </div>
+
+      {featured.length > 0 && (
+        <>
+          <div className="detail-h" style={{ marginTop: 24 }}><IconPipelines size={15} /> Recent pipelines</div>
+          <div className="pipe-recent">
+            {featured.map(({ pt, it }) => {
+              const Icon = pt.icon;
+              return (
+                <button key={`${pt.key}/${it.group}/${it.name}`} className="pipe-recent-row" onClick={() => navigate(it.path)}>
+                  <span className="idx-ico"><Icon size={14} /></span>
+                  <span className="pipe-recent-name mono">{it.name}</span>
+                  <span className="topn-group-chip mono"><IconGroup size={11} /> {it.group}</span>
+                  {it.meta}
+                  <span className="pipe-recent-go"><IconArrowRight size={14} /></span>
+                </button>
+              );
+            })}
+            {byType.filter((pt) => pt.items.length > 0).map((pt) => (
+              <button key={pt.key} className="pipe-recent-all" onClick={() => navigate(`/pipelines/${pt.key}`)}>
+                View all {pt.label} {pt.nounPlural} <IconArrowRight size={14} />
+              </button>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/canopy/web/src/pipelines/TopNDetail.test.tsx
+++ b/canopy/web/src/pipelines/TopNDetail.test.tsx
@@ -1,0 +1,208 @@
+/*
+ * Licensed to Apache Software Foundation (ASF) under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Apache Software Foundation (ASF) licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Component tests for TopNDetail (/pipelines/topn/:group/:name) — rank/sort/
+// field/counters chips, source-measure card (existing vs. missing), criteria
+// chips, the not-found state, canWrite-gated Edit/Delete, and the
+// "Run Top-N query" deep-link into /query with the expected seed state.
+
+import React from 'react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import type { TopNAggregationSchema, MeasureSchema } from 'canopy-shared';
+import { FieldType, EncodingMethod, CompressMethod } from 'canopy-shared';
+import { apiDataSource } from '../data/api.js';
+import { useAuth } from '../auth/AuthContext.js';
+import { TopNDetail } from './TopNDetail.js';
+
+// topn-shared.tsx's flattenTopNCriteria (used by TopNDetail) reuses the real
+// data/api.js's decodePropertyTagValue codec — keep the actual implementation
+// via importOriginal rather than re-deriving its {str,int,...} unwrap logic
+// here, and only stub the two apiDataSource methods this page calls.
+vi.mock('../data/api.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../data/api.js')>();
+  return {
+    ...actual,
+    apiDataSource: {
+      getTopNAggregation: vi.fn(),
+      listResourcesInGroup: vi.fn(),
+    },
+  };
+});
+
+vi.mock('../auth/AuthContext.js', () => ({
+  useAuth: vi.fn(),
+}));
+
+const AGG: TopNAggregationSchema = {
+  metadata: { name: 'service_cpm_topn', group: 'sw_metric' },
+  sourceMeasure: { group: 'sw_metric', name: 'service_cpm_minute' },
+  fieldName: 'value',
+  fieldValueSort: 'SORT_DESC',
+  groupByTagNames: ['service', 'region'],
+  criteria: {
+    le: {
+      op: 'LOGICAL_OP_AND',
+      left: { condition: { name: 'service', op: 'BINARY_OP_EQ', value: { str: { value: 'checkout' } } } },
+      right: { condition: { name: 'status', op: 'BINARY_OP_GT', value: { int: { value: '200' } } } },
+    },
+  },
+  countersNumber: 1000,
+  lruSize: 10,
+};
+
+const MEASURE: MeasureSchema = {
+  metadata: { name: 'service_cpm_minute', group: 'sw_metric' },
+  tagFamilies: [],
+  fields: [{ name: 'value', fieldType: FieldType.INT, encodingMethod: EncodingMethod.GORILLA, compressionMethod: CompressMethod.ZSTD }],
+  entity: { tagNames: ['id'] },
+  interval: '1m',
+};
+
+function LocationProbe() {
+  const loc = useLocation();
+  return <div data-testid="location-state">{JSON.stringify(loc.state)}</div>;
+}
+
+function makeWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={qc}>
+        <MemoryRouter initialEntries={['/pipelines/topn/sw_metric/service_cpm_topn']}>
+          <Routes>
+            <Route path="/pipelines/topn/sw_metric/service_cpm_topn" element={children} />
+            <Route path="/pipelines/topn" element={<div>TOPN LIST ROUTE</div>} />
+            <Route path="/query" element={<LocationProbe />} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+  }
+  Wrapper.displayName = 'TestWrapper';
+  return Wrapper;
+}
+
+function mockAuth(role: 'admin' | 'readonly' | null) {
+  vi.mocked(useAuth).mockReturnValue({
+    session: role ? { user: 'u', role, banyanVersion: null } : null,
+    loading: false,
+    setSession: vi.fn(),
+  });
+}
+
+// Loads and settles on the detail page's h1 (unique — the breadcrumb repeats
+// the same name as a plain <span>, not a heading), used as the "ready" signal
+// before scoping into a specific chip/chip-row block.
+async function findLoaded(name = 'service_cpm_topn') {
+  return screen.findByRole('heading', { level: 1, name });
+}
+
+describe('TopNDetail', () => {
+  beforeEach(() => {
+    vi.mocked(apiDataSource.getTopNAggregation).mockResolvedValue(AGG);
+    vi.mocked(apiDataSource.listResourcesInGroup).mockResolvedValue([MEASURE] as never);
+    mockAuth('admin');
+  });
+
+  it('renders rank/sort/field/counters chips', async () => {
+    render(<TopNDetail groupName="sw_metric" aggName="service_cpm_topn" />, { wrapper: makeWrapper() });
+    await findLoaded();
+    // Scope to the top meta-chip row — "SORT_DESC"/"1000"/"value" are each
+    // repeated verbatim further down in the Ranking/Source-measure blocks.
+    const meta = within(screen.getByRole('region', { name: 'TopN aggregation summary' }));
+    expect(meta.getByText('topN')).toBeInTheDocument();
+    expect(meta.getByText('SORT_DESC')).toBeInTheDocument();
+    expect(meta.getByText('value')).toBeInTheDocument();
+    expect(meta.getByText('1000')).toBeInTheDocument();
+    expect(meta.getByText('10')).toBeInTheDocument();
+  });
+
+  it('renders the group-by tags in order', async () => {
+    render(<TopNDetail groupName="sw_metric" aggName="service_cpm_topn" />, { wrapper: makeWrapper() });
+    await findLoaded();
+    // "service" also appears as a criteria condition's tag further down —
+    // scope to the Group-by-tags block specifically.
+    const block = screen.getByText('Group by tags').closest('.detail-block') as HTMLElement;
+    expect(within(block).getByText('service')).toBeInTheDocument();
+    expect(within(block).getByText('region')).toBeInTheDocument();
+  });
+
+  it('renders the criteria as AND-joined condition chips', async () => {
+    render(<TopNDetail groupName="sw_metric" aggName="service_cpm_topn" />, { wrapper: makeWrapper() });
+    await findLoaded();
+    const block = screen.getByText('Criteria').closest('.detail-block') as HTMLElement;
+    expect(within(block).getByText('service')).toBeInTheDocument();
+    expect(within(block).getByText('checkout')).toBeInTheDocument();
+    expect(within(block).getByText('AND')).toBeInTheDocument();
+    expect(within(block).getByText('status')).toBeInTheDocument();
+    expect(within(block).getByText('200')).toBeInTheDocument();
+  });
+
+  it('renders the "no criteria" note when criteria is absent', async () => {
+    vi.mocked(apiDataSource.getTopNAggregation).mockResolvedValue({ ...AGG, criteria: undefined });
+    render(<TopNDetail groupName="sw_metric" aggName="service_cpm_topn" />, { wrapper: makeWrapper() });
+    expect(await screen.findByText(/No criteria/)).toBeInTheDocument();
+  });
+
+  it('links the source measure card when the source measure exists', async () => {
+    render(<TopNDetail groupName="sw_metric" aggName="service_cpm_topn" />, { wrapper: makeWrapper() });
+    const link = await screen.findByTitle('Open sw_metric/service_cpm_minute');
+    expect(link.tagName).toBe('BUTTON');
+  });
+
+  it('flags a missing source measure instead of a link', async () => {
+    vi.mocked(apiDataSource.listResourcesInGroup).mockResolvedValue([]);
+    render(<TopNDetail groupName="sw_metric" aggName="service_cpm_topn" />, { wrapper: makeWrapper() });
+    expect(await screen.findByText(/measure no longer exists/)).toBeInTheDocument();
+  });
+
+  it('renders the not-found state for a missing aggregation', async () => {
+    vi.mocked(apiDataSource.getTopNAggregation).mockRejectedValue(new Error('404'));
+    render(<TopNDetail groupName="sw_metric" aggName="ghost" />, { wrapper: makeWrapper() });
+    expect(await screen.findByText('Aggregation not found')).toBeInTheDocument();
+  });
+
+  it('hides Edit/Delete for a readonly session', async () => {
+    mockAuth('readonly');
+    render(<TopNDetail groupName="sw_metric" aggName="service_cpm_topn" />, { wrapper: makeWrapper() });
+    await findLoaded();
+    expect(screen.queryByRole('button', { name: 'Edit' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Delete' })).not.toBeInTheDocument();
+  });
+
+  it('shows Edit/Delete for an admin session', async () => {
+    render(<TopNDetail groupName="sw_metric" aggName="service_cpm_topn" />, { wrapper: makeWrapper() });
+    await findLoaded();
+    expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+  });
+
+  it('"Run Top-N query" deep-links into /query with the topn seed state', async () => {
+    render(<TopNDetail groupName="sw_metric" aggName="service_cpm_topn" />, { wrapper: makeWrapper() });
+    const runBtn = await screen.findByRole('button', { name: /Run Top-N query/i });
+    fireEvent.click(runBtn);
+    const probe = await screen.findByTestId('location-state');
+    expect(JSON.parse(probe.textContent!)).toEqual({
+      seed: { catalog: 'topn', group: 'sw_metric', resource: 'service_cpm_topn' },
+    });
+  });
+});

--- a/canopy/web/src/pipelines/TopNDetail.test.tsx
+++ b/canopy/web/src/pipelines/TopNDetail.test.tsx
@@ -24,7 +24,7 @@
 
 import React from 'react';
 import { render, screen, fireEvent, within } from '@testing-library/react';
-import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import type { TopNAggregationSchema, MeasureSchema } from 'canopy-shared';

--- a/canopy/web/src/pipelines/TopNDetail.tsx
+++ b/canopy/web/src/pipelines/TopNDetail.tsx
@@ -1,0 +1,230 @@
+/*
+ * Licensed to Apache Software Foundation (ASF) under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Apache Software Foundation (ASF) licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// TopNDetail.tsx — the TopN pipeline type's detail page
+// (/pipelines/topn/:group/:name). Ported from
+// .handoff-import/banyandb/project/topn-page.jsx's TopNDetail.
+//
+// ADAPTATIONS: mock `groups` lookup -> getTopNAggregation + a live
+// listResourcesInGroup('measures', ...) existence check for the source
+// measure; onNavigate -> useNavigate; "Run Top-N query" reuses the EXISTING
+// GroupPage "Query this resource" deep-link seed
+// (navigate('/query', { state: { seed: { catalog: 'topn', group, resource } } }))
+// — QueryConsole.tsx already dispatches TopN queries to /v1/measure/topn, so
+// there is no new query path here (docs/pipelines-design.md §4). Edit/Delete
+// modals are owned locally, mirroring PropertyDetailPage.tsx.
+
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+
+import type { MeasureSchema } from 'canopy-shared';
+import { apiDataSource } from '../data/api.js';
+import { useAuth } from '../auth/AuthContext.js';
+import {
+  IconTopN, IconEmpty, IconMeasures, IconSort, IconKey, IconFilter,
+  IconPlay, IconArrowLeft, IconArrowRight, IconEdit, IconTrash, IconAlert,
+} from '../components/icons.js';
+import { CondChip, topNRank, topNSortLabel, flattenTopNCriteria, DEFAULT_COUNTERS } from './topn-shared.js';
+import { TopNFormModal, DeleteTopNModal } from './TopNForms.js';
+
+type ModalState = { readonly kind: 'edit' } | { readonly kind: 'delete' } | null;
+
+export function TopNDetail({ groupName, aggName }: { readonly groupName: string; readonly aggName: string }) {
+  const navigate = useNavigate();
+  const { session } = useAuth();
+  const canWrite = session?.role === 'admin';
+  const [modal, setModal] = useState<ModalState>(null);
+
+  const { data: agg, isLoading, isError } = useQuery({
+    queryKey: ['topNAggregation', groupName, aggName],
+    queryFn: () => apiDataSource.getTopNAggregation(groupName, aggName),
+  });
+
+  const src = agg?.sourceMeasure;
+  const { data: sourceMeasures = [] } = useQuery({
+    queryKey: ['resources', 'measures', src?.group ?? ''],
+    queryFn: () => apiDataSource.listResourcesInGroup('measures', src!.group),
+    enabled: !!src?.group,
+  });
+  const srcMeasure = sourceMeasures.find((m) => m.metadata.name === src?.name) as MeasureSchema | undefined;
+  const srcExists = !!srcMeasure;
+  const srcFieldNames = srcMeasure?.fields.map((f) => f.name) ?? [];
+
+  if (isLoading) {
+    return (
+      <div className="page-body">
+        <div className="empty">
+          <span className="empty-ico spin"><IconTopN size={32} /></span>
+          <div className="empty-title">Loading…</div>
+        </div>
+      </div>
+    );
+  }
+
+  if (isError || !agg) {
+    return (
+      <div className="page-body">
+        <header className="page-head">
+          <div className="crumbs">
+            <button className="crumb crumb-link" onClick={() => navigate('/pipelines')}>Pipelines</button>
+            <span className="crumb-sep">/</span>
+            <button className="crumb crumb-link" onClick={() => navigate('/pipelines/topn')}>TopN</button>
+            <span className="crumb-sep">/</span>
+            <span className="crumb is-last">{aggName}</span>
+          </div>
+          <h1 className="page-title">{aggName}</h1>
+        </header>
+        <div className="empty">
+          <span className="empty-ico"><IconEmpty size={36} /></span>
+          <div className="empty-title">Aggregation not found</div>
+          <p className="empty-text">No TopNAggregation named {aggName} exists in {groupName}.</p>
+        </div>
+      </div>
+    );
+  }
+
+  const counters = agg.countersNumber || DEFAULT_COUNTERS;
+  const conditions = flattenTopNCriteria(agg.criteria);
+  const openSource = () => srcExists && navigate(`/metadata/measures/${src!.group}/${src!.name}`);
+
+  // Deep-link into the Query console, pre-filled to query this aggregation.
+  // The seed shape/route mirror GroupPage.tsx's "Query this resource" action
+  // exactly (state.seed.{catalog,group,resource}); QueryConsole resolves a
+  // 'topn' catalog seed against the topn-agg registry for `group`, so the
+  // group here is the AGGREGATION's own group (== its source measure's
+  // group), not necessarily anything else.
+  const runQuery = () => navigate('/query', { state: { seed: { catalog: 'topn', group: groupName, resource: aggName } } });
+
+  return (
+    <div className="page-body">
+      <header className="page-head">
+        <div className="crumbs">
+          <button className="crumb crumb-link" onClick={() => navigate('/pipelines')}>Pipelines</button>
+          <span className="crumb-sep">/</span>
+          <button className="crumb crumb-link" onClick={() => navigate('/pipelines/topn')}>TopN</button>
+          <span className="crumb-sep">/</span>
+          <span className="crumb is-last">{aggName}</span>
+        </div>
+        <div className="page-title-row">
+          <h1 className="page-title">{aggName}</h1>
+          <div className="page-actions">
+            {srcExists && (
+              <button className="btn btn-primary" onClick={runQuery} title="Open the Query console pre-filled to rank this measure">
+                <IconPlay size={15} /> Run Top-N query
+              </button>
+            )}
+            <button className="btn btn-ghost" onClick={() => navigate('/pipelines/topn')}>
+              <IconArrowLeft size={15} /> Back
+            </button>
+            {canWrite && (
+              <button className="btn btn-ghost" onClick={() => setModal({ kind: 'edit' })}><IconEdit size={15} /> Edit</button>
+            )}
+            {canWrite && (
+              <button className="btn btn-danger-ghost" onClick={() => setModal({ kind: 'delete' })}><IconTrash size={15} /> Delete</button>
+            )}
+          </div>
+        </div>
+        <p className="page-meta">TopNAggregation in measure group {groupName}.</p>
+      </header>
+
+      <div className="grp-meta" role="region" aria-label="TopN aggregation summary">
+        <div className="meta-chip"><span className="meta-k">rank</span><span className="meta-v">{topNRank(agg.fieldValueSort)}</span></div>
+        <div className="meta-chip"><span className="meta-k">sort</span><span className="meta-v">{topNSortLabel(agg.fieldValueSort)}</span></div>
+        <div className="meta-chip"><span className="meta-k">field</span><span className="meta-v">{agg.fieldName}</span></div>
+        <div className="meta-chip"><span className="meta-k">counters</span><span className="meta-v">{counters}</span></div>
+        {agg.lruSize != null && (
+          <div className="meta-chip"><span className="meta-k">lru size</span><span className="meta-v">{agg.lruSize}</span></div>
+        )}
+      </div>
+
+      <div className="detail-block">
+        <div className="detail-h"><IconMeasures size={15} /> Source measure</div>
+        <div className="topn-source-card">
+          {srcExists ? (
+            <button className="topn-source-link" onClick={openSource} title={`Open ${src!.group}/${src!.name}`}>
+              <span className="topn-source-key mono">{src!.group}/</span>
+              <span className="topn-source-name mono">{src!.name}</span>
+              <IconArrowRight size={14} />
+            </button>
+          ) : (
+            <span className="topn-source-missing">
+              <IconAlert size={14} />
+              <span className="mono">{src?.group}/{src?.name}</span> — measure no longer exists
+            </span>
+          )}
+          <span className="topn-source-field">
+            ranks field <span className="mono">{agg.fieldName}</span>
+            {srcExists && !srcFieldNames.includes(agg.fieldName ?? '') && (
+              <span className="topn-warn-inline"><IconAlert size={12} /> not a field of the source</span>
+            )}
+          </span>
+        </div>
+      </div>
+
+      <div className="detail-block">
+        <div className="detail-h"><IconSort size={15} /> Ranking</div>
+        <div className="chip-row">
+          <span className={'topn-rank-lg is-' + (agg.fieldValueSort === 'SORT_ASC' ? 'bottomn' : agg.fieldValueSort === 'SORT_UNSPECIFIED' ? 'bothn' : 'topn')}>
+            <IconTopN size={14} /> {topNRank(agg.fieldValueSort)}
+          </span>
+          <span className="ord-chip"><span className="topn-k">field_value_sort</span>{topNSortLabel(agg.fieldValueSort)}</span>
+          <span className="ord-chip"><span className="topn-k">counters_number</span>{counters}</span>
+        </div>
+      </div>
+
+      <div className="detail-block" role="region" aria-label="Group by tags">
+        <div className="detail-h"><IconKey size={15} /> Group by tags</div>
+        <div className="chip-row">
+          {(agg.groupByTagNames ?? []).map((n, i) => (
+            <span key={n} className="ord-chip"><span className="picker-ord">{i + 1}</span>{n}</span>
+          ))}
+          {!(agg.groupByTagNames ?? []).length && <span className="dim">no grouping — single global ranking</span>}
+        </div>
+      </div>
+
+      <div className="detail-block">
+        <div className="detail-h"><IconFilter size={15} /> Criteria</div>
+        {conditions.length ? (
+          <div className="topn-cond-row">
+            {conditions.map((c, i) => (
+              <React.Fragment key={i}>
+                {i > 0 && <span className="topn-and">AND</span>}
+                <CondChip tag={c.tag} op={c.op} value={c.value} />
+              </React.Fragment>
+            ))}
+          </div>
+        ) : (
+          <div className="prop-note">
+            <IconFilter size={15} />
+            <span>No criteria — every data point in <span className="mono">{src?.name}</span> is aggregated.</span>
+          </div>
+        )}
+      </div>
+
+      {modal?.kind === 'edit' && (
+        <TopNFormModal mode="edit" groupName={groupName} aggregation={agg} onClose={() => setModal(null)} />
+      )}
+      {modal?.kind === 'delete' && (
+        <DeleteTopNModal groupName={groupName} aggregation={agg} onClose={() => setModal(null)}
+          onDeleted={() => navigate('/pipelines/topn')} />
+      )}
+    </div>
+  );
+}

--- a/canopy/web/src/pipelines/TopNDetail.tsx
+++ b/canopy/web/src/pipelines/TopNDetail.tsx
@@ -31,7 +31,7 @@
 // modals are owned locally, mirroring PropertyDetailPage.tsx.
 
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useQuery } from '@tanstack/react-query';
 
 import type { MeasureSchema } from 'canopy-shared';

--- a/canopy/web/src/pipelines/TopNForms.tsx
+++ b/canopy/web/src/pipelines/TopNForms.tsx
@@ -1,0 +1,582 @@
+/*
+ * Licensed to Apache Software Foundation (ASF) under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Apache Software Foundation (ASF) licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// TopNForms.tsx — TopNAggregation CRUD: create/edit modal + delete confirm.
+// Ported from .handoff-import/banyandb/project/topn-form.jsx (window-global
+// JSX -> ES module TSX). Validation mirrors schema.proto TopNAggregation
+// (metadata, source_measure, field_name min_len 1, field_value_sort,
+// group_by_tag_names, criteria, counters_number, lru_size).
+//
+// ADAPTATIONS FROM THE HANDOFF:
+//  - Mock `groups` prop -> live queries: listGroups (source group options),
+//    listResourcesInGroup('measures', ...) (source measure options),
+//    getResource (source measure's fields/tags), listTopNAggregations
+//    (per-group existing names, for the create-time uniqueness check).
+//  - The handoff's bespoke TopNSelect/TopNChipPicker are replaced by canopy's
+//    existing Combobox/MultiCombobox (Combobox.tsx) for the group/measure/
+//    field/group-by pickers — same fuzzy-filter UX already used by
+//    IndexRuleBindingForm, without introducing a second select widget.
+//  - CriteriaEditor's tag(name)/op/value rows build/parse the real
+//    model.v1.Criteria tree via topn-shared.ts's buildTopNCriteria /
+//    flattenTopNCriteria instead of carrying a flat array over the wire.
+//  - onSubmit -> createTopNAggregation / updateTopNAggregation; reuses
+//    useFocusTrap/useDirtyGuard from components/modal-utils.ts, matching
+//    every other *Form.tsx in this app (there is no shared exported
+//    Field/Modal component to reuse — each form locally duplicates the
+//    modal-overlay/modal markup, per GroupForm.tsx/PropertyForms.tsx).
+
+import React, { useEffect, useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import type {
+  MeasureSchema, TopNAggregationSchema,
+  CreateTopNAggregationRequest, UpdateTopNAggregationRequest,
+} from 'canopy-shared';
+import { apiDataSource } from '../data/api.js';
+import { useFocusTrap, useDirtyGuard } from '../components/modal-utils.js';
+import { Combobox, MultiCombobox } from '../components/Combobox.js';
+import { IconChevron, IconPlus, IconCheck } from '../components/icons.js';
+import {
+  SORT_OPTS, TOPN_OPS, DEFAULT_COUNTERS, topNTone, topNRank,
+  buildTopNCriteria, flattenTopNCriteria, type TopNCondition,
+} from './topn-shared.js';
+
+const TOPN_NAME_RE = /^[a-zA-Z0-9_-]+$/;
+
+const IconClose = (p: React.SVGProps<SVGSVGElement>) => (
+  <svg {...p} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M6 6l12 12M18 6 6 18" />
+  </svg>
+);
+
+// Mirrors the Field wrapper every *Form.tsx in this app duplicates locally.
+function Field({ label, hint, error, required, locked, children }: {
+  label: React.ReactNode;
+  hint?: string;
+  error?: string;
+  required?: boolean;
+  locked?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className={`f-field${error ? ' has-error' : ''}`}>
+      <label className="f-label">
+        {label}
+        {required && <span className="f-req">*</span>}
+        {locked && <span className="f-lock">read-only</span>}
+      </label>
+      {children}
+      {error ? <div className="f-error">{error}</div> : hint ? <div className="f-hint">{hint}</div> : null}
+    </div>
+  );
+}
+
+/* ============ criteria editor — flat ANDed {tag, op, value} rows ============ */
+
+function CriteriaEditor({ criteria, tagOptions, errors, onChange }: {
+  criteria: readonly TopNCondition[];
+  tagOptions: readonly string[];
+  errors?: ReadonlyArray<{ tag?: string; value?: string } | undefined>;
+  onChange: (v: TopNCondition[]) => void;
+}) {
+  const upd = (i: number, patch: Partial<TopNCondition>) =>
+    onChange(criteria.map((c, idx) => (idx === i ? { ...c, ...patch } : c)));
+  const del = (i: number) => onChange(criteria.filter((_, idx) => idx !== i));
+  const add = () => onChange([...criteria, { tag: tagOptions[0] ?? '', op: 'BINARY_OP_EQ', value: '' }]);
+
+  return (
+    <div className="spec-list">
+      {criteria.map((c, i) => {
+        const er = errors?.[i] ?? {};
+        return (
+          <div key={i} className="kv-row">
+            <div className={'spec-cell' + (er.tag ? ' has-error' : '')}>
+              <Combobox
+                value={c.tag}
+                options={tagOptions}
+                onChange={(val) => upd(i, { tag: val })}
+                placeholder="— tag —"
+                noOptionsHint="Source measure has no tags"
+                ariaLabel={`Criteria tag ${i + 1}`}
+              />
+              {er.tag && <div className="f-error">{er.tag}</div>}
+            </div>
+            <div className="spec-cell type">
+              <div className="f-select-wrap">
+                <select className="f-input f-select mono" aria-label={`Criteria operator ${i + 1}`} value={c.op}
+                  onChange={(e) => upd(i, { op: e.target.value })}>
+                  {TOPN_OPS.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
+                </select>
+                <span className="f-select-chev"><IconChevron size={13} /></span>
+              </div>
+            </div>
+            <div className={'spec-cell grow' + (er.value ? ' has-error' : '')}>
+              <input className="f-input mono" value={c.value} placeholder="value" aria-label={`Criteria value ${i + 1}`}
+                onChange={(e) => upd(i, { value: e.target.value })} />
+              {er.value && <div className="f-error">{er.value}</div>}
+            </div>
+            <button type="button" className="spec-del" onClick={() => del(i)} aria-label={`Remove condition ${i + 1}`}>
+              <IconClose width={14} height={14} />
+            </button>
+          </div>
+        );
+      })}
+      <button type="button" className="spec-add" onClick={add}><IconPlus size={14} /> Add condition</button>
+    </div>
+  );
+}
+
+/* ============ validation ============ */
+
+export interface TopNDraft {
+  readonly name: string;
+  readonly sourceGroup: string;
+  readonly sourceName: string;
+  readonly fieldName: string;
+  readonly fieldValueSort: 'SORT_DESC' | 'SORT_ASC' | 'SORT_UNSPECIFIED';
+  readonly groupByTagNames: readonly string[];
+  readonly criteria: readonly TopNCondition[];
+  readonly countersNumber: number | '';
+  readonly lruSize: number | '';
+}
+
+export interface TopNValidationErrors {
+  _?: string;
+  name?: string;
+  sourceGroup?: string;
+  sourceMeasure?: string;
+  fieldName?: string;
+  countersNumber?: string;
+  lruSize?: string;
+  criteria?: ReadonlyArray<{ tag?: string; value?: string } | undefined>;
+}
+
+export interface TopNValidationCtx {
+  readonly mode: 'create' | 'edit';
+  readonly existingNames?: ReadonlySet<string>;
+  readonly fieldOptions?: readonly string[];
+}
+
+/** Pure validation — advisory only; the registry is authoritative (mirrors
+ *  web/src/validation.ts's Principle 5 for the M3 forms). */
+export function validateTopN(v: TopNDraft, ctx: TopNValidationCtx): TopNValidationErrors {
+  const e: TopNValidationErrors = {};
+  if (ctx.mode === 'create') {
+    const name = v.name.trim();
+    if (!name) e.name = 'Name is required';
+    else if (name.length > 255) e.name = 'Must be 255 characters or fewer';
+    else if (!TOPN_NAME_RE.test(name)) e.name = "Only letters, digits, '_' and '-' are allowed";
+    else if (ctx.existingNames?.has(name.toLowerCase())) e.name = `An aggregation named "${name}" already exists in this group`;
+  }
+
+  if (!v.sourceGroup) e.sourceGroup = 'Select a source group';
+  if (!v.sourceName) e.sourceMeasure = 'Select a source measure';
+
+  const fieldName = v.fieldName.trim();
+  if (!fieldName) e.fieldName = 'Required';
+  else if (ctx.fieldOptions && ctx.fieldOptions.length > 0 && !ctx.fieldOptions.includes(fieldName)) {
+    e.fieldName = 'Must be a field of the source measure';
+  }
+
+  if (v.countersNumber !== '') {
+    const n = Number(v.countersNumber);
+    if (!Number.isInteger(n) || n <= 0) e.countersNumber = 'Must be a whole number greater than 0';
+  }
+  if (v.lruSize !== '') {
+    const n = Number(v.lruSize);
+    if (!Number.isInteger(n) || n < 0) e.lruSize = 'Must be 0 or a positive whole number';
+  }
+
+  const condErrs: Array<{ tag?: string; value?: string } | undefined> = [];
+  v.criteria.forEach((c, i) => {
+    const ce: { tag?: string; value?: string } = {};
+    if (!c.tag.trim()) ce.tag = 'Required';
+    if (!c.value.trim()) ce.value = 'Required';
+    if (Object.keys(ce).length) condErrs[i] = ce;
+  });
+  if (condErrs.length) e.criteria = condErrs;
+
+  return e;
+}
+
+function topNHasErrors(e: TopNValidationErrors): boolean {
+  return (Object.keys(e) as Array<keyof TopNValidationErrors>).some((k) => {
+    const val = e[k];
+    if (Array.isArray(val)) return val.some((x) => x && Object.keys(x).length > 0);
+    return !!val;
+  });
+}
+
+function blankTopN(sourceGroup: string): TopNDraft {
+  return {
+    name: '',
+    sourceGroup,
+    sourceName: '',
+    fieldName: '',
+    fieldValueSort: 'SORT_DESC',
+    groupByTagNames: [],
+    criteria: [],
+    countersNumber: DEFAULT_COUNTERS,
+    lruSize: 10,
+  };
+}
+
+function draftFromSchema(agg: TopNAggregationSchema): TopNDraft {
+  return {
+    name: agg.metadata.name,
+    sourceGroup: agg.sourceMeasure?.group ?? agg.metadata.group,
+    sourceName: agg.sourceMeasure?.name ?? '',
+    fieldName: agg.fieldName ?? '',
+    fieldValueSort: agg.fieldValueSort ?? 'SORT_DESC',
+    groupByTagNames: agg.groupByTagNames ?? [],
+    criteria: flattenTopNCriteria(agg.criteria),
+    countersNumber: agg.countersNumber ?? DEFAULT_COUNTERS,
+    lruSize: agg.lruSize ?? '',
+  };
+}
+
+/* ============ create / edit modal ============ */
+
+export interface TopNFormModalProps {
+  readonly mode: 'create' | 'edit';
+  /** Locks the target measure group. Required for edit; optional for create
+   *  (when omitted the user picks a measure group in the Identity section —
+   *  mirrors the handoff's "New aggregation" from the all-groups TopN list). */
+  readonly groupName?: string;
+  readonly aggregation?: TopNAggregationSchema;
+  readonly onClose: (created?: TopNAggregationSchema) => void;
+}
+
+export function TopNFormModal({ mode, groupName, aggregation, onClose }: TopNFormModalProps) {
+  const qc = useQueryClient();
+  const isEdit = mode === 'edit';
+  const fixedGroup = isEdit ? (aggregation?.metadata.group ?? groupName ?? null) : (groupName ?? null);
+
+  const { data: groupsData } = useQuery({ queryKey: ['groups'], queryFn: () => apiDataSource.listGroups() });
+  const measureGroupNames = useMemo(
+    () => (groupsData?.groups ?? []).filter((g) => g.catalog === 'CATALOG_MEASURE').map((g) => g.name).sort(),
+    [groupsData],
+  );
+
+  const [targetGroup, setTargetGroup] = useState(fixedGroup ?? '');
+  useEffect(() => {
+    if (!fixedGroup && !targetGroup && measureGroupNames.length > 0) setTargetGroup(measureGroupNames[0]);
+  }, [fixedGroup, targetGroup, measureGroupNames]);
+
+  const init = useMemo<TopNDraft>(
+    () => (isEdit && aggregation ? draftFromSchema(aggregation) : blankTopN(fixedGroup ?? '')),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- snapshot on mount only
+    [],
+  );
+  const [v, setV] = useState<TopNDraft>(init);
+  const set = (patch: Partial<TopNDraft>) => setV((c) => ({ ...c, ...patch }));
+
+  // Existing aggregation names in the target group, for the create-time
+  // uniqueness check (the registry itself is authoritative either way).
+  const { data: existingAggs = [] } = useQuery({
+    queryKey: ['topNAggregations', targetGroup],
+    queryFn: () => apiDataSource.listTopNAggregations(targetGroup),
+    enabled: !!targetGroup,
+  });
+  const existingNames = useMemo(
+    () => new Set(
+      existingAggs
+        .filter((a) => !isEdit || a.metadata.name !== aggregation?.metadata.name)
+        .map((a) => a.metadata.name.toLowerCase()),
+    ),
+    [existingAggs, isEdit, aggregation],
+  );
+
+  const { data: sourceMeasures = [] } = useQuery({
+    queryKey: ['resources', 'measures', v.sourceGroup],
+    queryFn: () => apiDataSource.listResourcesInGroup('measures', v.sourceGroup),
+    enabled: !!v.sourceGroup,
+  });
+  const measureOptions = useMemo(() => sourceMeasures.map((m) => m.metadata.name).sort(), [sourceMeasures]);
+
+  const { data: srcMeasure } = useQuery({
+    queryKey: ['resource', 'measures', v.sourceGroup, v.sourceName],
+    queryFn: () => apiDataSource.getResource('measures', v.sourceGroup, v.sourceName) as Promise<MeasureSchema>,
+    enabled: !!v.sourceGroup && !!v.sourceName,
+  });
+  const fieldOptions = useMemo(() => srcMeasure?.fields.map((f) => f.name) ?? [], [srcMeasure]);
+  const tagOptions = useMemo(
+    () => srcMeasure?.tagFamilies.flatMap((f) => f.tags.map((t) => t.name)) ?? [],
+    [srcMeasure],
+  );
+
+  // When the source measure changes, drop a field/group-by selection that no
+  // longer applies to the new measure.
+  const changeSourceMeasure = (name: string) => {
+    set({ sourceName: name, fieldName: '', groupByTagNames: [] });
+  };
+  const changeSourceGroup = (group: string) => {
+    set({ sourceGroup: group, sourceName: '', fieldName: '', groupByTagNames: [] });
+  };
+
+  const [errors, setErrors] = useState<TopNValidationErrors>({});
+  const [submitted, setSubmitted] = useState(false);
+  useEffect(() => {
+    if (submitted) setErrors(validateTopN(v, { mode, existingNames, fieldOptions }));
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- re-validate on relevant state, not on the ctx object identity
+  }, [v, submitted, existingNames, fieldOptions, mode]);
+
+  const dirty = useMemo(
+    () => JSON.stringify(v) !== JSON.stringify(init) || targetGroup !== (fixedGroup ?? init.sourceGroup),
+    [v, init, targetGroup, fixedGroup],
+  );
+  const { guardedClose, resetDirty } = useDirtyGuard(dirty, () => onClose());
+  const trapRef = useFocusTrap(true, guardedClose);
+
+  const createMut = useMutation({
+    mutationFn: (req: CreateTopNAggregationRequest) => apiDataSource.createTopNAggregation(req),
+    onSuccess: (agg) => {
+      void qc.invalidateQueries({ queryKey: ['topNAggregations'] });
+      resetDirty();
+      onClose(agg);
+    },
+    onError: (e: Error) => setErrors({ _: e.message }),
+  });
+  const updateMut = useMutation({
+    mutationFn: (req: UpdateTopNAggregationRequest) => apiDataSource.updateTopNAggregation(targetGroup, aggregation!.metadata.name, req),
+    onSuccess: (agg) => {
+      void qc.invalidateQueries({ queryKey: ['topNAggregations'] });
+      void qc.invalidateQueries({ queryKey: ['topNAggregation', targetGroup, aggregation?.metadata.name] });
+      resetDirty();
+      onClose(agg);
+    },
+    onError: (e: Error) => setErrors({ _: e.message }),
+  });
+  const isPending = createMut.isPending || updateMut.isPending;
+
+  const submit = () => {
+    const e = validateTopN(v, { mode, existingNames, fieldOptions });
+    setSubmitted(true);
+    setErrors(e);
+    if (topNHasErrors(e)) {
+      requestAnimationFrame(() => {
+        const first = document.querySelector<HTMLElement>('.modal .has-error .f-input, .modal .has-error input');
+        first?.focus();
+      });
+      return;
+    }
+    // Guard against zeroing group-by tags before the source measure's schema
+    // has finished loading (tagOptions starts empty until that query settles).
+    const validGroupBy = tagOptions.length > 0 ? v.groupByTagNames.filter((t) => tagOptions.includes(t)) : v.groupByTagNames;
+    const payload = {
+      metadata: { name: (isEdit ? aggregation!.metadata.name : v.name.trim()), group: targetGroup },
+      sourceMeasure: { group: v.sourceGroup, name: v.sourceName },
+      fieldName: v.fieldName.trim(),
+      fieldValueSort: v.fieldValueSort,
+      groupByTagNames: validGroupBy,
+      criteria: buildTopNCriteria(v.criteria),
+      countersNumber: v.countersNumber === '' ? DEFAULT_COUNTERS : Number(v.countersNumber),
+      lruSize: v.lruSize === '' ? undefined : Number(v.lruSize),
+    };
+    if (isEdit) updateMut.mutate({ topNAggregation: payload });
+    else createMut.mutate({ topNAggregation: payload });
+  };
+
+  return (
+    <div className="modal-overlay" onClick={guardedClose}>
+      <div className="modal is-wide" role="dialog" aria-modal="true"
+        aria-label={isEdit ? 'Edit TopN aggregation' : 'Create TopN aggregation'}
+        ref={trapRef} onClick={(e) => e.stopPropagation()}>
+        <div className="modal-head">
+          <div>
+            <span className="modal-title">{isEdit ? 'Edit TopN aggregation' : 'Create TopN aggregation'}</span>
+            <p className="modal-sub">
+              {isEdit
+                ? 'Name is immutable. Update the source, ranking and criteria below.'
+                : (fixedGroup ? `Define a TopNAggregation in measure group "${fixedGroup}".` : 'Define a TopNAggregation. Choose the measure group it belongs to below.')}
+            </p>
+          </div>
+          <button type="button" className="modal-x" onClick={guardedClose} aria-label="Close" />
+        </div>
+
+        <div className="modal-body">
+          <section className="f-section">
+            <div className="f-section-title">Identity</div>
+            <div className="f-grid">
+              <Field label="Name" required={!isEdit} locked={isEdit} error={errors.name}
+                hint={isEdit ? undefined : "Unique within the group · letters, digits, '_' and '-'"}>
+                <input className="f-input mono" value={isEdit ? aggregation!.metadata.name : v.name} disabled={isEdit} autoFocus={!isEdit}
+                  placeholder="service_cpm_minute_topn" onChange={(e) => set({ name: e.target.value })} />
+              </Field>
+              <Field label="Group" required={!fixedGroup} locked={!!fixedGroup}
+                hint={fixedGroup ? 'Aggregations are scoped to their measure group' : 'Measure group this aggregation is registered in'}>
+                {fixedGroup ? (
+                  <input className="f-input mono" value={fixedGroup} disabled />
+                ) : (
+                  <Combobox value={targetGroup} options={measureGroupNames} onChange={setTargetGroup}
+                    placeholder="— group —" ariaLabel="Group" noOptionsHint="No measure groups yet" />
+                )}
+              </Field>
+            </div>
+          </section>
+
+          <section className="f-section">
+            <div className="f-section-title">Source measure <span className="f-req">*</span></div>
+            <p className="f-section-desc">The measure whose data points this aggregation ranks, and the field used for ranking.</p>
+            <div className="f-grid">
+              <Field label="Source group" required error={errors.sourceGroup}>
+                <Combobox value={v.sourceGroup} options={measureGroupNames} onChange={changeSourceGroup}
+                  placeholder="— group —" ariaLabel="Source group" noOptionsHint="No measure groups yet" />
+              </Field>
+              <Field label="Source measure" required error={errors.sourceMeasure}>
+                {measureOptions.length === 0 ? (
+                  <div className="picker-empty">No measures in this group.</div>
+                ) : (
+                  <Combobox value={v.sourceName} options={measureOptions} onChange={changeSourceMeasure}
+                    placeholder="— measure —" ariaLabel="Source measure" noOptionsHint="No measures in this group" />
+                )}
+              </Field>
+              <Field label="Ranked field" required error={errors.fieldName}
+                hint={srcMeasure && fieldOptions.length === 0 ? 'Source measure has no fields' : 'field_name used for ranking'}>
+                {fieldOptions.length === 0 ? (
+                  <input className="f-input mono" value={v.fieldName} placeholder="field_name" onChange={(e) => set({ fieldName: e.target.value })} />
+                ) : (
+                  <Combobox value={v.fieldName} options={fieldOptions} onChange={(val) => set({ fieldName: val })}
+                    placeholder="— field —" ariaLabel="Ranked field" noOptionsHint="No fields" />
+                )}
+              </Field>
+            </div>
+          </section>
+
+          <section className="f-section">
+            <div className="f-section-title">Ranking direction</div>
+            <p className="f-section-desc">
+              <span className="mono">field_value_sort</span> — DESC ranks the largest values (topN), ASC the smallest (bottomN).
+            </p>
+            <div className="idx-type-choices">
+              {SORT_OPTS.map((s) => (
+                <button type="button" key={s.value}
+                  className={'idx-type-card' + (v.fieldValueSort === s.value ? ' is-on' : '')}
+                  onClick={() => set({ fieldValueSort: s.value })}>
+                  <span className="idx-type-card-h">
+                    <span className={'topn-rank is-' + topNTone(s.value)}>{topNRank(s.value)}</span>
+                    {v.fieldValueSort === s.value && <IconCheck size={15} />}
+                  </span>
+                  <span className="idx-type-card-hint"><span className="mono">{s.label}</span> · {s.hint}</span>
+                </button>
+              ))}
+            </div>
+            <div className="f-grid" style={{ marginTop: 16 }}>
+              <Field label="Counters number" error={errors.countersNumber} hint="Number of counters tracked · default 1000">
+                <input className="f-input mono" type="number" min={1} aria-label="Counters number" value={v.countersNumber}
+                  onChange={(e) => set({ countersNumber: e.target.value === '' ? '' : Number(e.target.value) })} />
+              </Field>
+              <Field label="LRU size" error={errors.lruSize} hint="In-memory entries retained · optional">
+                <input className="f-input mono" type="number" min={0} aria-label="LRU size" value={v.lruSize}
+                  onChange={(e) => set({ lruSize: e.target.value === '' ? '' : Number(e.target.value) })} />
+              </Field>
+            </div>
+          </section>
+
+          <section className="f-section">
+            <div className="f-section-title">Group by tags <span className="f-optional">optional</span></div>
+            <p className="f-section-desc">Data points are grouped into separate ranked counters per distinct combination of these tags.</p>
+            {tagOptions.length === 0 ? (
+              <div className="picker-empty">{srcMeasure ? 'Source measure has no tags.' : 'Choose a source measure first.'}</div>
+            ) : (
+              <MultiCombobox value={[...v.groupByTagNames]} options={tagOptions} onChange={(groupByTagNames) => set({ groupByTagNames })}
+                placeholder="— select group-by tags —" ariaLabel="Group by tags" noOptionsHint="Source measure has no tags" />
+            )}
+          </section>
+
+          <section className="f-section">
+            <div className="f-section-title">Criteria <span className="f-optional">optional</span></div>
+            <p className="f-section-desc">Select a partial set of data points to aggregate. Conditions are combined with AND.</p>
+            {tagOptions.length === 0 && v.criteria.length === 0 ? (
+              <div className="picker-empty">Choose a source measure with tags to add criteria.</div>
+            ) : (
+              <CriteriaEditor criteria={v.criteria} tagOptions={tagOptions} errors={errors.criteria}
+                onChange={(criteria) => set({ criteria })} />
+            )}
+          </section>
+
+          {errors._ && <div className="f-error" role="alert">{errors._}</div>}
+        </div>
+
+        <div className="modal-foot">
+          <button type="button" className="btn btn-ghost" onClick={guardedClose} disabled={isPending}>Cancel</button>
+          <button type="button" className="btn btn-primary" onClick={submit} disabled={isPending}>
+            {isPending ? (isEdit ? 'Saving…' : 'Creating…') : (isEdit ? 'Save changes' : 'Create aggregation')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ============ delete confirmation ============ */
+
+export interface DeleteTopNModalProps {
+  readonly groupName: string;
+  readonly aggregation: TopNAggregationSchema;
+  readonly onClose: () => void;
+  readonly onDeleted?: () => void;
+}
+
+export function DeleteTopNModal({ groupName, aggregation, onClose, onDeleted }: DeleteTopNModalProps) {
+  const qc = useQueryClient();
+  const [text, setText] = useState('');
+  const trapRef = useFocusTrap(true, onClose);
+  const match = text === aggregation.metadata.name;
+
+  const deleteMut = useMutation({
+    mutationFn: () => apiDataSource.deleteTopNAggregation(groupName, aggregation.metadata.name),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: ['topNAggregations'] });
+      onClose();
+      onDeleted?.();
+    },
+  });
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal is-danger" role="dialog" aria-modal="true" aria-label="Delete TopN aggregation" ref={trapRef} onClick={(e) => e.stopPropagation()}>
+        <div className="modal-head">
+          <span className="modal-title">Delete TopN aggregation</span>
+          <button type="button" className="modal-x" onClick={onClose} aria-label="Close" />
+        </div>
+        <div className="modal-body">
+          <p className="del-warn">
+            You are about to permanently delete the TopNAggregation <b className="mono">{aggregation.metadata.name}</b> from
+            group <b className="mono">{groupName}</b>. Its pre-computed ranked statistics will be dropped.
+            The source measure <b className="mono">{aggregation.sourceMeasure?.name}</b> is not affected.
+          </p>
+          <div className="f-field" style={{ marginTop: 16 }}>
+            <label className="f-label">Type <span className="mono">{aggregation.metadata.name}</span> to confirm</label>
+            <input type="text" className="f-input mono" autoFocus value={text} placeholder={aggregation.metadata.name}
+              onChange={(e) => setText(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter' && match && !deleteMut.isPending) deleteMut.mutate(); }} />
+          </div>
+          {deleteMut.isError && <div className="f-error" style={{ marginTop: 8 }}>{deleteMut.error.message}</div>}
+        </div>
+        <div className="modal-foot">
+          <button type="button" className="btn btn-ghost" onClick={onClose} disabled={deleteMut.isPending}>Cancel</button>
+          <button type="button" className="btn btn-danger" disabled={!match || deleteMut.isPending} onClick={() => deleteMut.mutate()}>
+            {deleteMut.isPending ? 'Deleting…' : 'Delete aggregation'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/canopy/web/src/pipelines/TopNForms.tsx
+++ b/canopy/web/src/pipelines/TopNForms.tsx
@@ -54,7 +54,7 @@ import { Combobox, MultiCombobox } from '../components/Combobox.js';
 import { IconChevron, IconPlus, IconCheck } from '../components/icons.js';
 import {
   SORT_OPTS, TOPN_OPS, DEFAULT_COUNTERS, topNTone, topNRank,
-  buildTopNCriteria, flattenTopNCriteria, type TopNCondition,
+  buildTopNCriteria, flattenTopNCriteria, topNAggregationsQueryKey, type TopNCondition,
 } from './topn-shared.js';
 
 const TOPN_NAME_RE = /^[a-zA-Z0-9_-]+$/;
@@ -290,7 +290,7 @@ export function TopNFormModal({ mode, groupName, aggregation, onClose }: TopNFor
   // Existing aggregation names in the target group, for the create-time
   // uniqueness check (the registry itself is authoritative either way).
   const { data: existingAggs = [] } = useQuery({
-    queryKey: ['topNAggregations', targetGroup],
+    queryKey: topNAggregationsQueryKey(targetGroup),
     queryFn: () => apiDataSource.listTopNAggregations(targetGroup),
     enabled: !!targetGroup,
   });
@@ -347,7 +347,7 @@ export function TopNFormModal({ mode, groupName, aggregation, onClose }: TopNFor
   const createMut = useMutation({
     mutationFn: (req: CreateTopNAggregationRequest) => apiDataSource.createTopNAggregation(req),
     onSuccess: (agg) => {
-      void qc.invalidateQueries({ queryKey: ['topNAggregations'] });
+      void qc.invalidateQueries({ queryKey: ['topnAggregations'] });
       resetDirty();
       onClose(agg);
     },
@@ -356,7 +356,7 @@ export function TopNFormModal({ mode, groupName, aggregation, onClose }: TopNFor
   const updateMut = useMutation({
     mutationFn: (req: UpdateTopNAggregationRequest) => apiDataSource.updateTopNAggregation(targetGroup, aggregation!.metadata.name, req),
     onSuccess: (agg) => {
-      void qc.invalidateQueries({ queryKey: ['topNAggregations'] });
+      void qc.invalidateQueries({ queryKey: ['topnAggregations'] });
       void qc.invalidateQueries({ queryKey: ['topNAggregation', targetGroup, aggregation?.metadata.name] });
       resetDirty();
       onClose(agg);
@@ -374,6 +374,15 @@ export function TopNFormModal({ mode, groupName, aggregation, onClose }: TopNFor
         const first = document.querySelector<HTMLElement>('.modal .has-error .f-input, .modal .has-error input');
         first?.focus();
       });
+      return;
+    }
+    // A TopNAggregation ranks measures within its own registry group: the
+    // precomputed result measure is written into metadata.group while the
+    // counters stream from sourceMeasure.group, so a mismatch produces
+    // results the user can't trace. Block it here with a clear message
+    // instead of letting the request fail server-side.
+    if (v.sourceGroup !== targetGroup) {
+      setErrors({ _: `Source measure group "${v.sourceGroup}" must match the aggregation's group "${targetGroup}" — a TopN aggregation ranks measures within its own group.` });
       return;
     }
     // Guard against zeroing group-by tags before the source measure's schema
@@ -543,7 +552,7 @@ export function DeleteTopNModal({ groupName, aggregation, onClose, onDeleted }: 
   const deleteMut = useMutation({
     mutationFn: () => apiDataSource.deleteTopNAggregation(groupName, aggregation.metadata.name),
     onSuccess: () => {
-      void qc.invalidateQueries({ queryKey: ['topNAggregations'] });
+      void qc.invalidateQueries({ queryKey: ['topnAggregations'] });
       onClose();
       onDeleted?.();
     },

--- a/canopy/web/src/pipelines/TopNList.test.tsx
+++ b/canopy/web/src/pipelines/TopNList.test.tsx
@@ -24,7 +24,7 @@
 
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { MemoryRouter, Routes, Route } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import type { TopNAggregationSchema, MeasureSchema } from 'canopy-shared';

--- a/canopy/web/src/pipelines/TopNList.test.tsx
+++ b/canopy/web/src/pipelines/TopNList.test.tsx
@@ -1,0 +1,172 @@
+/*
+ * Licensed to Apache Software Foundation (ASF) under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Apache Software Foundation (ASF) licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Component tests for TopNList (/pipelines/topn) — the cross-group TopN
+// aggregation list: loading/empty states, name/rank filtering, the
+// "source measure no longer exists" danger badge, canWrite-gated actions,
+// and row-click navigation to the detail route.
+
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import type { TopNAggregationSchema, MeasureSchema } from 'canopy-shared';
+import { FieldType, EncodingMethod, CompressMethod } from 'canopy-shared';
+import { apiDataSource } from '../data/api.js';
+import { useAuth } from '../auth/AuthContext.js';
+import { TopNList } from './TopNList.js';
+
+vi.mock('../data/api.js', () => ({
+  apiDataSource: {
+    listGroups: vi.fn(),
+    listTopNAggregations: vi.fn(),
+    listResourcesInGroup: vi.fn(),
+  },
+}));
+
+vi.mock('../auth/AuthContext.js', () => ({
+  useAuth: vi.fn(),
+}));
+
+const GROUPS = { groups: [{ name: 'sw_metric', catalog: 'CATALOG_MEASURE', resourceOpts: { shardNum: 1 } }] };
+
+const AGG_A: TopNAggregationSchema = {
+  metadata: { name: 'service_cpm_topn', group: 'sw_metric' },
+  sourceMeasure: { group: 'sw_metric', name: 'service_cpm_minute' },
+  fieldName: 'value',
+  fieldValueSort: 'SORT_DESC',
+  groupByTagNames: ['service'],
+  countersNumber: 1000,
+  lruSize: 10,
+};
+
+const AGG_B: TopNAggregationSchema = {
+  metadata: { name: 'endpoint_latency_bottomn', group: 'sw_metric' },
+  sourceMeasure: { group: 'sw_metric', name: 'missing_measure' },
+  fieldName: 'latency',
+  fieldValueSort: 'SORT_ASC',
+  groupByTagNames: [],
+  countersNumber: 500,
+};
+
+const MEASURE: MeasureSchema = {
+  metadata: { name: 'service_cpm_minute', group: 'sw_metric' },
+  tagFamilies: [],
+  fields: [{ name: 'value', fieldType: FieldType.INT, encodingMethod: EncodingMethod.GORILLA, compressionMethod: CompressMethod.ZSTD }],
+  entity: { tagNames: ['id'] },
+  interval: '1m',
+};
+
+function makeWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={qc}>
+        <MemoryRouter initialEntries={['/pipelines/topn']}>
+          <Routes>
+            <Route path="/pipelines/topn" element={children} />
+            <Route path="/pipelines/topn/:group/:name" element={<div>DETAIL ROUTE</div>} />
+            <Route path="/pipelines" element={<div>PIPELINES OVERVIEW</div>} />
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+  }
+  Wrapper.displayName = 'TestWrapper';
+  return Wrapper;
+}
+
+function mockAuth(role: 'admin' | 'readonly' | null) {
+  vi.mocked(useAuth).mockReturnValue({
+    session: role ? { user: 'u', role, banyanVersion: null } : null,
+    loading: false,
+    setSession: vi.fn(),
+  });
+}
+
+describe('TopNList', () => {
+  beforeEach(() => {
+    vi.mocked(apiDataSource.listGroups).mockResolvedValue(GROUPS as never);
+    vi.mocked(apiDataSource.listTopNAggregations).mockResolvedValue([AGG_A, AGG_B]);
+    vi.mocked(apiDataSource.listResourcesInGroup).mockResolvedValue([MEASURE] as never);
+    mockAuth('admin');
+  });
+
+  it('renders both aggregation rows once loaded', async () => {
+    render(<TopNList />, { wrapper: makeWrapper() });
+    expect(await screen.findByText('service_cpm_topn')).toBeInTheDocument();
+    expect(screen.getByText('endpoint_latency_bottomn')).toBeInTheDocument();
+    expect(screen.getByText('2 aggregations')).toBeInTheDocument();
+  });
+
+  it('flags a source measure that no longer exists with the danger chip', async () => {
+    render(<TopNList />, { wrapper: makeWrapper() });
+    await screen.findByText('service_cpm_topn');
+    // AGG_B's source ("missing_measure") isn't in the resolved measure list.
+    expect(screen.getByTitle('Source measure no longer exists')).toBeInTheDocument();
+  });
+
+  it('filters the list by name', async () => {
+    render(<TopNList />, { wrapper: makeWrapper() });
+    await screen.findByText('service_cpm_topn');
+    fireEvent.change(screen.getByPlaceholderText('Filter by name'), { target: { value: 'endpoint' } });
+    await waitFor(() => expect(screen.queryByText('service_cpm_topn')).not.toBeInTheDocument());
+    expect(screen.getByText('endpoint_latency_bottomn')).toBeInTheDocument();
+    expect(screen.getByText('1 of 2')).toBeInTheDocument();
+  });
+
+  it('filters the list by rank direction', async () => {
+    render(<TopNList />, { wrapper: makeWrapper() });
+    await screen.findByText('service_cpm_topn');
+    fireEvent.change(screen.getByLabelText('Rank'), { target: { value: 'SORT_ASC' } });
+    await waitFor(() => expect(screen.queryByText('service_cpm_topn')).not.toBeInTheDocument());
+    expect(screen.getByText('endpoint_latency_bottomn')).toBeInTheDocument();
+  });
+
+  it('shows the empty state when there are no aggregations at all', async () => {
+    vi.mocked(apiDataSource.listTopNAggregations).mockResolvedValue([]);
+    render(<TopNList />, { wrapper: makeWrapper() });
+    expect(await screen.findByText('No TopN aggregations yet')).toBeInTheDocument();
+  });
+
+  it('hides New/Edit/Delete actions for a readonly session', async () => {
+    mockAuth('readonly');
+    render(<TopNList />, { wrapper: makeWrapper() });
+    await screen.findByText('service_cpm_topn');
+    expect(screen.queryByRole('button', { name: /New aggregation/i })).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Edit')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Delete')).not.toBeInTheDocument();
+  });
+
+  it('shows New/Edit/Delete actions for an admin session', async () => {
+    render(<TopNList />, { wrapper: makeWrapper() });
+    await screen.findByText('service_cpm_topn');
+    expect(screen.getByRole('button', { name: /New aggregation/i })).toBeInTheDocument();
+    expect(screen.getAllByTitle('Edit').length).toBe(2);
+    expect(screen.getAllByTitle('Delete').length).toBe(2);
+  });
+
+  it('navigates to the detail route when a row is clicked', async () => {
+    render(<TopNList />, { wrapper: makeWrapper() });
+    const row = await screen.findByText('service_cpm_topn');
+    fireEvent.click(row.closest('.topn-row')!);
+    expect(await screen.findByText('DETAIL ROUTE')).toBeInTheDocument();
+  });
+});

--- a/canopy/web/src/pipelines/TopNList.tsx
+++ b/canopy/web/src/pipelines/TopNList.tsx
@@ -43,6 +43,8 @@ import {
 import { RankBadge, SORT_OPTS } from './topn-shared.js';
 import { TopNFormModal, DeleteTopNModal } from './TopNForms.js';
 
+const PAGE_SIZE = 10;
+
 interface Row {
   readonly agg: TopNAggregationSchema;
   readonly group: string;
@@ -147,6 +149,15 @@ export function TopNList() {
   const filtersActive = !!q || sourceF !== 'all' || rankF !== 'all' || groupF !== 'all';
   const newTargetGroup = groupF !== 'all' ? groupF : undefined;
 
+  // Client-side paging over the filtered list (same pattern as DocList):
+  // clamps when a filter change shrinks the list under the current page.
+  const [page, setPage] = useState(0);
+  const pages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  const cur = Math.min(page, pages - 1);
+  useEffect(() => { if (page !== cur) setPage(cur); }, [page, cur]);
+  const start = cur * PAGE_SIZE;
+  const paged = filtered.slice(start, start + PAGE_SIZE);
+
   return (
     <div className="page-body">
       <header className="page-head">
@@ -208,16 +219,17 @@ export function TopNList() {
           <p className="empty-text">No aggregation matches the current filters.</p>
         </div>
       ) : (
-        <div className="idx-table topn-x">
-          <div className="topn-head">
-            <span>Aggregation</span>
-            <span>Group</span>
-            <span>Source · field</span>
-            <span>Rank</span>
-            <span>Group by</span>
-            <span className="idx-actions-h" />
-          </div>
-          {filtered.map((r) => {
+        <>
+          <div className="idx-table topn-x">
+            <div className="topn-head">
+              <span>Aggregation</span>
+              <span>Group</span>
+              <span>Source · field</span>
+              <span>Rank</span>
+              <span>Group by</span>
+              <span className="idx-actions-h" />
+            </div>
+            {paged.map((r) => {
             const a = r.agg;
             const src = a.sourceMeasure;
             const srcExists = !!src && (measureNames.get(src.group) ?? []).includes(src.name);
@@ -271,7 +283,18 @@ export function TopNList() {
               </div>
             );
           })}
-        </div>
+          </div>
+          {filtered.length > PAGE_SIZE && (
+            <div className="doc-pager">
+              <span className="mono">showing {start + 1}–{Math.min(start + PAGE_SIZE, filtered.length)} of {filtered.length} aggregations</span>
+              <span className="doc-pager-btns">
+                <button type="button" className="pg-btn" disabled={cur === 0} onClick={() => setPage(cur - 1)}>← Prev</button>
+                <span className="doc-pager-page mono">{cur + 1} / {pages}</span>
+                <button type="button" className="pg-btn" disabled={cur >= pages - 1} onClick={() => setPage(cur + 1)}>Next →</button>
+              </span>
+            </div>
+          )}
+        </>
       )}
 
       {modal?.kind === 'create' && (

--- a/canopy/web/src/pipelines/TopNList.tsx
+++ b/canopy/web/src/pipelines/TopNList.tsx
@@ -1,0 +1,292 @@
+/*
+ * Licensed to Apache Software Foundation (ASF) under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Apache Software Foundation (ASF) licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// TopNList.tsx — the TopN pipeline type's list page (/pipelines/topn):
+// filter by name/group/source/direction, New/Edit/Delete. Ported from
+// .handoff-import/banyandb/project/topn-page.jsx's TopNList (window-global
+// JSX -> ES module TSX; the handoff's per-group "locked" drill-down variant
+// is dropped — docs/pipelines-design.md §3 only routes the all-groups list
+// and the detail page, not a per-group index).
+//
+// ADAPTATIONS: mock `groups` prop -> live listGroups + listTopNAggregations
+// (one call per measure group, mirroring QueryConsole.tsx's group-topn-agg
+// prefetch pattern); onNavigate -> useNavigate; New/Edit/Delete modals are
+// owned locally (mirrors PropertyDetailPage.tsx's local ModalState, not
+// App.tsx's central union — Pipelines is a self-contained route tree).
+
+import React, { useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+
+import type { TopNAggregationSchema } from 'canopy-shared';
+import { apiDataSource } from '../data/api.js';
+import { useAuth } from '../auth/AuthContext.js';
+import {
+  IconTopN, IconSearch, IconPlus, IconEdit, IconTrash, IconGroup, IconChevron, IconAlert,
+} from '../components/icons.js';
+import { RankBadge, SORT_OPTS } from './topn-shared.js';
+import { TopNFormModal, DeleteTopNModal } from './TopNForms.js';
+
+interface Row {
+  readonly agg: TopNAggregationSchema;
+  readonly group: string;
+}
+
+type ModalState =
+  | { readonly kind: 'create'; readonly groupName?: string }
+  | { readonly kind: 'edit'; readonly groupName: string; readonly agg: TopNAggregationSchema }
+  | { readonly kind: 'delete'; readonly groupName: string; readonly agg: TopNAggregationSchema }
+  | null;
+
+function FilterSelect({ label, value, options, onChange }: {
+  label: string;
+  value: string;
+  options: ReadonlyArray<{ value: string; label: string }>;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <label className="topn-filter">
+      <span className="topn-filter-label">{label}</span>
+      <span className="topn-select-wrap">
+        <select className="topn-select" value={value} onChange={(e) => onChange(e.target.value)} aria-label={label}>
+          {options.map((o) => <option key={o.value} value={o.value}>{o.label}</option>)}
+        </select>
+        <span className="topn-select-chev"><IconChevron size={13} /></span>
+      </span>
+    </label>
+  );
+}
+
+export function TopNList() {
+  const navigate = useNavigate();
+  const { session } = useAuth();
+  const canWrite = session?.role === 'admin';
+  const [modal, setModal] = useState<ModalState>(null);
+
+  const { data: groupsData } = useQuery({ queryKey: ['groups'], queryFn: () => apiDataSource.listGroups() });
+  const measureGroups = useMemo(() => (groupsData?.groups ?? []).filter((g) => g.catalog === 'CATALOG_MEASURE'), [groupsData]);
+  const measureGroupNames = useMemo(() => measureGroups.map((g) => g.name), [measureGroups]);
+
+  const [rows, setRows] = useState<readonly Row[]>([]);
+  const [loaded, setLoaded] = useState(false);
+  useEffect(() => {
+    if (measureGroupNames.length === 0) { setRows([]); setLoaded(true); return; }
+    let cancelled = false;
+    Promise.allSettled(
+      measureGroupNames.map((g) => apiDataSource.listTopNAggregations(g).then((aggs) => ({ group: g, aggs }))),
+    ).then((results) => {
+      if (cancelled) return;
+      const out: Row[] = [];
+      for (const r of results) if (r.status === 'fulfilled') for (const agg of r.value.aggs) out.push({ agg, group: r.value.group });
+      setRows(out);
+      setLoaded(true);
+    });
+    return () => { cancelled = true; };
+  }, [measureGroupNames]);
+
+  // Measure names per group, so a row can flag a source measure that no
+  // longer exists (like the handoff's srcExists check).
+  const [measureNames, setMeasureNames] = useState<ReadonlyMap<string, readonly string[]>>(new Map());
+  useEffect(() => {
+    if (measureGroupNames.length === 0) return;
+    let cancelled = false;
+    Promise.allSettled(
+      measureGroupNames.map((g) => apiDataSource.listResourcesInGroup('measures', g).then((rs) => ({ group: g, names: rs.map((r) => r.metadata.name) }))),
+    ).then((results) => {
+      if (cancelled) return;
+      setMeasureNames((prev) => {
+        const next = new Map(prev);
+        for (const r of results) if (r.status === 'fulfilled') next.set(r.value.group, r.value.names);
+        return next;
+      });
+    });
+    return () => { cancelled = true; };
+  }, [measureGroupNames]);
+
+  const [nameQ, setNameQ] = useState('');
+  const [groupF, setGroupF] = useState('all');
+  const [sourceF, setSourceF] = useState('all');
+  const [rankF, setRankF] = useState('all');
+
+  const groupScoped = groupF === 'all' ? rows : rows.filter((r) => r.group === groupF);
+
+  const sourceOptions = useMemo(() => {
+    const out: string[] = [];
+    for (const r of groupScoped) {
+      const n = r.agg.sourceMeasure?.name;
+      if (n && !out.includes(n)) out.push(n);
+    }
+    return out.sort();
+  }, [groupScoped]);
+
+  const q = nameQ.trim().toLowerCase();
+  const filtered = groupScoped.filter((r) => {
+    if (q && !r.agg.metadata.name.toLowerCase().includes(q)) return false;
+    if (sourceF !== 'all' && r.agg.sourceMeasure?.name !== sourceF) return false;
+    if (rankF !== 'all' && (r.agg.fieldValueSort ?? 'SORT_DESC') !== rankF) return false;
+    return true;
+  });
+
+  const totalCount = rows.length;
+  const filtersActive = !!q || sourceF !== 'all' || rankF !== 'all' || groupF !== 'all';
+  const newTargetGroup = groupF !== 'all' ? groupF : undefined;
+
+  return (
+    <div className="page-body">
+      <header className="page-head">
+        <div className="crumbs">
+          <button className="crumb crumb-link" onClick={() => navigate('/pipelines')}>Pipelines</button>
+          <span className="crumb-sep">/</span>
+          <span className="crumb is-last">TopN</span>
+        </div>
+        <h1 className="page-title">TopN</h1>
+        <p className="page-meta">Offline TopN statistics computed over measures across all groups.</p>
+      </header>
+
+      <div className="res-toolbar topn-toolbar">
+        <div className="topn-filters">
+          <div className="search-box">
+            <IconSearch size={15} />
+            <input placeholder="Filter by name" value={nameQ} onChange={(e) => setNameQ(e.target.value)} />
+          </div>
+          <FilterSelect label="Group" value={groupF}
+            onChange={(val) => { setGroupF(val); setSourceF('all'); }}
+            options={[{ value: 'all', label: 'All groups' }, ...measureGroupNames.map((n) => ({ value: n, label: n }))]} />
+          <FilterSelect label="Source" value={sourceF} onChange={setSourceF}
+            options={[{ value: 'all', label: 'All measures' }, ...sourceOptions.map((n) => ({ value: n, label: n }))]} />
+          <FilterSelect label="Rank" value={rankF} onChange={setRankF}
+            options={[{ value: 'all', label: 'Any direction' }, ...SORT_OPTS.map((s) => ({ value: s.value, label: s.rank }))]} />
+        </div>
+        <div className="res-toolbar-right">
+          <span className="res-count">
+            {filtersActive ? `${filtered.length} of ${totalCount}` : `${totalCount} ${totalCount === 1 ? 'aggregation' : 'aggregations'}`}
+          </span>
+          {canWrite && (
+            <button className="btn btn-primary" onClick={() => setModal({ kind: 'create', groupName: newTargetGroup })}>
+              <IconPlus size={16} /> New aggregation
+            </button>
+          )}
+        </div>
+      </div>
+
+      {!loaded ? (
+        <div className="empty">
+          <span className="empty-ico spin"><IconTopN size={32} /></span>
+          <div className="empty-title">Loading…</div>
+        </div>
+      ) : totalCount === 0 ? (
+        <div className="empty">
+          <span className="empty-ico"><IconTopN size={36} /></span>
+          <div className="empty-title">No TopN aggregations yet</div>
+          <p className="empty-text">Define a TopNAggregation over a measure to pre-compute ranked statistics.</p>
+          {canWrite && (
+            <button className="btn btn-primary" onClick={() => setModal({ kind: 'create', groupName: newTargetGroup })}>
+              <IconPlus size={15} /> Create aggregation
+            </button>
+          )}
+        </div>
+      ) : filtered.length === 0 ? (
+        <div className="empty">
+          <span className="empty-ico"><IconSearch size={36} /></span>
+          <div className="empty-title">No matches</div>
+          <p className="empty-text">No aggregation matches the current filters.</p>
+        </div>
+      ) : (
+        <div className="idx-table topn-x">
+          <div className="topn-head">
+            <span>Aggregation</span>
+            <span>Group</span>
+            <span>Source · field</span>
+            <span>Rank</span>
+            <span>Group by</span>
+            <span className="idx-actions-h" />
+          </div>
+          {filtered.map((r) => {
+            const a = r.agg;
+            const src = a.sourceMeasure;
+            const srcExists = !!src && (measureNames.get(src.group) ?? []).includes(src.name);
+            const path = `/pipelines/topn/${r.group}/${a.metadata.name}`;
+            return (
+              <div key={`${r.group}/${a.metadata.name}`} className="topn-row" role="button" tabIndex={0}
+                data-testid="topn-row"
+                onClick={() => navigate(path)}
+                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); navigate(path); } }}>
+                <span className="idx-name-cell">
+                  <span className="idx-ico"><IconTopN size={14} /></span>
+                  <span className="idx-name mono">{a.metadata.name}</span>
+                </span>
+
+                <span className="idx-chiprow">
+                  <span className="topn-group-chip mono" title={`Group ${r.group}`}>
+                    <IconGroup size={11} /> {r.group}
+                  </span>
+                </span>
+
+                <span className="topn-src-cell">
+                  {srcExists ? (
+                    <span className="subj-chip is-static" title={`${src!.group}/${src!.name}`}>{src!.name}</span>
+                  ) : (
+                    <span className="subj-chip is-danger" title="Source measure no longer exists">
+                      <IconAlert size={11} /> {src?.name ?? '—'}
+                    </span>
+                  )}
+                  <span className="topn-field mono">{a.fieldName}</span>
+                </span>
+
+                <span><RankBadge sort={a.fieldValueSort} /></span>
+
+                <span className="idx-chiprow">
+                  {(a.groupByTagNames ?? []).map((t) => <span key={t} className="idx-tag mono">{t}</span>)}
+                  {!(a.groupByTagNames ?? []).length && <span className="idx-dim">none</span>}
+                </span>
+
+                <span className="idx-actions" onClick={(e) => e.stopPropagation()}>
+                  {canWrite && (
+                    <button className="idx-act" title="Edit" onClick={() => setModal({ kind: 'edit', groupName: r.group, agg: a })}>
+                      <IconEdit size={15} />
+                    </button>
+                  )}
+                  {canWrite && (
+                    <button className="idx-act is-danger" title="Delete" onClick={() => setModal({ kind: 'delete', groupName: r.group, agg: a })}>
+                      <IconTrash size={15} />
+                    </button>
+                  )}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {modal?.kind === 'create' && (
+        <TopNFormModal mode="create" groupName={modal.groupName}
+          onClose={(created) => {
+            setModal(null);
+            if (created) navigate(`/pipelines/topn/${created.metadata.group}/${created.metadata.name}`);
+          }} />
+      )}
+      {modal?.kind === 'edit' && (
+        <TopNFormModal mode="edit" groupName={modal.groupName} aggregation={modal.agg} onClose={() => setModal(null)} />
+      )}
+      {modal?.kind === 'delete' && (
+        <DeleteTopNModal groupName={modal.groupName} aggregation={modal.agg} onClose={() => setModal(null)} />
+      )}
+    </div>
+  );
+}

--- a/canopy/web/src/pipelines/TopNList.tsx
+++ b/canopy/web/src/pipelines/TopNList.tsx
@@ -31,7 +31,7 @@
 // App.tsx's central union — Pipelines is a self-contained route tree).
 
 import React, { useEffect, useMemo, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useQuery } from '@tanstack/react-query';
 
 import type { TopNAggregationSchema } from 'canopy-shared';

--- a/canopy/web/src/pipelines/TopNList.tsx
+++ b/canopy/web/src/pipelines/TopNList.tsx
@@ -238,7 +238,9 @@ export function TopNList() {
               <div key={`${r.group}/${a.metadata.name}`} className="topn-row" role="button" tabIndex={0}
                 data-testid="topn-row"
                 onClick={() => navigate(path)}
-                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); navigate(path); } }}>
+                // Ignore keys bubbling from the inner Edit/Delete buttons —
+                // Space/Enter there must activate the button, not navigate.
+                onKeyDown={(e) => { if (e.target !== e.currentTarget) return; if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); navigate(path); } }}>
                 <span className="idx-name-cell">
                   <span className="idx-ico"><IconTopN size={14} /></span>
                   <span className="idx-name mono">{a.metadata.name}</span>

--- a/canopy/web/src/pipelines/topn-shared.test.ts
+++ b/canopy/web/src/pipelines/topn-shared.test.ts
@@ -112,6 +112,18 @@ describe('buildTopNCriteria / flattenTopNCriteria — flat AND chain <-> model.v
     });
   });
 
+  it('decimals encode as str — TagValue has no float variant', () => {
+    // 1.5 as TagValue.int would be an invalid payload the server rejects.
+    const rows: TopNCondition[] = [{ tag: 'rate', op: 'BINARY_OP_GT', value: '1.5' }];
+    expect(buildTopNCriteria(rows)).toEqual({
+      condition: { name: 'rate', op: 'BINARY_OP_GT', value: { str: { value: '1.5' } } },
+    });
+    const mixed: TopNCondition[] = [{ tag: 'rate', op: 'BINARY_OP_IN', value: '1.5, 2' }];
+    expect(buildTopNCriteria(mixed)).toEqual({
+      condition: { name: 'rate', op: 'BINARY_OP_IN', value: { strArray: { value: ['1.5', '2'] } } },
+    });
+  });
+
   it('chains multiple rows with LOGICAL_OP_AND, left-associatively', () => {
     const rows: TopNCondition[] = [
       { tag: 'service', op: 'BINARY_OP_EQ', value: 'checkout' },

--- a/canopy/web/src/pipelines/topn-shared.test.ts
+++ b/canopy/web/src/pipelines/topn-shared.test.ts
@@ -1,0 +1,283 @@
+/*
+ * Licensed to Apache Software Foundation (ASF) under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Apache Software Foundation (ASF) licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Unit tests for topn-shared.tsx's pure helpers (direction<->sort mapping,
+// the flat-criteria<->model.v1.Criteria codec) and TopNForms.tsx's
+// validateTopN. Colocated in one file per the Pipelines/TopN test plan —
+// validateTopN lives in TopNForms.tsx (it needs TopNDraft/TopNValidationCtx,
+// which are declared there), but its rules are the same "shared TopN
+// domain logic" this file is about, so it's exercised alongside the
+// direction/criteria helpers rather than split into a same-named file.
+
+import { describe, it, expect } from 'vitest';
+import {
+  topNTone, topNRank, topNSortLabel, topnOpSymbol, SORT_OPTS, TOPN_OPS, DEFAULT_COUNTERS,
+  buildTopNCriteria, flattenTopNCriteria, type TopNCondition, type TopNSort,
+} from './topn-shared.js';
+import { validateTopN, type TopNDraft, type TopNValidationCtx } from './TopNForms.js';
+
+describe('topNTone / topNRank — direction<->sort mapping', () => {
+  it('SORT_DESC -> topN / topn tone', () => {
+    expect(topNRank('SORT_DESC')).toBe('topN');
+    expect(topNTone('SORT_DESC')).toBe('topn');
+  });
+  it('SORT_ASC -> bottomN / bottomn tone', () => {
+    expect(topNRank('SORT_ASC')).toBe('bottomN');
+    expect(topNTone('SORT_ASC')).toBe('bottomn');
+  });
+  it('SORT_UNSPECIFIED -> both / bothn tone', () => {
+    expect(topNRank('SORT_UNSPECIFIED')).toBe('both');
+    expect(topNTone('SORT_UNSPECIFIED')).toBe('bothn');
+  });
+  it('undefined is treated the same as SORT_DESC (proto3 zero value)', () => {
+    const sort: TopNSort = undefined;
+    expect(topNRank(sort)).toBe('topN');
+    expect(topNTone(sort)).toBe('topn');
+    expect(topNSortLabel(sort)).toBe('SORT_DESC');
+  });
+  it('topNSortLabel echoes a defined sort verbatim', () => {
+    expect(topNSortLabel('SORT_ASC')).toBe('SORT_ASC');
+    expect(topNSortLabel('SORT_UNSPECIFIED')).toBe('SORT_UNSPECIFIED');
+  });
+});
+
+describe('SORT_OPTS', () => {
+  it('offers exactly the three Sort enum values with the correct rank mapping', () => {
+    expect(SORT_OPTS.map((o) => o.value)).toEqual(['SORT_DESC', 'SORT_ASC', 'SORT_UNSPECIFIED']);
+    expect(SORT_OPTS.find((o) => o.value === 'SORT_DESC')?.rank).toBe('topN');
+    expect(SORT_OPTS.find((o) => o.value === 'SORT_ASC')?.rank).toBe('bottomN');
+    expect(SORT_OPTS.find((o) => o.value === 'SORT_UNSPECIFIED')?.rank).toBe('both');
+  });
+});
+
+describe('topnOpSymbol', () => {
+  it('maps every TOPN_OPS entry to a symbol', () => {
+    for (const op of TOPN_OPS) {
+      expect(topnOpSymbol(op.value)).not.toBe(op.value === 'BINARY_OP_EQ' ? undefined : '');
+    }
+    expect(topnOpSymbol('BINARY_OP_EQ')).toBe('=');
+    expect(topnOpSymbol('BINARY_OP_IN')).toBe('IN');
+  });
+  it('falls back to the raw op string for an unknown operator', () => {
+    expect(topnOpSymbol('BINARY_OP_HAVING')).toBe('BINARY_OP_HAVING');
+  });
+});
+
+describe('buildTopNCriteria / flattenTopNCriteria — flat AND chain <-> model.v1.Criteria codec', () => {
+  it('returns undefined for an empty condition list', () => {
+    expect(buildTopNCriteria([])).toBeUndefined();
+  });
+
+  it('drops blank-tag rows and returns undefined if nothing remains', () => {
+    const rows: TopNCondition[] = [{ tag: '   ', op: 'BINARY_OP_EQ', value: 'x' }];
+    expect(buildTopNCriteria(rows)).toBeUndefined();
+  });
+
+  it('builds a single condition leaf for one row', () => {
+    const rows: TopNCondition[] = [{ tag: 'service', op: 'BINARY_OP_EQ', value: 'checkout' }];
+    const tree = buildTopNCriteria(rows);
+    expect(tree).toEqual({ condition: { name: 'service', op: 'BINARY_OP_EQ', value: { str: { value: 'checkout' } } } });
+  });
+
+  it('numeric-looking values are encoded as int, not str', () => {
+    const rows: TopNCondition[] = [{ tag: 'status', op: 'BINARY_OP_GT', value: '200' }];
+    const tree = buildTopNCriteria(rows);
+    expect(tree).toEqual({ condition: { name: 'status', op: 'BINARY_OP_GT', value: { int: { value: '200' } } } });
+  });
+
+  it('IN/NOT_IN values are split on commas into an array TagValue', () => {
+    const strRows: TopNCondition[] = [{ tag: 'service', op: 'BINARY_OP_IN', value: 'checkout, cart' }];
+    expect(buildTopNCriteria(strRows)).toEqual({
+      condition: { name: 'service', op: 'BINARY_OP_IN', value: { strArray: { value: ['checkout', 'cart'] } } },
+    });
+    const intRows: TopNCondition[] = [{ tag: 'status', op: 'BINARY_OP_NOT_IN', value: '200, 500' }];
+    expect(buildTopNCriteria(intRows)).toEqual({
+      condition: { name: 'status', op: 'BINARY_OP_NOT_IN', value: { intArray: { value: ['200', '500'] } } },
+    });
+  });
+
+  it('chains multiple rows with LOGICAL_OP_AND, left-associatively', () => {
+    const rows: TopNCondition[] = [
+      { tag: 'service', op: 'BINARY_OP_EQ', value: 'checkout' },
+      { tag: 'region', op: 'BINARY_OP_EQ', value: 'us' },
+      { tag: 'status', op: 'BINARY_OP_GT', value: '200' },
+    ];
+    const tree = buildTopNCriteria(rows);
+    expect(tree).toEqual({
+      le: {
+        op: 'LOGICAL_OP_AND',
+        left: {
+          le: {
+            op: 'LOGICAL_OP_AND',
+            left: { condition: { name: 'service', op: 'BINARY_OP_EQ', value: { str: { value: 'checkout' } } } },
+            right: { condition: { name: 'region', op: 'BINARY_OP_EQ', value: { str: { value: 'us' } } } },
+          },
+        },
+        right: { condition: { name: 'status', op: 'BINARY_OP_GT', value: { int: { value: '200' } } } },
+      },
+    });
+  });
+
+  it('round-trips a flat AND chain through build -> flatten', () => {
+    const rows: TopNCondition[] = [
+      { tag: 'service', op: 'BINARY_OP_EQ', value: 'checkout' },
+      { tag: 'region', op: 'BINARY_OP_NE', value: 'eu' },
+      { tag: 'latency_ms', op: 'BINARY_OP_LE', value: '500' },
+    ];
+    const tree = buildTopNCriteria(rows);
+    expect(flattenTopNCriteria(tree)).toEqual(rows);
+  });
+
+  it('flattenTopNCriteria returns an empty array for undefined criteria', () => {
+    expect(flattenTopNCriteria(undefined)).toEqual([]);
+  });
+});
+
+// ── validateTopN — TopNForms.tsx ────────────────────────────────────────────
+//
+// Signature: validateTopN(v: TopNDraft, ctx: TopNValidationCtx): TopNValidationErrors
+//   TopNDraft = { name, sourceGroup, sourceName, fieldName, fieldValueSort,
+//                 groupByTagNames, criteria, countersNumber, lruSize }
+//   TopNValidationCtx = { mode: 'create' | 'edit', existingNames?, fieldOptions? }
+
+function baseDraft(overrides: Partial<TopNDraft> = {}): TopNDraft {
+  return {
+    name: 'svc_cpm_topn',
+    sourceGroup: 'sw_metric',
+    sourceName: 'service_cpm_minute',
+    fieldName: 'value',
+    fieldValueSort: 'SORT_DESC',
+    groupByTagNames: [],
+    criteria: [],
+    countersNumber: DEFAULT_COUNTERS,
+    lruSize: 10,
+    ...overrides,
+  };
+}
+
+const createCtx: TopNValidationCtx = { mode: 'create', existingNames: new Set(), fieldOptions: ['value', 'latency'] };
+const editCtx: TopNValidationCtx = { mode: 'edit', fieldOptions: ['value', 'latency'] };
+
+describe('validateTopN', () => {
+  it('returns no errors for a fully valid create draft', () => {
+    expect(validateTopN(baseDraft(), createCtx)).toEqual({});
+  });
+
+  it('returns no errors for a fully valid edit draft (name not checked in edit mode)', () => {
+    expect(validateTopN(baseDraft({ name: '' }), editCtx)).toEqual({});
+  });
+
+  it('flags a missing name in create mode', () => {
+    const errs = validateTopN(baseDraft({ name: '' }), createCtx);
+    expect(errs.name).toMatch(/required/i);
+  });
+
+  it('does not flag a missing name in edit mode (name is immutable there)', () => {
+    const errs = validateTopN(baseDraft({ name: '' }), editCtx);
+    expect(errs.name).toBeUndefined();
+  });
+
+  it('flags a name that violates the allowed character pattern', () => {
+    const errs = validateTopN(baseDraft({ name: 'bad name!' }), createCtx);
+    expect(errs.name).toMatch(/letters, digits/i);
+  });
+
+  it('flags a name over 255 characters', () => {
+    const errs = validateTopN(baseDraft({ name: 'a'.repeat(256) }), createCtx);
+    expect(errs.name).toMatch(/255/);
+  });
+
+  it('flags a duplicate name (case-insensitive) against existingNames', () => {
+    const ctx: TopNValidationCtx = { mode: 'create', existingNames: new Set(['svc_cpm_topn']) };
+    const errs = validateTopN(baseDraft({ name: 'SVC_CPM_TOPN' }), ctx);
+    expect(errs.name).toMatch(/already exists/i);
+  });
+
+  it('flags a missing source group', () => {
+    const errs = validateTopN(baseDraft({ sourceGroup: '' }), createCtx);
+    expect(errs.sourceGroup).toMatch(/select a source group/i);
+  });
+
+  it('flags a missing source measure', () => {
+    const errs = validateTopN(baseDraft({ sourceName: '' }), createCtx);
+    expect(errs.sourceMeasure).toMatch(/select a source measure/i);
+  });
+
+  it('flags a missing ranked field', () => {
+    const errs = validateTopN(baseDraft({ fieldName: '' }), createCtx);
+    expect(errs.fieldName).toMatch(/required/i);
+  });
+
+  it('flags a ranked field that is not one of the source measure fieldOptions', () => {
+    const errs = validateTopN(baseDraft({ fieldName: 'not_a_field' }), createCtx);
+    expect(errs.fieldName).toMatch(/must be a field/i);
+  });
+
+  it('does not flag fieldName against fieldOptions when fieldOptions is empty/unknown', () => {
+    const ctx: TopNValidationCtx = { mode: 'create', existingNames: new Set(), fieldOptions: [] };
+    const errs = validateTopN(baseDraft({ fieldName: 'anything' }), ctx);
+    expect(errs.fieldName).toBeUndefined();
+  });
+
+  it('flags an out-of-range countersNumber (zero or non-integer)', () => {
+    expect(validateTopN(baseDraft({ countersNumber: 0 }), createCtx).countersNumber).toMatch(/greater than 0/i);
+    expect(validateTopN(baseDraft({ countersNumber: 1.5 }), createCtx).countersNumber).toMatch(/whole number/i);
+    expect(validateTopN(baseDraft({ countersNumber: -5 }), createCtx).countersNumber).toMatch(/greater than 0/i);
+  });
+
+  it('allows an empty countersNumber (falls back to the default at submit time)', () => {
+    expect(validateTopN(baseDraft({ countersNumber: '' }), createCtx).countersNumber).toBeUndefined();
+  });
+
+  it('flags an out-of-range lruSize (negative or non-integer)', () => {
+    expect(validateTopN(baseDraft({ lruSize: -1 }), createCtx).lruSize).toMatch(/0 or a positive/i);
+    expect(validateTopN(baseDraft({ lruSize: 2.2 }), createCtx).lruSize).toMatch(/0 or a positive/i);
+  });
+
+  it('allows lruSize of exactly 0 (optional field, 0 is a valid LRU size)', () => {
+    expect(validateTopN(baseDraft({ lruSize: 0 }), createCtx).lruSize).toBeUndefined();
+  });
+
+  it('flags a criteria row missing its tag', () => {
+    const errs = validateTopN(baseDraft({ criteria: [{ tag: '', op: 'BINARY_OP_EQ', value: 'x' }] }), createCtx);
+    expect(errs.criteria?.[0]?.tag).toMatch(/required/i);
+    expect(errs.criteria?.[0]?.value).toBeUndefined();
+  });
+
+  it('flags a criteria row missing its value', () => {
+    const errs = validateTopN(baseDraft({ criteria: [{ tag: 'service', op: 'BINARY_OP_EQ', value: '' }] }), createCtx);
+    expect(errs.criteria?.[0]?.value).toMatch(/required/i);
+    expect(errs.criteria?.[0]?.tag).toBeUndefined();
+  });
+
+  it('leaves the criteria error slot undefined for a fully-filled row among several', () => {
+    const errs = validateTopN(
+      baseDraft({
+        criteria: [
+          { tag: 'service', op: 'BINARY_OP_EQ', value: 'checkout' },
+          { tag: '', op: 'BINARY_OP_EQ', value: '' },
+        ],
+      }),
+      createCtx,
+    );
+    expect(errs.criteria?.[0]).toBeUndefined();
+    expect(errs.criteria?.[1]?.tag).toMatch(/required/i);
+    expect(errs.criteria?.[1]?.value).toMatch(/required/i);
+  });
+});

--- a/canopy/web/src/pipelines/topn-shared.tsx
+++ b/canopy/web/src/pipelines/topn-shared.tsx
@@ -1,0 +1,277 @@
+/*
+ * Licensed to Apache Software Foundation (ASF) under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Apache Software Foundation (ASF) licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// topn-shared.tsx — direction<->sort mapping, the RankBadge/CondChip atoms and
+// the flat-criteria<->model.v1.Criteria codec shared by TopNForms.tsx,
+// TopNList.tsx and TopNDetail.tsx (docs/pipelines-design.md §1/§6).
+//
+// Ported from the handoff's topn-page.jsx (RankBadge, CondChip, SORT_TONE/
+// SORT_RANK helpers) and topn-form.jsx (TOPN_OPS, DEFAULT_COUNTERS), pulled
+// into one module so the form and the list/detail pages don't have to import
+// from each other. NEW here (the handoff had no wire-codec — its mock
+// `criteria` was already a flat array): buildTopNCriteria/flattenTopNCriteria,
+// which translate the UI's flat ANDed {tag,op,value} rows to/from the real
+// model.v1.Criteria recursive tree BanyanDB expects. This reuses
+// PropertyTagValue/encodePropertyTagValue/decodePropertyTagValue from
+// data/api.ts — model.v1.Criteria's Condition.value is the same TagValue
+// oneof for every catalog (property, measure, ...), so there is nothing
+// TopN-specific to add there.
+
+import { useMemo } from 'react';
+import { useQuery, useQueries } from '@tanstack/react-query';
+import type { PropertyCriteria, PropertyTagValue, MeasureSchema, TopNAggregationSchema } from 'canopy-shared';
+import { apiDataSource, decodePropertyTagValue } from '../data/api.js';
+import { IconTopN } from '../components/icons.js';
+
+export type TopNSort = 'SORT_DESC' | 'SORT_ASC' | 'SORT_UNSPECIFIED' | undefined;
+
+// BanyanDB defaults an unset field_value_sort to SORT_DESC (proto3 zero value
+// for the Sort enum) — treat undefined the same as SORT_DESC everywhere.
+export function topNTone(sort: TopNSort): 'topn' | 'bottomn' | 'bothn' {
+  if (sort === 'SORT_ASC') return 'bottomn';
+  if (sort === 'SORT_UNSPECIFIED') return 'bothn';
+  return 'topn';
+}
+
+export function topNRank(sort: TopNSort): 'topN' | 'bottomN' | 'both' {
+  if (sort === 'SORT_ASC') return 'bottomN';
+  if (sort === 'SORT_UNSPECIFIED') return 'both';
+  return 'topN';
+}
+
+export function topNSortLabel(sort: TopNSort): string {
+  return sort ?? 'SORT_DESC';
+}
+
+export const SORT_OPTS: ReadonlyArray<{
+  readonly value: 'SORT_DESC' | 'SORT_ASC' | 'SORT_UNSPECIFIED';
+  readonly rank: 'topN' | 'bottomN' | 'both';
+  readonly label: string;
+  readonly hint: string;
+}> = [
+  { value: 'SORT_DESC', rank: 'topN', label: 'SORT_DESC', hint: 'ranks the largest values first' },
+  { value: 'SORT_ASC', rank: 'bottomN', label: 'SORT_ASC', hint: 'ranks the smallest values first' },
+  { value: 'SORT_UNSPECIFIED', rank: 'both', label: 'SORT_UNSPECIFIED', hint: 'tracks both top and bottom counters' },
+];
+
+export const DEFAULT_COUNTERS = 1000;
+
+/** model.v1.Condition.BinaryOp offered in the flat criteria editor — mirrors
+ *  property-bydbql.ts's PROP_OPS (comparison + set membership; MATCH/HAVING
+ *  are query-time-only operators, not meaningful for a topn-agg's criteria). */
+export const TOPN_OPS: ReadonlyArray<{ readonly value: string; readonly label: string }> = [
+  { value: 'BINARY_OP_EQ', label: 'equals  =' },
+  { value: 'BINARY_OP_NE', label: 'not equals  ≠' },
+  { value: 'BINARY_OP_GT', label: 'greater  >' },
+  { value: 'BINARY_OP_GE', label: 'greater or equal  ≥' },
+  { value: 'BINARY_OP_LT', label: 'less  <' },
+  { value: 'BINARY_OP_LE', label: 'less or equal  ≤' },
+  { value: 'BINARY_OP_IN', label: 'in  (a, b)' },
+  { value: 'BINARY_OP_NOT_IN', label: 'not in  (a, b)' },
+];
+
+const TOPN_OP_SYMBOL: Record<string, string> = {
+  BINARY_OP_EQ: '=',
+  BINARY_OP_NE: '≠',
+  BINARY_OP_GT: '>',
+  BINARY_OP_GE: '≥',
+  BINARY_OP_LT: '<',
+  BINARY_OP_LE: '≤',
+  BINARY_OP_IN: 'IN',
+  BINARY_OP_NOT_IN: 'NOT IN',
+};
+
+export function topnOpSymbol(op: string): string {
+  return TOPN_OP_SYMBOL[op] ?? op;
+}
+
+/** small shared badge: DESC->topN / ASC->bottomN / UNSPECIFIED->both */
+export function RankBadge({ sort, large }: { readonly sort: TopNSort; readonly large?: boolean }) {
+  const cls = (large ? 'topn-rank-lg' : 'topn-rank') + ' is-' + topNTone(sort);
+  return (
+    <span className={cls}>
+      <IconTopN size={large ? 14 : 11} />
+      {topNRank(sort)}
+    </span>
+  );
+}
+
+/** a single criteria condition rendered as a chip: tag op value */
+export function CondChip({ tag, op, value }: { readonly tag: string; readonly op: string; readonly value: string }) {
+  return (
+    <span className="topn-cond mono">
+      <span className="topn-cond-tag">{tag}</span>
+      <span className="topn-cond-op">{topnOpSymbol(op)}</span>
+      <span className="topn-cond-val">{value === '' ? '∅' : value}</span>
+    </span>
+  );
+}
+
+// ── flat criteria <-> model.v1.Criteria codec ───────────────────────────────
+
+export interface TopNCondition {
+  readonly tag: string;
+  readonly op: string;
+  readonly value: string;
+}
+
+const PQ_NUM = (s: string): boolean => /^-?\d+(\.\d+)?$/.test(s.trim());
+
+function topnConditionValue(op: string, raw: string): PropertyTagValue {
+  const value = raw.trim();
+  if (op === 'BINARY_OP_IN' || op === 'BINARY_OP_NOT_IN') {
+    const parts = value.split(',').map((x) => x.trim()).filter(Boolean);
+    return parts.length && parts.every(PQ_NUM) ? { intArray: { value: parts } } : { strArray: { value: parts } };
+  }
+  return PQ_NUM(value) ? { int: { value } } : { str: { value } };
+}
+
+/** Build a flat AND chain of Conditions into the model.v1.Criteria tree the
+ *  registry expects. Empty/blank-tag rows are dropped. */
+export function buildTopNCriteria(conditions: readonly TopNCondition[]): PropertyCriteria | undefined {
+  const parts: PropertyCriteria[] = conditions
+    .filter((c) => c.tag.trim())
+    .map((c) => ({ condition: { name: c.tag.trim(), op: c.op, value: topnConditionValue(c.op, c.value) } }));
+  if (!parts.length) return undefined;
+  return parts.reduce((acc, part) => ({ le: { op: 'LOGICAL_OP_AND', left: acc, right: part } }));
+}
+
+/** Flatten a model.v1.Criteria tree back into the editor's row shape.
+ *  Documented simplification (matches the design's "flat ANDed list, not the
+ *  recursive WHERE tree"): every `condition` leaf reachable through nested
+ *  `le` nodes is surfaced as one AND row regardless of whether the original
+ *  tree actually used AND or OR — a schema built outside this UI with OR'd
+ *  criteria will round-trip lossily, same tradeoff PropertyForms' editor
+ *  accepts for its own criteria tree. */
+export function flattenTopNCriteria(criteria: PropertyCriteria | undefined): TopNCondition[] {
+  const out: TopNCondition[] = [];
+  const walk = (node: PropertyCriteria | undefined): void => {
+    if (!node) return;
+    if (node.condition) {
+      out.push({ tag: node.condition.name, op: node.condition.op, value: decodePropertyTagValue(node.condition.value).value });
+      return;
+    }
+    if (node.le) { walk(node.le.left); walk(node.le.right); }
+  };
+  walk(criteria);
+  return out;
+}
+
+// ── measure lookups (mirrors the handoff's data.jsx findMeasure/
+// measureFieldNames/measureTagNames, adapted to canopy's fetched-schema
+// shape) ─────────────────────────────────────────────────────────────────
+
+/** Field names defined on a measure resource — offered as `field_name` ranking picks. */
+export function measureFieldNames(m: MeasureSchema | undefined): string[] {
+  return m?.fields ? m.fields.map((f) => f.name) : [];
+}
+
+/** Tag names defined on a measure resource — offered for group-by + criteria picks. */
+export function measureTagNames(m: MeasureSchema | undefined): string[] {
+  if (!m) return [];
+  return m.tagFamilies.flatMap((f) => f.tags.map((t) => t.name));
+}
+
+/** Resolve a measure resource by {group,name} out of a group-name -> resources map. */
+export function findMeasureIn(
+  resourcesByGroup: ReadonlyMap<string, readonly MeasureSchema[]>,
+  ref: { readonly group: string; readonly name: string } | undefined,
+): MeasureSchema | undefined {
+  if (!ref?.group || !ref.name) return undefined;
+  return resourcesByGroup.get(ref.group)?.find((m) => m.metadata.name === ref.name);
+}
+
+// ── shared data hook ────────────────────────────────────────────────────────
+//
+// Every Pipelines/TopN surface (overview counts, the cross-group list, the
+// create/edit form's source pickers) needs the same two things: every measure
+// group + its measures (for the source-measure picker and "does the source
+// still exist" check), and every measure group's registered TopNAggregations.
+// Centralizing the fetch here means the three surfaces share one TanStack
+// Query cache (same query keys `['groups']` / `['resources','measures',g]` /
+// `['topnAggregations',g]` already used by GroupPage/Sidebar/QueryConsole),
+// so navigating between them doesn't re-fetch, and a create/edit/delete
+// mutation that invalidates `['topnAggregations', group]` refreshes every
+// consumer at once.
+
+export interface TopNRow {
+  readonly agg: TopNAggregationSchema;
+  readonly group: string;
+}
+
+export function topNAggregationsQueryKey(group: string): readonly [string, string] {
+  return ['topnAggregations', group] as const;
+}
+
+export interface TopNCatalog {
+  /** Every CATALOG_MEASURE group. */
+  readonly measureGroups: readonly { readonly name: string }[];
+  /** Every registered TopNAggregation, across all measure groups. */
+  readonly rows: readonly TopNRow[];
+  /** Each measure group's measures, keyed by group name — powers the source
+   *  picker and the "source measure still exists" check. */
+  readonly resourcesByGroup: ReadonlyMap<string, readonly MeasureSchema[]>;
+  readonly isLoading: boolean;
+}
+
+export function useTopNCatalog(): TopNCatalog {
+  const { data: groupsData, isLoading: groupsLoading } = useQuery({
+    queryKey: ['groups'],
+    queryFn: () => apiDataSource.listGroups(),
+  });
+  const measureGroups = useMemo(
+    () => (groupsData?.groups ?? []).filter((g) => g.catalog === 'CATALOG_MEASURE'),
+    [groupsData],
+  );
+
+  const aggQueries = useQueries({
+    queries: measureGroups.map((g) => ({
+      queryKey: topNAggregationsQueryKey(g.name),
+      queryFn: () => apiDataSource.listTopNAggregations(g.name),
+    })),
+  });
+  const resourceQueries = useQueries({
+    queries: measureGroups.map((g) => ({
+      queryKey: ['resources', 'measures', g.name],
+      queryFn: () => apiDataSource.listResourcesInGroup('measures', g.name),
+    })),
+  });
+
+  const rows = useMemo(() => {
+    const out: TopNRow[] = [];
+    measureGroups.forEach((g, i) => {
+      for (const agg of aggQueries[i]?.data ?? []) out.push({ agg, group: g.name });
+    });
+    return out;
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- aggQueries is a
+    // fresh array of useQueries results every render; depend on the actual
+    // fetched data (via measureGroups + JSON) rather than the array identity.
+  }, [measureGroups, JSON.stringify(aggQueries.map((q) => q.dataUpdatedAt))]);
+
+  const resourcesByGroup = useMemo(() => {
+    const m = new Map<string, readonly MeasureSchema[]>();
+    measureGroups.forEach((g, i) => m.set(g.name, (resourceQueries[i]?.data ?? []) as MeasureSchema[]));
+    return m;
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- see rows above.
+  }, [measureGroups, JSON.stringify(resourceQueries.map((q) => q.dataUpdatedAt))]);
+
+  const isLoading = groupsLoading || aggQueries.some((q) => q.isLoading) || resourceQueries.some((q) => q.isLoading);
+
+  return { measureGroups, rows, resourcesByGroup, isLoading };
+}

--- a/canopy/web/src/pipelines/topn-shared.tsx
+++ b/canopy/web/src/pipelines/topn-shared.tsx
@@ -131,7 +131,9 @@ export interface TopNCondition {
   readonly value: string;
 }
 
-const PQ_NUM = (s: string): boolean => /^-?\d+(\.\d+)?$/.test(s.trim());
+// TagValue has no float variant — only integers encode as int; a decimal
+// like 1.5 falls through to str instead of producing an invalid int payload.
+const PQ_NUM = (s: string): boolean => /^-?\d+$/.test(s.trim());
 
 function topnConditionValue(op: string, raw: string): PropertyTagValue {
   const value = raw.trim();

--- a/canopy/web/src/query/QueryBuilder.tsx
+++ b/canopy/web/src/query/QueryBuilder.tsx
@@ -1014,7 +1014,8 @@ export function QueryBuilder({
           disabled={isRunning}
           onClick={() => onRun()}
         >
-          <IconPlay width={15} height={15} /> Run
+          <IconPlay width={15} height={15} /> {isRunning ? 'Running…' : 'Run'}
+          <kbd className="kbd">{typeof navigator !== 'undefined' && /Mac/i.test(navigator.platform) ? '⌘↵' : 'Ctrl↵'}</kbd>
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Port the Pipelines surface from the handoff into canopy:

- **Pipelines overview + TopN aggregation CRUD** — list / create / edit / delete topn-aggregations per group; the TopN list pages client-side (10 per page).
- **Top-N in the query console** — new Top-N catalog in the query builder (`SHOW TOP n FROM MEASURE …`), with a leaderboard result view (rank bars, entity-value decoding, time-bucket picker when the server returns multiple lists).
- **Housekeeping** — react-router-dom → react-router v8 import fixes in the pipelines pages; Ctrl↵ hint on the builder Run button for consistency with the code console.

## Test plan

- `npm run -w web test` — 466 tests passing
- `npm run -w web typecheck` — clean
- Smoke-tested against a live BanyanDB (TopN list + detail + query console ranking view)

## Notes

Follow-up fixes already staged on a separate branch (not in this PR): TopN agg wire shape for distributed liaisons, trace ORDER BY default, result-view polish. They will come as a stacked PR.
