### PR TITLE
Fix sampling for traces split across blocks

### DIFF
--- a/banyand/trace/finalizer.go
+++ b/banyand/trace/finalizer.go
@@ -156,6 +156,7 @@ func (tst *tsTable) runFinalizeRound(samplers []sdk.Sampler, graceNs int64) (boo
 		owner:       tst,
 		timeout:     tst.option.decideTimeout,
 		stageBudget: stageBudget,
+		traceBudget: resolveTraceBudget(tst.option),
 		forceSlow:   projectionRequiresSlowPath(chain.projection),
 	}
 

--- a/banyand/trace/merger.go
+++ b/banyand/trace/merger.go
@@ -93,6 +93,19 @@ func resolveStageBudget(opt option) uint64 {
 	return stageBudgetFromLimit(limit)
 }
 
+// resolveTraceBudget returns the hard limit on bytes retained for one logical
+// trace evaluation. A trace that exceeds it is retained without reaching the
+// sampler, because a partial trace must never be evaluated. It deliberately
+// uses the same memory-derived value as the aggregate staging budget: the two
+// limits protect different scopes even when their numeric values match.
+func resolveTraceBudget(opt option) uint64 {
+	var limit uint64
+	if opt.protector != nil {
+		limit = opt.protector.GetLimit()
+	}
+	return stageBudgetFromLimit(limit)
+}
+
 // stageBudgetFromLimit derives the per-merge staged-byte budget from the memory
 // limit. With up to cgroups.CPUs() merges staging at once, each merge is allowed
 // memLimit/(stageBudgetAggregateDivisor*CPUs) so the aggregate stays ~memLimit/
@@ -388,6 +401,7 @@ func (tst *tsTable) buildHotMergeFilter(parts []*partWrapper) *mergeFilter {
 		owner:       tst,
 		timeout:     tst.option.decideTimeout,
 		stageBudget: stageBudget,
+		traceBudget: resolveTraceBudget(tst.option),
 		forceSlow:   projectionRequiresSlowPath(chain.projection),
 	}
 }
@@ -852,6 +866,7 @@ type mergeFilter struct {
 	owner       *tsTable
 	timeout     time.Duration
 	stageBudget uint64 // soft cap on staged bytes; a trace-boundary chunk flush fires once exceeded (0 disables chunking)
+	traceBudget uint64 // hard cap on one trace's staged bytes; exceeding it retains the trace without evaluation (0 disables bypass)
 	forceSlow   bool   // forces the slow assembly path when the chain projects row data
 }
 
@@ -944,6 +959,14 @@ func writeStagedKeep(bw *blockWriter, st *stagedTrace) {
 		return
 	}
 	bw.mustWriteBlock(st.traceID, &st.slowBlock.block)
+}
+
+func releaseStagedTrace(st *stagedTrace) {
+	if st.isRaw || st.slowBlock == nil {
+		return
+	}
+	releaseBlockPointer(st.slowBlock)
+	st.slowBlock = nil
 }
 
 type stagedEvaluationBatch struct {
@@ -1064,10 +1087,7 @@ func flushStaged(bw *blockWriter, filter *mergeFilter, staged []stagedTrace, dro
 		} else {
 			writeStagedKeep(bw, &staged[i])
 		}
-		if !staged[i].isRaw && staged[i].slowBlock != nil {
-			releaseBlockPointer(staged[i].slowBlock)
-			staged[i].slowBlock = nil
-		}
+		releaseStagedTrace(&staged[i])
 	}
 }
 
@@ -1083,6 +1103,89 @@ func rawFastPathEligible(filter *mergeFilter, nextB, b *blockPointer) bool {
 		return false
 	}
 	return nextB == nil || nextB.bm.traceID != b.bm.traceID
