### PR TITLE
Fix flaky Canopy auth session test by mocking version probe

### DIFF
--- a/canopy/server/test/bff.test.ts
+++ b/canopy/server/test/bff.test.ts
@@ -25,7 +25,7 @@ import { registerProxy } from '../src/plugins/proxy.js';
 import { registerStatic } from '../src/plugins/static.js';
 import type { Config } from '../src/config.js';
 import bcrypt from 'bcryptjs';
-import { MockAgent, setGlobalDispatcher } from 'undici';
+import { getGlobalDispatcher, MockAgent, setGlobalDispatcher } from 'undici';
 
 // Mock DNS so SSRF check passes for test hostnames (no real DNS in unit tests)
 vi.mock('node:dns/promises', () => ({
@@ -88,9 +88,25 @@ async function loginAs(app: FastifyInstance, username: string, password: string)
 
 describe('Auth routes', () => {
   let app: FastifyInstance;
+  let mockAgent: MockAgent;
+  let previousDispatcher: ReturnType<typeof getGlobalDispatcher>;
 
-  beforeEach(async () => { app = await buildTestApp(); });
-  afterEach(async () => { await app.close(); });
+  beforeEach(async () => {
+    previousDispatcher = getGlobalDispatcher();
+    mockAgent = new MockAgent();
+    mockAgent.disableNetConnect();
+    setGlobalDispatcher(mockAgent);
+    mockAgent.get('http://upstream-a.test:17913')
+      .intercept({ path: '/api/v1/common/api/version', method: 'GET' })
+      .reply(200, { version: { version: 'test-version' } });
+    app = await buildTestApp();
+  });
+
+  afterEach(async () => {
+    await app.close();
+    setGlobalDispatcher(previousDispatcher);
+    await mockAgent.close();
+  });
 
   it('POST /auth/login with valid credentials sets session', async () => {
     const res = await app.inject({


### PR DESCRIPTION
## Summary

Make the Canopy Auth route tests independent of external network timing by serving the login-time BanyanDB version probe through a test-owned Undici mock. Restore the previous global dispatcher after each test so the mock remains scoped to the Auth suite.

## Verification

- Ran the Canopy server suite 20 times successfully.
- Ran server lint and type checking.
- Ran repository lint, license, format, and tidy checks.

Flaky-Test: canopy-server.Auth routes > GET /auth/session returns user info when authenticated
