### PR TITLE
Fix flaky pool discard test without relying on reuse

### DIFF
--- a/pkg/pool/pool_test.go
+++ b/pkg/pool/pool_test.go
@@ -36,12 +36,7 @@ func TestSyncedDiscardBalancesCheckoutWithoutPooling(t *testing.T) {
 	value := testPool.Get()
 	require.Nil(t, value)
 	require.Equal(t, 1, testPool.RefsCount())
-	testPool.Put(new(int))
-	require.Zero(t, testPool.RefsCount())
-
-	reused := testPool.Get()
-	require.NotNil(t, reused)
-	testPool.Discard(reused)
+	testPool.Discard(new(int))
 
 	require.Zero(t, testPool.RefsCount())
 	require.Nil(t, testPool.Get(), "discarded objects must not be returned by the pool")


### PR DESCRIPTION
## Summary

`TestSyncedDiscardBalancesCheckoutWithoutPooling` assumed that an object put into `sync.Pool` would necessarily be returned by the next `Get`. The runtime may discard pooled objects at any time, so that setup could legitimately produce `nil`.

Exercise `Discard` directly on the caller-created replacement for an empty checkout. This preserves the test's reference-count and non-retention coverage without depending on nondeterministic pool reuse.

Flaky-Test: github.com/apache/skywalking-banyandb/pkg/pool.TestSyncedDiscardBalancesCheckoutWithoutPooling

## Testing

- 250 race-enabled iterations of the targeted test across five batches
- `make lint`
- `make check` (license, format, and tidy passed; the final dirty-tree guard reported the intended test-file change)

No production behavior is changed.