+}
+
+type traceEvaluationStager struct {
+	bw                *blockWriter
+	filter            *mergeFilter
+	droppedSet        map[string]struct{}
+	lastStagedTraceID string
+	bypassedTraceID   string
+	staged            []stagedTrace
+	stagedBytes       uint64
+	currentTraceBytes uint64
+	currentTraceStart int
+}
+
+func (tes *traceEvaluationStager) flush() {
+	if len(tes.staged) == 0 {
+		return
+	}
+	flushStaged(tes.bw, tes.filter, tes.staged, tes.droppedSet)
+	tes.staged = nil
+	tes.stagedBytes = 0
+	tes.currentTraceBytes = 0
+	tes.currentTraceStart = 0
+}
+
+func (tes *traceEvaluationStager) writeBypassed(bypassed []stagedTrace) {
+	for stagedIdx := range bypassed {
+		writeStagedKeep(tes.bw, &bypassed[stagedIdx])
+		releaseStagedTrace(&bypassed[stagedIdx])
+	}
+}
+
+func (tes *traceEvaluationStager) stage(st stagedTrace) {
+	if tes.bypassedTraceID != "" {
+		if st.traceID == tes.bypassedTraceID {
+			writeStagedKeep(tes.bw, &st)
+			releaseStagedTrace(&st)
+			tes.lastStagedTraceID = ""
+			return
+		}
+		tes.bypassedTraceID = ""
+	}
+	if len(tes.staged) == 0 || st.traceID != tes.lastStagedTraceID {
+		tes.currentTraceStart = len(tes.staged)
+		tes.currentTraceBytes = 0
+	}
+	stagedTraceBytes := st.approxBytes()
+	tes.staged = append(tes.staged, st)
+	tes.stagedBytes += stagedTraceBytes
+	tes.currentTraceBytes += stagedTraceBytes
+	tes.lastStagedTraceID = st.traceID
+	if tes.filter.traceBudget == 0 || tes.currentTraceBytes <= tes.filter.traceBudget {
+		return
+	}
+	if tes.currentTraceStart > 0 {
+		flushStaged(tes.bw, tes.filter, tes.staged[:tes.currentTraceStart], tes.droppedSet)
+	}
+	tes.writeBypassed(tes.staged[tes.currentTraceStart:])
+	tes.bypassedTraceID = st.traceID
+	tes.lastStagedTraceID = ""
+	tes.staged = nil
+	tes.stagedBytes = 0
+	tes.currentTraceBytes = 0
+	tes.currentTraceStart = 0
+	if tes.filter.owner != nil {
+		tes.filter.owner.incPipelineOversizedTracesBypassed(1)
+	}
+}
+
+func (tes *traceEvaluationStager) flushBefore(nextTraceID string, pendingBlock *blockPointer, pendingBlockIsEmpty bool) {
+	if tes.filter.stageBudget == 0 || tes.stagedBytes < tes.filter.stageBudget || len(tes.staged) == 0 || nextTraceID == tes.lastStagedTraceID {
+		return
+	}
+	pendingCompletesStagedTrace := !pendingBlockIsEmpty && pendingBlock.bm.traceID == tes.lastStagedTraceID
+	if !pendingCompletesStagedTrace {
+		tes.flush()
+	}
+}
+
+func (tes *traceEvaluationStager) flushAfter(completedTraceID, nextTraceID string) {
+	if tes.filter.stageBudget > 0 && tes.stagedBytes >= tes.filter.stageBudget && completedTraceID != nextTraceID {
+		tes.flush()
+	}
 }
 
 func mergeBlocks(closeCh <-chan struct{}, bw *blockWriter, br *blockReader, conflictTags map[string]struct{},
@@ -1114,29 +1217,15 @@ func mergeBlocks(closeCh <-chan struct{}, bw *blockWriter, br *blockReader, conf
 		br.mustReadRaw(&rawBlk, bm)
 		renameRawConflictTags(&rawBlk, conflictTags)
 	}
-	var staged []stagedTrace
-	var stagedBytes uint64
-	var lastStagedTraceID string
 	var droppedSet map[string]struct{}
+	var evaluationStager *traceEvaluationStager
 	if filter != nil {
 		droppedSet = make(map[string]struct{})
-	}
-	stage := func(st stagedTrace) {
-		staged = append(staged, st)
-		stagedBytes += st.approxBytes()
-		lastStagedTraceID = st.traceID
-	}
-	// flushChunk decides + writes the currently staged traces, then frees them.
-	// It is invoked at trace boundaries once stagedBytes exceeds stageBudget, and
-	// once more at end-of-merge for the remainder. droppedSet accumulates across
-	// chunks so the downstream sidx pruning still sees every dropped trace id.
-	flushChunk := func() {
-		if len(staged) == 0 {
-			return
+		evaluationStager = &traceEvaluationStager{
+			bw:         bw,
+			filter:     filter,
+			droppedSet: droppedSet,
 		}
-		flushStaged(bw, filter, staged, droppedSet)
-		staged = nil
-		stagedBytes = 0
 	}
 	// writeRawBlock writes the just-read rawBlk. When the hook is inactive it
 	// writes immediately (byte-identical to the legacy path). When active the
@@ -1148,7 +1237,7 @@ func mergeBlocks(closeCh <-chan struct{}, bw *blockWriter, br *blockReader, conf
 			bw.mustWriteRawBlock(&rawBlk)
 			return
 		}
-		stage(stageRawTrace(&rawBlk))
+		evaluationStager.stage(stageRawTrace(&rawBlk))
 	}
 	// writeSlowBlock writes (or, on the active hook path, stages) an accumulated
 	// slow-path block.
@@ -1162,7 +1251,7 @@ func mergeBlocks(closeCh <-chan struct{}, bw *blockWriter, br *blockReader, conf
 		// copyFrom copies slice headers only; the bytes alias the decoder's
 		// internal buffer which is reset when the next trace is loaded.
 		newBP.block.deepCopyValues()
-		stage(stagedTrace{
+		evaluationStager.stage(stagedTrace{
 			traceID:   bp.bm.traceID,
 			slowBlock: newBP,
 		})
@@ -1177,14 +1266,12 @@ func mergeBlocks(closeCh <-chan struct{}, bw *blockWriter, br *blockReader, conf
 		// Bounded staging: at a trace boundary (the current block belongs to a
 		// different traceID than the last staged one), once staged bytes exceed
 		// the budget, decide+write the accumulated chunk before reading further.
-		// The boundary guard guarantees a trace's blocks are never split across
-		// chunks, so each trace stays a single Decide unit and the chunk write
-		// order remains ascending. A single trace larger than the budget is still
-		// held whole (a trace is an indivisible decision), so the cap is a soft
-		// per-merge bound, not a hard ceiling.
-		if filter != nil && filter.stageBudget > 0 && stagedBytes >= filter.stageBudget &&
-			len(staged) > 0 && b.bm.traceID != lastStagedTraceID {
-			flushChunk()
+		// A pending output block may still complete the last staged trace even
+		// after the source reader advances to a new trace ID. Do not flush until
+		// that pending block is staged. The separate per-trace budget fails open
+		// and streams an oversized trace without sending a partial trace to Decide.
+		if evaluationStager != nil {
+			evaluationStager.flushBefore(b.bm.traceID, pendingBlock, pendingBlockIsEmpty)
 		}
 		// Fast path: if this is the only block for this traceID AND we have no pending block,
 		// copy it raw without unmarshaling
@@ -1204,9 +1291,14 @@ func mergeBlocks(closeCh <-chan struct{}, bw *blockWriter, br *blockReader, conf
 		}
 
 		if pendingBlock.bm.traceID != b.bm.traceID || pendingBlock.block.spanSize() >= maxUncompressedSpanSize {
+			pendingTraceID := pendingBlock.bm.traceID
 			writeSlowBlock(pendingBlock)
 			releaseDecoder()
 			pendingBlock.reset()
+			pendingBlockIsEmpty = true
+			if evaluationStager != nil {
+				evaluationStager.flushAfter(pendingTraceID, b.bm.traceID)
+			}
 			// After writing the pending block, check if the new block can be copied raw
 			// This is the same fast path check as at the beginning of the loop
 			nextB = br.peek()
@@ -1251,8 +1343,8 @@ func mergeBlocks(closeCh <-chan struct{}, bw *blockWriter, br *blockReader, conf
 		writeSlowBlock(pendingBlock)
 	}
 	releaseDecoder()
-	if filter != nil {
-		flushChunk()
+	if evaluationStager != nil {
+		evaluationStager.flush()
 	}
 	var pm partMetadata
 	var tf traceIDFilter

--- a/banyand/trace/metrics.go
+++ b/banyand/trace/metrics.go
@@ -71,6 +71,7 @@ type metrics struct {
 	pipelineTracesDropped            meter.Counter
 	pipelineTracesRetained           meter.Counter
 	pipelineTracesImmature           meter.Counter
+	pipelineOversizedTracesBypassed  meter.Counter
 	pipelinePluginErrors             meter.Counter
 	pipelineAmbiguous                meter.Counter
 	pipelineSidxPruned               meter.Counter
@@ -309,6 +310,14 @@ func (tst *tsTable) incPipelineTracesImmature(delta int) {
 }
 
 //nolint:unused
+func (tst *tsTable) incPipelineOversizedTracesBypassed(delta int) {
+	if tst == nil || tst.metrics == nil {
+		return
+	}
+	tst.metrics.pipelineOversizedTracesBypassed.Inc(float64(delta))
+}
+
+//nolint:unused
 func (tst *tsTable) incPipelinePluginErrors(delta int, reason string) {
 	if tst == nil || tst.metrics == nil {
 		return
@@ -438,6 +447,7 @@ func (m *metrics) DeleteAll() {
 	m.pipelineTracesDropped.Delete()
 	m.pipelineTracesRetained.Delete()
 	m.pipelineTracesImmature.Delete()
+	m.pipelineOversizedTracesBypassed.Delete()
 	m.pipelineAmbiguous.Delete()
 	m.pipelineSidxPruned.Delete()
 	m.pipelineGuardBloomProbes.Delete()
@@ -482,6 +492,7 @@ func (s *supplier) newMetrics(p common.Position) storage.Metrics {
 		pipelineTracesDropped:            factory.NewCounter("pipeline_traces_dropped"),
 		pipelineTracesRetained:           factory.NewCounter("pipeline_traces_retained"),
 		pipelineTracesImmature:           factory.NewCounter("pipeline_traces_immature"),
+		pipelineOversizedTracesBypassed:  factory.NewCounter("pipeline_oversized_traces_bypassed"),
 		pipelinePluginErrors:             factory.NewCounter("pipeline_plugin_errors", "reason"),
 		pipelineAmbiguous:                factory.NewCounter("pipeline_ambiguous"),
 		pipelineSidxPruned:               factory.NewCounter("pipeline_sidx_pruned"),
@@ -542,6 +553,7 @@ func (qs *queueSupplier) newMetrics(p common.Position) (storage.Metrics, observa
 		pipelineTracesDropped:            factory.NewCounter("pipeline_traces_dropped"),
 		pipelineTracesRetained:           factory.NewCounter("pipeline_traces_retained"),
 		pipelineTracesImmature:           factory.NewCounter("pipeline_traces_immature"),
+		pipelineOversizedTracesBypassed:  factory.NewCounter("pipeline_oversized_traces_bypassed"),
 		pipelinePluginErrors:             factory.NewCounter("pipeline_plugin_errors", "reason"),
 		pipelineAmbiguous:                factory.NewCounter("pipeline_ambiguous"),
 		pipelineSidxPruned:               factory.NewCounter("pipeline_sidx_pruned"),

--- a/banyand/trace/pipeline_chain_test.go
+++ b/banyand/trace/pipeline_chain_test.go
@@ -19,6 +19,7 @@ package trace
 
 import (
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -40,6 +41,65 @@ type fakeSampler struct {
 	panicNow  bool
 	errNow    bool
 	wrongSize bool
+}
+
+type wholeTraceErrorSampler struct {
+	calls      atomic.Int64
+	traceCount atomic.Int64
+	rowCount   atomic.Int64
+}
+
+type durationEnvelopeSampler struct {
+	threshold int64
+	calls     atomic.Int64
+	minTS     atomic.Int64
+	maxTS     atomic.Int64
+}
+
+func (s *durationEnvelopeSampler) Kind() sdk.Kind          { return sdk.KindSampler }
+func (s *durationEnvelopeSampler) Project() sdk.Projection { return sdk.Projection{} }
+func (s *durationEnvelopeSampler) Close() error            { return nil }
+
+func (s *durationEnvelopeSampler) Decide(batch *sdk.TraceBatch) (sdk.Verdict, error) {
+	s.calls.Add(1)
+	keep := make([]bool, len(batch.Traces))
+	for traceIdx := range batch.Traces {
+		traceBlock := &batch.Traces[traceIdx]
+		s.minTS.Store(traceBlock.MinTS)
+		s.maxTS.Store(traceBlock.MaxTS)
+		keep[traceIdx] = traceBlock.MaxTS-traceBlock.MinTS >= s.threshold
+	}
+	return sdk.Verdict{Keep: keep}, nil
+}
+
+func (s *wholeTraceErrorSampler) Kind() sdk.Kind { return sdk.KindSampler }
+
+func (s *wholeTraceErrorSampler) Project() sdk.Projection {
+	return sdk.Projection{Tags: []string{"status"}}
+}
+
+func (s *wholeTraceErrorSampler) Close() error { return nil }
+
+func (s *wholeTraceErrorSampler) Decide(batch *sdk.TraceBatch) (sdk.Verdict, error) {
+	s.calls.Add(1)
+	s.traceCount.Add(int64(len(batch.Traces)))
+	keep := make([]bool, len(batch.Traces))
+	for traceIdx := range batch.Traces {
+		traceBlock := &batch.Traces[traceIdx]
+		s.rowCount.Add(int64(traceBlock.Len()))
+		statusColumn := traceBlock.Tag("status")
+		if statusColumn == nil {
+			continue
+		}
+		for rowIdx := 0; rowIdx < traceBlock.Len(); rowIdx++ {
+			statusValue, statusErr := statusColumn.At(rowIdx)
+			if statusErr == nil && !statusValue.IsNull() && statusValue.Str() == "error" {
+				keep[traceIdx] = true
+				break
+			}
+		}
+	}
+	return sdk.Verdict{Keep: keep}, nil
 }
 
 func (f *fakeSampler) Kind() sdk.Kind          { return sdk.KindSampler }
@@ -142,6 +202,158 @@ func singleTraceParts(ids []string) []*traces {
 		})
 	}
 	return parts
+}
+
+func splitTraceParts(tailStatus string) []*traces {
+	const traceID = "trace-large"
+	largeSpan := make([]byte, maxUncompressedSpanSize)
+	return []*traces{{
+		traceIDs:   []string{traceID, traceID},
+		timestamps: []int64{int64(100 * time.Millisecond), int64(10 * time.Second)},
+		tags: [][]*tagValue{
+			{{tag: "status", valueType: pbv1.ValueTypeStr, value: convert.StringToBytes("success")}},
+			{{tag: "status", valueType: pbv1.ValueTypeStr, value: convert.StringToBytes(tailStatus)}},
+		},
+		spans:   [][]byte{largeSpan, []byte("tail-span")},
+		spanIDs: []string{"head-span", "tail-span"},
+	}}
+}
+
+func multiBlockOversizedTraceParts() []*traces {
+	parts := splitTraceParts("success")
+	parts[0].spans[1] = make([]byte, maxUncompressedSpanSize)
+	return parts
+}
+
+func appendTrace(parts []*traces, traceID, status string) []*traces {
+	parts[0].traceIDs = append(parts[0].traceIDs, traceID)
+	parts[0].timestamps = append(parts[0].timestamps, int64(20*time.Second))
+	parts[0].tags = append(parts[0].tags, []*tagValue{{tag: "status", valueType: pbv1.ValueTypeStr, value: convert.StringToBytes(status)}})
+	parts[0].spans = append(parts[0].spans, []byte("span-"+traceID))
+	parts[0].spanIDs = append(parts[0].spanIDs, "span-"+traceID)
+	return parts
+}
+
+func TestMergeFilter_AssemblesEveryPhysicalBlockBeforeDecide(t *testing.T) {
+	sampler := &wholeTraceErrorSampler{}
+	chain := newMergeChain("g", "s", []sdk.Sampler{sampler}, 0)
+	filter := &mergeFilter{
+		chain:       chain,
+		timeout:     time.Second,
+		stageBudget: 1,
+		forceSlow:   true,
+	}
+
+	parts := appendTrace(splitTraceParts("error"), "trace-next", "success")
+	got, dropped := mergeWithFilter(t, parts, filter)
+
+	require.Equal(t, []string{"trace-large", "trace-large"}, got,
+		"error evidence in the second physical block must retain every block")
+	require.NotContains(t, dropped, "trace-large")
+	require.Contains(t, dropped, "trace-next")
+	require.Equal(t, int64(2), sampler.calls.Load(), "the tiny stage budget may flush only at complete trace boundaries")
+	require.Equal(t, int64(2), sampler.traceCount.Load(), "each trace ID must appear exactly once across Decide batches")
+	require.Equal(t, int64(3), sampler.rowCount.Load(), "the logical traces must contain every physical row")
+}
+
+func TestMergeFilter_AggregatesSplitTraceTimestampEnvelope(t *testing.T) {
+	sampler := &durationEnvelopeSampler{threshold: int64(5 * time.Second)}
+	chain := newMergeChain("g", "s", []sdk.Sampler{sampler}, 0)
+	filter := &mergeFilter{chain: chain, timeout: time.Second}
+
+	got, dropped := mergeWithFilter(t, splitTraceParts("success"), filter)
+
+	require.Equal(t, []string{"trace-large", "trace-large"}, got)
+	require.Empty(t, dropped)
+	require.Equal(t, int64(1), sampler.calls.Load())
+	require.Equal(t, int64(100*time.Millisecond), sampler.minTS.Load())
+	require.Equal(t, int64(10*time.Second), sampler.maxTS.Load())
+}
+
+func TestMergeFilter_DropsEveryPhysicalBlockOfLogicalTrace(t *testing.T) {
+	sampler := &wholeTraceErrorSampler{}
+	chain := newMergeChain("g", "s", []sdk.Sampler{sampler}, 0)
+	filter := &mergeFilter{chain: chain, timeout: time.Second, forceSlow: true}
+
+	got, dropped := mergeWithFilter(t, splitTraceParts("success"), filter)
+
+	require.Empty(t, got, "one logical drop verdict must remove every physical block")
+	require.Contains(t, dropped, "trace-large")
+	require.Equal(t, int64(1), sampler.calls.Load())
+	require.Equal(t, int64(1), sampler.traceCount.Load())
+	require.Equal(t, int64(2), sampler.rowCount.Load())
+}
+
+func TestMergeFilter_OversizedTraceBypassesPartialEvaluation(t *testing.T) {
+	sampler := &wholeTraceErrorSampler{}
+	chain := newMergeChain("g", "s", []sdk.Sampler{sampler}, 0)
+	filter := &mergeFilter{
+		chain:       chain,
+		timeout:     time.Second,
+		traceBudget: maxUncompressedSpanSize / 2,
+		forceSlow:   true,
+	}
+
+	parts := appendTrace(splitTraceParts("success"), "trace-next", "error")
+	got, dropped := mergeWithFilter(t, parts, filter)
+
+	require.Equal(t, []string{"trace-large", "trace-large", "trace-next"}, got,
+		"an oversized trace must fail open instead of being partially evaluated")
+	require.Empty(t, dropped)
+	require.Equal(t, int64(1), sampler.calls.Load(), "only the following bounded trace may reach Decide")
+	require.Equal(t, int64(1), sampler.traceCount.Load())
+	require.Equal(t, int64(1), sampler.rowCount.Load())
+}
+
+func TestTraceEvaluationStager_ExactBudgetDoesNotBypass(t *testing.T) {
+	stagedTraceBlock := stagedTrace{
+		isRaw:    true,
+		traceID:  "trace-exact",
+		rawSpans: []byte("exact-budget"),
+	}
+	exactBudget := stagedTraceBlock.approxBytes()
+	stager := &traceEvaluationStager{
+		filter: &mergeFilter{traceBudget: exactBudget},
+	}
+
+	stager.stage(stagedTraceBlock)
+
+	require.Len(t, stager.staged, 1)
+	require.Equal(t, exactBudget, stager.currentTraceBytes)
+	require.Empty(t, stager.bypassedTraceID)
+}
+
+func TestMergeFilter_RawOversizedTracesBypassEvaluationInOrder(t *testing.T) {
+	sampler := &durationEnvelopeSampler{threshold: int64(time.Hour)}
+	chain := newMergeChain("g", "s", []sdk.Sampler{sampler}, 0)
+	filter := &mergeFilter{
+		chain:       chain,
+		timeout:     time.Second,
+		traceBudget: 1,
+	}
+
+	got, dropped := mergeWithFilter(t, singleTraceParts([]string{"trace-a", "trace-b"}), filter)
+
+	require.Equal(t, []string{"trace-a", "trace-b"}, got)
+	require.Empty(t, dropped)
+	require.Zero(t, sampler.calls.Load(), "raw oversized traces must bypass Decide")
+}
+
+func TestMergeFilter_MultiBlockOversizedTraceAtEOFBypassesAsUnit(t *testing.T) {
+	sampler := &wholeTraceErrorSampler{}
+	chain := newMergeChain("g", "s", []sdk.Sampler{sampler}, 0)
+	filter := &mergeFilter{
+		chain:       chain,
+		timeout:     time.Second,
+		traceBudget: maxUncompressedSpanSize + maxUncompressedSpanSize/2,
+		forceSlow:   true,
+	}
+
+	got, dropped := mergeWithFilter(t, multiBlockOversizedTraceParts(), filter)
+
+	require.Equal(t, []string{"trace-large", "trace-large"}, got)
+	require.Empty(t, dropped)
+	require.Zero(t, sampler.calls.Load(), "the accumulated oversized trace must never partially reach Decide")
 }
 
 func TestMergeFilter_DropMatureTrace(t *testing.T) {


### PR DESCRIPTION
## Summary

- assemble every physical block for a trace ID into one logical sampler input
- defer stage-budget flushes until any pending block for the current trace has been staged
- retain oversized traces without evaluating a partial trace, with a dedicated bypass metric
- apply the same per-trace budget to merge and finalization paths
- add regression coverage for real traces split by the 2 MiB block threshold, atomic keep/drop decisions, timestamp aggregation, raw bypass, EOF, and budget boundaries

## Root cause

A trace larger than the physical block size limit can produce multiple blocks with the same trace ID. Although the sampler SDK promises one logical block per trace ID, a staging-budget flush could evaluate already staged blocks before the final pending block of that trace was included. The resulting verdict was based on a trace prefix and could incorrectly drop an error or slow trace.

The merge path now treats a trace ID as an indivisible evaluation unit. Oversized logical traces fail open instead of sending a partial trace to `Decide`.

## Validation

- `make pre-push`
- focused whole-trace regression tests under the race detector
- full `go test ./banyand/trace -count=1`

Fixes apache/skywalking#13962
