### PR TITLE
Fix flaky TestTraceWriteRoundTrip by stopping modules before reading trace parts

### DIFF
--- a/banyand/internal/dump/trace/suite_test.go
+++ b/banyand/internal/dump/trace/suite_test.go
@@ -23,6 +23,7 @@ import (
 	"io/fs"
 	"path/filepath"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -84,8 +85,8 @@ func TestTraceWriteRoundTrip(t *testing.T) {
 		"--trace-root-path=" + rootPath,
 		"--trace-flush-timeout=200ms",
 	}
-	moduleDefer := test.SetupModules(flags, pipeline, metaSvc, traceSvc)
-	defer moduleDefer()
+	stopModules := sync.OnceFunc(test.SetupModules(flags, pipeline, metaSvc, traceSvc))
+	defer stopModules()
 
 	registerRoundTripTrace(t, metaSvc)
 	require.Eventually(t, func() bool {
@@ -139,6 +140,7 @@ func TestTraceWriteRoundTrip(t *testing.T) {
 		req.NoError(errPub)
 	}
 	req.Empty(bp.Close())
+	stopModules()
 
 	var partDirs []string
 	require.Eventually(t, func() bool {


### PR DESCRIPTION
## Summary

`TestTraceWriteRoundTrip` intermittently opened a trace part as soon as `metadata.json` appeared, while the trace service could still flush or merge the part. That allowed the dump reader to combine metadata and data from different file generations and panic on an invalid byte-block type.

The test now stops the modules after publishing and before discovering or reading part directories. Cleanup is guarded with `sync.OnceFunc`, preserving deferred cleanup on early failures while making shutdown the explicit flush/quiescence barrier.

No timeout, polling window, sleep, retry, skip, or assertion was changed. The fixed test passed 50 race-enabled executions in five batches with `GOMAXPROCS=4`, plus a final race-enabled smoke check after restoring the fix.

Measure and stream round-trip tests were left unchanged because the reported failure and exact local reproduction were trace-specific.

Flaky-Test: github.com/apache/skywalking-banyandb/banyand/internal/dump/trace.TestTraceWriteRoundTrip
