### PR TITLE
canopy: docker image, makefile toolchain, CI integration tests (standalone + distributed)

### DIFF
--- a/.github/workflows/canopy.yml
+++ b/.github/workflows/canopy.yml
@@ -96,6 +96,9 @@ jobs:
     name: Image build (canopy)
     runs-on: ubuntu-latest
     needs: build-test
+    permissions:
+      contents: read
+      packages: write
     env:
       HUB: ghcr.io/apache
     steps:
@@ -130,6 +133,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: image-build
     permissions:
+      contents: read
+      actions: read
       packages: read
     strategy:
       fail-fast: false

--- a/.github/workflows/canopy.yml
+++ b/.github/workflows/canopy.yml
@@ -88,6 +88,103 @@ jobs:
           fi
           echo "✓ ui/ untouched"
 
+  # ── Canopy console image ────────────────────────────────────────────────────
+  # Builds ghcr.io/apache/skywalking-banyandb:<sha>-canopy (the tag suffix is
+  # applied inside scripts/build/docker.mk). On PRs the image is only built
+  # and handed to the integration test; the dual-arch push happens on main.
+  image-build:
+    name: Image build (canopy)
+    runs-on: ubuntu-latest
+    needs: build-test
+    env:
+      HUB: ghcr.io/apache
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build canopy image
+        run: TAG=${{ github.sha }} PLATFORMS=linux/amd64 make -C canopy docker
+
+      - name: Save image for the integration test
+        run: docker save "ghcr.io/apache/skywalking-banyandb:${{ github.sha }}-canopy" -o /tmp/canopy-image.tar
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: canopy-image
+          path: /tmp/canopy-image.tar
+          retention-days: 1
+
+      - name: Login to ghcr (main only)
+        if: github.ref == 'refs/heads/main'
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Push canopy image (main only)
+        if: github.ref == 'refs/heads/main'
+        run: TAG=${{ github.sha }} PLATFORMS=linux/amd64,linux/arm64 make -C canopy docker.push
+
+  # ── Integration test: canopy image vs BanyanDB, both topologies ─────────────
+  # Standalone and liaison+data cluster — the cluster leg exercises the
+  # distributed dquery paths (TopN agg validation, trace index-rule
+  # resolution) that a standalone never hits.
+  integration-test:
+    name: Integration test (${{ matrix.mode }})
+    runs-on: ubuntu-latest
+    needs: image-build
+    permissions:
+      packages: read
+    strategy:
+      fail-fast: false
+      matrix:
+        mode: [standalone, cluster]
+    env:
+      HUB: ghcr.io/apache
+      CANOPY_IMAGE: ghcr.io/apache/skywalking-banyandb:${{ github.sha }}-canopy
+    defaults:
+      run:
+        working-directory: canopy/e2e/integration
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: canopy-image
+          path: /tmp
+
+      - name: Load canopy image
+        run: docker load -i /tmp/canopy-image.tar
+
+      - name: Login to ghcr (pull the BanyanDB testing image)
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Resolve latest BanyanDB testing image
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Always resolve against the upstream repo (forks have no
+          # publish-docker runs); falls back to a pinned known-good sha when
+          # the API or the manifest is unreachable.
+          SHA=$(gh api "repos/apache/skywalking-banyandb/actions/workflows/publish-docker.yml/runs?branch=main&status=success&per_page=1" --jq '.workflow_runs[0].head_sha' 2>/dev/null || true)
+          IMG="ghcr.io/apache/skywalking-banyandb:${SHA}-testing"
+          if [ -z "$SHA" ] || [ "$SHA" = "null" ] || ! docker manifest inspect "$IMG" >/dev/null 2>&1; then
+            IMG="ghcr.io/apache/skywalking-banyandb:0c91de57-testing"
+            echo "latest -testing image not resolvable (sha='${SHA:-none}') — falling back to pinned $IMG"
+            docker manifest inspect "$IMG" >/dev/null
+          fi
+          echo "BANYANDB_IMAGE=$IMG" >> "$GITHUB_ENV"
+
+      - name: Compose up (${{ matrix.mode }})
+        run: docker compose -f docker-compose.${{ matrix.mode }}.yml up -d --wait
+
+      - name: Smoke
+        run: bash smoke.sh http://127.0.0.1:4000
+
+      - name: Compose logs on failure
+        if: failure()
+        run: docker compose -f docker-compose.${{ matrix.mode }}.yml logs --tail=200
+
+      - name: Teardown
+        if: always()
+        run: docker compose -f docker-compose.${{ matrix.mode }}.yml down -v
+
   # ── Required-check shims for canopy-only PRs ────────────────────────────────
   # Branch protection requires the Go pipeline's aggregate checks ("Continuous
   # Integration" from ci.yml and "push-banyandb-image" from publish-docker.yml).

--- a/canopy/.dockerignore
+++ b/canopy/.dockerignore
@@ -1,0 +1,28 @@
+
+# Licensed to Apache Software Foundation (ASF) under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Apache Software Foundation (ASF) licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+node_modules
+**/node_modules
+web/dist
+server/dist
+e2e/.auth
+e2e/test-results
+e2e/playwright-report
+test-results
+.omc
+crash
+*.log

--- a/canopy/Dockerfile
+++ b/canopy/Dockerfile
@@ -39,9 +39,14 @@ RUN npm run build
 FROM deps AS prod-deps
 RUN npm ci --omit=dev
 
-# ── runtime: distroless node24. Node >= 23.6 strips TypeScript types natively,
-#    which is how the BFF resolves canopy-shared (exports raw src/index.ts —
-#    see server/tsconfig.json paths). nonroot, no shell, no package manager. ──
+# ── runtime: distroless node24. The compiled server has NO runtime imports of
+#    canopy-shared (verified: `grep -r canopy-shared server/dist/src` is empty
+#    — every shared import is type-only and elided by tsc), so the enums in
+#    shared/src/schema.ts are never executed here. shared/ is still copied so
+#    the node_modules workspace symlink resolves; if a VALUE import of
+#    canopy-shared is ever added, shared must gain a real JS build — Node's
+#    type stripping does not execute `export enum`, and the integration smoke
+#    (boot + all endpoints) is the guardrail that would catch it. ──
 FROM gcr.io/distroless/nodejs24-debian12:nonroot
 WORKDIR /app
 COPY --from=build /app/web/dist web/dist

--- a/canopy/Dockerfile
+++ b/canopy/Dockerfile
@@ -1,0 +1,63 @@
+# Licensed to Apache Software Foundation (ASF) under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Apache Software Foundation (ASF) licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# canopy web console image — React SPA (web/) + Fastify BFF (server/).
+# Build context: canopy/ — invoked as `make -C canopy docker` (see canopy/Makefile
+# and scripts/build/docker.mk). Runtime is distroless for minimal CVE surface.
+
+# ── deps: full workspace install for the build ─────────────────────────────
+FROM node:24.6.0-bookworm AS deps
+WORKDIR /app
+COPY package.json package-lock.json ./
+COPY shared/package.json shared/
+COPY web/package.json web/
+COPY server/package.json server/
+RUN npm ci
+
+# ── build: shared type check + web bundle + server tsc ─────────────────────
+FROM deps AS build
+COPY tsconfig.base.json ./
+COPY shared/ shared/
+COPY web/ web/
+COPY server/ server/
+RUN npm run build
+
+# ── prod-deps: runtime-only node_modules (workspace symlink to shared kept) ──
+FROM deps AS prod-deps
+RUN npm ci --omit=dev
+
+# ── runtime: distroless node24. Node >= 23.6 strips TypeScript types natively,
+#    which is how the BFF resolves canopy-shared (exports raw src/index.ts —
+#    see server/tsconfig.json paths). nonroot, no shell, no package manager. ──
+FROM gcr.io/distroless/nodejs24-debian12:nonroot
+WORKDIR /app
+COPY --from=build /app/web/dist web/dist
+COPY --from=build /app/server/dist server/dist
+COPY --from=build /app/server/package.json server/package.json
+COPY --from=prod-deps /app/node_modules node_modules
+COPY shared/package.json shared/package.json
+COPY shared/src shared/src
+# The BFF serves the SPA from ../web/dist relative to its cwd (server/src/
+# plugins/static.ts), so the workdir must be the server package dir.
+WORKDIR /app/server
+ENV NODE_ENV=production \
+    PORT=4000 \
+    LOG_LEVEL=info
+EXPOSE 4000
+# No curl/wget in distroless — healthcheck through node itself.
+HEALTHCHECK --interval=10s --timeout=3s --start-period=10s --retries=6 \
+  CMD ["/nodejs/bin/node", "-e", "fetch('http://127.0.0.1:4000/healthz').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
+CMD ["dist/src/index.js"]

--- a/canopy/Makefile
+++ b/canopy/Makefile
@@ -61,9 +61,10 @@ e2e: build
 .PHONY: release
 release: build
 
-# docker / docker.push come from docker.mk (build the web+server bundles first,
-# like mcp does). The image tag gets the "-canopy" suffix inside docker.mk.
-docker: build
+# docker / docker.push come from docker.mk. Unlike mcp, they do NOT depend on
+# the host-side build: the Dockerfile runs the full npm ci + build in-container
+# (and the CI image-build job has no Node setup), so a host toolchain is never
+# required for the image.
 
 # license-check / license-fix delegate to the ROOT .licenserc.yaml instead of
 # canopy/.licenserc.yaml, so the OMC runtime state + handoff / playwright

--- a/canopy/Makefile
+++ b/canopy/Makefile
@@ -17,25 +17,34 @@
 #
 
 NAME := canopy
+IMG_NAME := skywalking-banyandb
+DIST_INDEX := server/dist/src/index.js
 
 mk_path  := $(abspath $(lastword $(MAKEFILE_LIST)))
 mk_dir   := $(dir $(mk_path))
 tool_bin := $(mk_dir)../bin
 repo_root := $(abspath $(mk_dir)../)
 
+include ../scripts/build/docker.mk
 include ../scripts/build/license.mk
 
 .PHONY: install
 install:
 	npm install
 
-.PHONY: build
-build: install
+$(DIST_INDEX): install
 	npm run build
+
+.PHONY: build
+build: $(DIST_INDEX)
 
 .PHONY: clean-build
 clean-build:
 	rm -rf web/dist server/dist
+
+.PHONY: typecheck
+typecheck: install
+	npm run typecheck
 
 .PHONY: lint
 lint: install
@@ -44,6 +53,17 @@ lint: install
 .PHONY: test
 test: install
 	npm run test
+
+.PHONY: e2e
+e2e: build
+	npm run e2e
+
+.PHONY: release
+release: build
+
+# docker / docker.push come from docker.mk (build the web+server bundles first,
+# like mcp does). The image tag gets the "-canopy" suffix inside docker.mk.
+docker: build
 
 # license-check / license-fix delegate to the ROOT .licenserc.yaml instead of
 # canopy/.licenserc.yaml, so the OMC runtime state + handoff / playwright

--- a/canopy/e2e/integration/docker-compose.cluster.yml
+++ b/canopy/e2e/integration/docker-compose.cluster.yml
@@ -1,0 +1,63 @@
+# Licensed to Apache Software Foundation (ASF) under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Apache Software Foundation (ASF) licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Tier-1 integration topology: the canopy image against a DISTRIBUTED BanyanDB
+# (liaison + data, file-based node discovery — the same wiring as
+# test/e2e-v2/cases/cluster). This exercises the liaison's dquery paths
+# (TopN validateRequest, trace index-rule resolution) that a standalone
+# never hits. Run:
+#   CANOPY_IMAGE=<image> docker compose -f docker-compose.cluster.yml up -d --wait
+services:
+  data:
+    image: ${BANYANDB_IMAGE:-apache/skywalking-banyandb:0.10.2}
+    command: data --node-discovery-mode=file --node-discovery-file-path=/etc/banyandb/nodes.yaml
+    volumes:
+      - ./nodes.yaml:/etc/banyandb/nodes.yaml:ro
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:17913/api/healthz"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+
+  liaison:
+    image: ${BANYANDB_IMAGE:-apache/skywalking-banyandb:0.10.2}
+    command: liaison --node-discovery-mode=file --node-discovery-file-path=/etc/banyandb/nodes.yaml
+    volumes:
+      - ./nodes.yaml:/etc/banyandb/nodes.yaml:ro
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:17913/api/healthz"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+    depends_on:
+      data:
+        condition: service_healthy
+
+  canopy:
+    image: ${CANOPY_IMAGE:?set CANOPY_IMAGE to the canopy image under test}
+    environment:
+      PORT: "4000"
+      SESSION_SECRET: canopy-integration-secret-32chars!!
+      CANOPY_USERS: /etc/canopy/users.yaml
+      BANYANDB_TARGET: http://liaison:17913
+      MONITOR_TARGET: http://liaison:2121
+    volumes:
+      - ./users.yaml:/etc/canopy/users.yaml:ro
+    ports:
+      - "${CANOPY_HOST_PORT:-4000}:4000"
+    depends_on:
+      liaison:
+        condition: service_healthy

--- a/canopy/e2e/integration/docker-compose.standalone.yml
+++ b/canopy/e2e/integration/docker-compose.standalone.yml
@@ -1,0 +1,46 @@
+# Licensed to Apache Software Foundation (ASF) under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Apache Software Foundation (ASF) licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Tier-1 integration topology: the canopy image against a STANDALONE BanyanDB.
+# CI uses BANYANDB_IMAGE=ghcr.io/apache/skywalking-banyandb:<sha>-testing;
+# locally any released image works (default below). Run:
+#   CANOPY_IMAGE=<image> docker compose -f docker-compose.standalone.yml up -d --wait
+services:
+  banyandb:
+    image: ${BANYANDB_IMAGE:-apache/skywalking-banyandb:0.10.2}
+    command: standalone
+    healthcheck:
+      # busybox wget — present in both the release and the -testing images.
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:17913/api/healthz"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+
+  canopy:
+    image: ${CANOPY_IMAGE:?set CANOPY_IMAGE to the canopy image under test}
+    environment:
+      PORT: "4000"
+      SESSION_SECRET: canopy-integration-secret-32chars!!
+      CANOPY_USERS: /etc/canopy/users.yaml
+      BANYANDB_TARGET: http://banyandb:17913
+      MONITOR_TARGET: http://banyandb:2121
+    volumes:
+      - ./users.yaml:/etc/canopy/users.yaml:ro
+    ports:
+      - "${CANOPY_HOST_PORT:-4000}:4000"
+    depends_on:
+      banyandb:
+        condition: service_healthy

--- a/canopy/e2e/integration/nodes.yaml
+++ b/canopy/e2e/integration/nodes.yaml
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# File-based node discovery for the cluster topology (docker-compose.cluster.yml) —
+# the liaison dials the data node over gRPC using these addresses.
+nodes:
+  - name: data
+    grpc_address: data:17912
+  - name: liaison
+    grpc_address: liaison:17912

--- a/canopy/e2e/integration/smoke.sh
+++ b/canopy/e2e/integration/smoke.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Tier-1 smoke for the canopy image against a live BanyanDB topology
+# (standalone or liaison+data cluster — same assertions). Proves the image
+# boots, serves the SPA, authenticates via CANOPY_USERS, and proxies
+# registry + query traffic; plus two regression probes for bugs that only
+# surface on a distributed liaison (TopN agg validation, trace ORDER BY
+# index-rule resolution).
+#
+# Usage: smoke.sh [base-url]   (default http://127.0.0.1:4000)
+set -u
+BASE="${1:-http://127.0.0.1:4000}"
+JAR="$(mktemp)"
+RESP="$(mktemp)"
+trap 'rm -f "$JAR" "$RESP"' EXIT
+
+fail() { echo "SMOKE FAIL: $*" >&2; exit 1; }
+ok() { echo "ok - $*"; }
+
+# curl helpers: assert HTTP 200, body left in $RESP.
+post() { # path body
+  local code
+  code=$(curl -sS -o "$RESP" -w "%{http_code}" -b "$JAR" -X POST "$BASE$1" \
+    -H 'Content-Type: application/json' -d "$2") || fail "POST $1 transport error"
+  [ "$code" = 200 ] || fail "POST $1 -> HTTP $code: $(head -c 300 "$RESP")"
+}
+# seed(): like post but tolerates 409 (resource already exists) so the smoke
+# is idempotent across reruns against a reused topology.
+seed() { # path body
+  local code
+  code=$(curl -sS -o "$RESP" -w "%{http_code}" -b "$JAR" -X POST "$BASE$1" \
+    -H 'Content-Type: application/json' -d "$2") || fail "POST $1 transport error"
+  [ "$code" = 200 ] || [ "$code" = 409 ] || fail "POST $1 -> HTTP $code: $(head -c 300 "$RESP")"
+}
+get() { # path
+  local code
+  code=$(curl -sS -o "$RESP" -w "%{http_code}" -b "$JAR" "$BASE$1") || fail "GET $1 transport error"
+  [ "$code" = 200 ] || fail "GET $1 -> HTTP $code: $(head -c 300 "$RESP")"
+}
+
+# ── 1. health ──────────────────────────────────────────────────────────────
+ready=""
+for _ in $(seq 1 60); do
+  curl -fsS -m 2 "$BASE/healthz" >/dev/null 2>&1 && { ready=1; break; }
+  sleep 2
+done
+[ -n "$ready" ] || fail "canopy /healthz not ready after 120s"
+ok "healthz"
+
+# ── 2. production login (CANOPY_USERS, bcrypt) ─────────────────────────────
+code=$(curl -sS -o "$RESP" -w "%{http_code}" -c "$JAR" -X POST "$BASE/auth/login" \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"canopy-admin","password":"canopy-it-pass"}')
+[ "$code" = 200 ] || fail "login -> HTTP $code: $(head -c 300 "$RESP")"
+grep -q '"role":"admin"' "$RESP" || fail "login response missing admin role: $(head -c 200 "$RESP")"
+ok "login via CANOPY_USERS"
+
+# ── 3. BFF <-> BanyanDB reachability ───────────────────────────────────────
+get /api/meta
+grep -q '"reachable":true' "$RESP" || fail "/api/meta reports unreachable: $(head -c 200 "$RESP")"
+ok "api/meta reachable"
+
+# ── 4. SPA served ──────────────────────────────────────────────────────────
+code=$(curl -sS -o "$RESP" -w "%{http_code}" "$BASE/")
+[ "$code" = 200 ] || fail "SPA index -> HTTP $code"
+grep -qi '<div id="root"' "$RESP" || grep -qi '<script' "$RESP" || fail "SPA index has no app markup"
+ok "SPA index"
+
+# ── 5. schema seeding through the BFF proxy ────────────────────────────────
+seed /api/v1/group/schema '{"group":{"metadata":{"name":"it_metrics"},"catalog":"CATALOG_MEASURE","resourceOpts":{"shardNum":1,"segmentInterval":{"unit":"UNIT_DAY","num":1},"ttl":{"unit":"UNIT_DAY","num":3}}}}'
+seed /api/v1/group/schema '{"group":{"metadata":{"name":"it_traces"},"catalog":"CATALOG_TRACE","resourceOpts":{"shardNum":1,"segmentInterval":{"unit":"UNIT_DAY","num":1},"ttl":{"unit":"UNIT_DAY","num":3}}}}'
+ok "groups created"
+
+seed /api/v1/measure/schema '{"measure":{"metadata":{"group":"it_metrics","name":"cpu"},"tagFamilies":[{"name":"default","tags":[{"name":"entity_id","type":"TAG_TYPE_STRING"}]}],"fields":[{"name":"value","fieldType":"FIELD_TYPE_INT","encodingMethod":"ENCODING_METHOD_GORILLA","compressionMethod":"COMPRESSION_METHOD_ZSTD"}],"entity":{"tagNames":["entity_id"]},"interval":"1m"}}'
+ok "measure schema created"
+
+seed /api/v1/trace/schema '{"trace":{"metadata":{"group":"it_traces","name":"segment"},"tags":[{"name":"trace_id","type":"TAG_TYPE_STRING"},{"name":"start_time","type":"TAG_TYPE_TIMESTAMP"}],"traceIdTagName":"trace_id","spanIdTagName":"trace_id","timestampTagName":"start_time"}}'
+seed /api/v1/index-rule/schema '{"indexRule":{"metadata":{"group":"it_traces","name":"start_time"},"tags":["start_time"],"type":"TYPE_TREE"}}'
+seed /api/v1/index-rule-binding/schema '{"indexRuleBinding":{"metadata":{"group":"it_traces","name":"segment"},"rules":["start_time"],"subject":{"catalog":"CATALOG_TRACE","name":"segment"},"beginAt":"2025-01-01T00:00:00Z","expireAt":"2099-01-01T00:00:00Z"}}'
+ok "trace schema + index rule + binding created"
+
+# ── 6. regression probe: TopN query (dquery validateRequest path) ──────────
+seed /api/v1/topn-agg/schema '{"topNAggregation":{"metadata":{"group":"it_metrics","name":"cpu-topn"},"sourceMeasure":{"group":"it_metrics","name":"cpu"},"fieldName":"value","fieldValueSort":"SORT_DESC","groupByTagNames":["entity_id"],"countersNumber":1000}}'
+ok "topn aggregation created"
+
+NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+BEGIN=$(date -u -d '1 hour ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -v-1H +%Y-%m-%dT%H:%M:%SZ)
+post /api/v1/measure/topn "{\"groups\":[\"it_metrics\"],\"name\":\"cpu-topn\",\"topN\":5,\"agg\":\"AGGREGATION_FUNCTION_MEAN\",\"fieldValueSort\":\"SORT_DESC\",\"timeRange\":{\"begin\":\"$BEGIN\",\"end\":\"$NOW\"}}"
+grep -q 'unspecified requested aggregation function' "$RESP" && fail "topn agg validation regressed: $(head -c 300 "$RESP")"
+ok "topn query (bare-enum agg) passes validation"
+
+# ── 7. regression probe: trace ORDER BY resolves an index-rule name ────────
+post /api/v1/bydbql/query '{"query":"SELECT trace_id, start_time FROM TRACE segment IN it_traces TIME > '"'"'-1h'"'"' ORDER BY start_time DESC LIMIT 5"}'
+grep -q 'index rule' "$RESP" && fail "trace ORDER BY start_time errored: $(head -c 300 "$RESP")"
+ok "trace ORDER BY start_time (bound rule) accepted"
+
+# Negative control: a rule that does NOT exist must fail with the analyzer's
+# message — proves the probe above actually exercised the index-rule path.
+code=$(curl -sS -o "$RESP" -w "%{http_code}" -b "$JAR" -X POST "$BASE/api/v1/bydbql/query" \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"SELECT trace_id FROM TRACE segment IN it_traces TIME > '"'"'-1h'"'"' ORDER BY timestamp DESC LIMIT 5"}')
+grep -q 'index rule timestamp not found' "$RESP" || fail "negative control: expected 'index rule timestamp not found', got HTTP $code: $(head -c 300 "$RESP")"
+ok "negative control: unbound rule name rejected"
+
+echo "SMOKE PASS ($BASE)"

--- a/canopy/e2e/integration/smoke.sh
+++ b/canopy/e2e/integration/smoke.sh
@@ -31,10 +31,11 @@ trap 'rm -f "$JAR" "$RESP"' EXIT
 fail() { echo "SMOKE FAIL: $*" >&2; exit 1; }
 ok() { echo "ok - $*"; }
 
-# curl helpers: assert HTTP 200, body left in $RESP.
+# curl helpers: assert HTTP 200, body left in $RESP. Every request carries a
+# max-time so a stalled container hangs the job for seconds, not forever.
 post() { # path body
   local code
-  code=$(curl -sS -o "$RESP" -w "%{http_code}" -b "$JAR" -X POST "$BASE$1" \
+  code=$(curl -sS --max-time 30 -o "$RESP" -w "%{http_code}" -b "$JAR" -X POST "$BASE$1" \
     -H 'Content-Type: application/json' -d "$2") || fail "POST $1 transport error"
   [ "$code" = 200 ] || fail "POST $1 -> HTTP $code: $(head -c 300 "$RESP")"
 }
@@ -42,13 +43,13 @@ post() { # path body
 # is idempotent across reruns against a reused topology.
 seed() { # path body
   local code
-  code=$(curl -sS -o "$RESP" -w "%{http_code}" -b "$JAR" -X POST "$BASE$1" \
+  code=$(curl -sS --max-time 30 -o "$RESP" -w "%{http_code}" -b "$JAR" -X POST "$BASE$1" \
     -H 'Content-Type: application/json' -d "$2") || fail "POST $1 transport error"
   [ "$code" = 200 ] || [ "$code" = 409 ] || fail "POST $1 -> HTTP $code: $(head -c 300 "$RESP")"
 }
 get() { # path
   local code
-  code=$(curl -sS -o "$RESP" -w "%{http_code}" -b "$JAR" "$BASE$1") || fail "GET $1 transport error"
+  code=$(curl -sS --max-time 30 -o "$RESP" -w "%{http_code}" -b "$JAR" "$BASE$1") || fail "GET $1 transport error"
   [ "$code" = 200 ] || fail "GET $1 -> HTTP $code: $(head -c 300 "$RESP")"
 }
 
@@ -62,7 +63,7 @@ done
 ok "healthz"
 
 # ── 2. production login (CANOPY_USERS, bcrypt) ─────────────────────────────
-code=$(curl -sS -o "$RESP" -w "%{http_code}" -c "$JAR" -X POST "$BASE/auth/login" \
+code=$(curl -sS --max-time 30 -o "$RESP" -w "%{http_code}" -c "$JAR" -X POST "$BASE/auth/login" \
   -H 'Content-Type: application/json' \
   -d '{"username":"canopy-admin","password":"canopy-it-pass"}')
 [ "$code" = 200 ] || fail "login -> HTTP $code: $(head -c 300 "$RESP")"
@@ -75,7 +76,7 @@ grep -q '"reachable":true' "$RESP" || fail "/api/meta reports unreachable: $(hea
 ok "api/meta reachable"
 
 # ── 4. SPA served ──────────────────────────────────────────────────────────
-code=$(curl -sS -o "$RESP" -w "%{http_code}" "$BASE/")
+code=$(curl -sS --max-time 30 -o "$RESP" -w "%{http_code}" "$BASE/")
 [ "$code" = 200 ] || fail "SPA index -> HTTP $code"
 grep -qi '<div id="root"' "$RESP" || grep -qi '<script' "$RESP" || fail "SPA index has no app markup"
 ok "SPA index"
@@ -110,9 +111,10 @@ ok "trace ORDER BY start_time (bound rule) accepted"
 
 # Negative control: a rule that does NOT exist must fail with the analyzer's
 # message — proves the probe above actually exercised the index-rule path.
-code=$(curl -sS -o "$RESP" -w "%{http_code}" -b "$JAR" -X POST "$BASE/api/v1/bydbql/query" \
+code=$(curl -sS --max-time 30 -o "$RESP" -w "%{http_code}" -b "$JAR" -X POST "$BASE/api/v1/bydbql/query" \
   -H 'Content-Type: application/json' \
-  -d '{"query":"SELECT trace_id FROM TRACE segment IN it_traces TIME > '"'"'-1h'"'"' ORDER BY timestamp DESC LIMIT 5"}')
+  -d '{"query":"SELECT trace_id FROM TRACE segment IN it_traces TIME > '"'"'-1h'"'"' ORDER BY timestamp DESC LIMIT 5"}') \
+  || fail "negative control: transport error"
 grep -q 'index rule timestamp not found' "$RESP" || fail "negative control: expected 'index rule timestamp not found', got HTTP $code: $(head -c 300 "$RESP")"
 ok "negative control: unbound rule name rejected"
 

--- a/canopy/e2e/integration/users.yaml
+++ b/canopy/e2e/integration/users.yaml
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test-only credentials for the integration smoke (CANOPY_USERS format:
+# non-empty array of {username, passwordHash, role}). The hash is bcrypt of
+# "canopy-it-pass" — throwaway, used only inside the ephemeral compose
+# topology. Never reuse for a real deployment.
+- username: canopy-admin
+  passwordHash: $2b$10$D8xX.KxHM29Ksr9FRSZ9gOqUJ9Po3e99JI.jDnN6k7XFaBO7XFuou
+  role: admin

--- a/scripts/build/docker.mk
+++ b/scripts/build/docker.mk
@@ -33,6 +33,15 @@ ifeq ($(BINARYTYPE),slim)
 	TAG := $(TAG)-slim
 endif
 
+# The canopy web console ships in the SAME repo as every other banyandb image,
+# distinguished only by the "-canopy" TAG suffix (mirrors the slim pattern
+# above): $(HUB)/$(IMG_NAME):$(TAG)-canopy. canopy/Makefile sets NAME=canopy
+# and IMG_NAME=skywalking-banyandb; CI passes TAG via the environment, so this
+# makefile-level assignment wins as it does for slim.
+ifeq ($(NAME),canopy)
+	TAG := $(TAG)-canopy
+endif
+
 # banyand/Dockerfile has a "-plugins" builder stage (BINARYTYPE=plugins) whose
 # COPY --from=reporoot reaches the full repo module (go.mod lives one
 # directory above banyand/, this project's own build context), plus a later


### PR DESCRIPTION
## Summary

Builds and CI-publishes a Docker image for the canopy console, adds the missing Makefile toolchain targets, and gates it with integration tests against BanyanDB in **both standalone and distributed (liaison+data) modes** — all in one PR, with the integration test as the gate.

**Image** (`canopy/Dockerfile`)
- Multi-stage: `npm ci` → `npm run build` (shared+web+server) → `npm ci --omit=dev` → **distroless `nodejs24-debian12:nonroot`** runtime for minimal CVE surface.
- Node ≥ 23.6 strips TS types natively, which is how the BFF resolves `canopy-shared` (it exports raw `src/index.ts`).
- Layout keeps `/app/server` as workdir so the static plugin's `../web/dist` anchor resolves; `EXPOSE 4000`, node-based `HEALTHCHECK /healthz`, no secrets baked in (`SESSION_SECRET`/`CANOPY_USERS` at runtime; dev-noauth stays production-forbidden).

**Tag & toolchain**
- Ships as `ghcr.io/apache/skywalking-banyandb:<sha>-canopy` — tag suffix via a `NAME=canopy` conditional in `scripts/build/docker.mk`, mirroring the `-slim` pattern.
- `canopy/Makefile` gains `typecheck`, `e2e`, `release`, `docker`, `docker.push` (docker.mk wired mcp-style; image tag `<sha>-canopy`). Root `docker.build`/`docker.push` project lists are intentionally **unchanged** — a `--no-cache` npm build on every Go PR is too heavy a tax; the canopy image is built/pushed from `canopy.yml` instead.

**CI** (`.github/workflows/canopy.yml`)
- `image-build`: builds on PRs (artifact for the test job), pushes dual-arch (`linux/amd64,linux/arm64`) on main.
- `integration-test` (matrix `standalone` / `cluster`): loads the image, resolves the latest published `-testing` BanyanDB image from the upstream repo (fork-proof), with a pinned-sha fallback in the workflow, and runs the tier-1 smoke under docker compose. The cluster leg uses liaison+data with file node discovery (`nodes.yaml`), exercising the distributed dquery paths.

**Smoke** (`canopy/e2e/integration/smoke.sh`) — healthz, production `CANOPY_USERS` bcrypt login, `/api/meta`, SPA markup, schema seeding through the BFF proxy, plus two distributed regression probes with a negative control: TopN query validation (the #1236 bug class) and trace `ORDER BY start_time` index-rule resolution. Idempotent (409-tolerant seeds).

## Test plan

- Local image build (`make -C canopy docker`) + boot: healthz, CANOPY_USERS login, `/api/meta` reachable, SPA 200 — all pass.
- **SMOKE PASS on both topologies locally** (standalone on 4010, liaison+data cluster on 4011), including both regression probes and the negative control.
- YAML/bash syntax validated; license headers present on all new files (the local `license-check` failure is pre-existing `canopy/node_modules` noise, identical on main).
