### PR TITLE
ci: reduce pull request feedback time

### DIFF
--- a/.github/actions/build-docker-image/action.yml
+++ b/.github/actions/build-docker-image/action.yml
@@ -35,16 +35,20 @@ runs:
   steps:
     - name: Build binary
       shell: bash
-      run: make release
+      run: |
+        make -C banyand banyand-server-static banyand-lifecycle-static
+        make -C bydbctl bydbctl-cli-static
 
     - name: Build docker image
-      shell: bash
-      run: |
-        make -C test/docker build
-        docker image ls
-      env:
-        TAG: ${{ inputs.tag }}
-        HUB: ${{ inputs.hub }}
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
+      with:
+        context: .
+        file: test/docker/Dockerfile
+        load: true
+        tags: ${{ inputs.hub }}/skywalking-banyandb:${{ inputs.tag }}-testing
+        provenance: false
+        cache-from: type=gha,scope=banyandb-testing-${{ runner.arch }}
+        cache-to: type=gha,mode=max,scope=banyandb-testing-${{ runner.arch }},ignore-error=true
 
     - name: Package docker image
       shell: bash

--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -26,6 +26,14 @@ inputs:
     description: 'Whether to setup Docker Buildx'
     required: false
     default: 'false'
+  setup-node:
+    description: 'Whether to setup Node.js'
+    required: false
+    default: 'true'
+  setup-qemu:
+    description: 'Whether to setup QEMU when Docker is enabled'
+    required: false
+    default: 'true'
 
 runs:
   using: composite
@@ -37,6 +45,7 @@ runs:
         name: build-artifacts
 
     - name: Setup Node.js
+      if: inputs.setup-node == 'true'
       uses: actions/setup-node@v6
       with:
         node-version: 24.6.0
@@ -60,7 +69,7 @@ runs:
       run: echo "GOTOOLCHAIN=auto" >> "$GITHUB_ENV"
 
     - name: Set up QEMU
-      if: inputs.setup-docker == 'true'
+      if: inputs.setup-docker == 'true' && inputs.setup-qemu == 'true'
       uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
 
     - name: Set up Docker Buildx

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,10 @@ on:
 env:
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5
 
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   prepare:
     name: Prepare (Generate)
@@ -54,11 +58,11 @@ jobs:
         id: cache-tool
         with:
           path: bin
-          key: ${{ runner.os }}-generate-tool-${{ hashFiles('**/version.mk') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-generate-tool-${{ hashFiles('scripts/build/version.mk') }}
       - name: npm ci and format
         run: |
+          make -C ui install
           cd ui
-          npm ci
           npm run format
           cd ../
       - name: Run consistency check
@@ -88,7 +92,7 @@ jobs:
       - name: Generate dependencies licenses
         run: make license-dep
       - name: Check
-        run: make check
+        run: make check-format
   vuln-check:
     name: Vulnerability Scan
     runs-on: ubuntu-latest
@@ -100,18 +104,19 @@ jobs:
         uses: ./.github/actions/setup-build-env
         with:
           download-artifacts: 'true'
+          setup-node: 'false'
           setup-docker: 'false'
       - name: Cache Tools
         uses: actions/cache@v4
         with:
           path: bin
-          key: ${{ runner.os }}-generate-tool-${{ hashFiles('**/version.mk') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-vuln-tool-${{ hashFiles('scripts/build/version.mk') }}
       - name: Run govulncheck (stdlib + dependency CVEs)
         run: make vuln-check
   detect_fodc_e2e_changes:
     name: Detect FODC E2E Changes
     runs-on: ubuntu-latest
-    needs: [check]
+    needs: [prepare]
     outputs:
       should_run: ${{ steps.filter.outputs.should_run }}
     steps:
@@ -147,43 +152,53 @@ jobs:
           echo "should_run=${should_run}" >> "${GITHUB_OUTPUT}"
   test-banyand:
     name: Test Banyand
-    needs: [check]
+    needs: [prepare]
     uses: ./.github/workflows/test-banyand.yml
   test-bydbctl:
     name: Test Bydbctl
-    needs: [check]
+    needs: [prepare]
     uses: ./.github/workflows/test-bydbctl.yml
   test-fodc:
     name: Test FODC
-    needs: [check]
+    needs: [prepare]
     uses: ./.github/workflows/test-fodc.yml
   test-fodc-e2e:
     name: Test FODC E2E
-    needs: [check, detect_fodc_e2e_changes]
+    needs: [prepare, detect_fodc_e2e_changes]
     uses: ./.github/workflows/test-fodc-e2e.yml
     with:
       should_run: ${{ github.event_name != 'pull_request' || needs.detect_fodc_e2e_changes.outputs.should_run == 'true' }}
   test-pkg:
     name: Test Pkg
-    needs: [check]
+    needs: [prepare]
     uses: ./.github/workflows/test-pkg.yml
   test-integration-standalone:
     name: Test Integration Standalone
-    needs: [check]
+    needs: [prepare]
     uses: ./.github/workflows/test-integration-standalone.yml
   test-integration-distributed:
     name: Test Integration Distributed
-    needs: [check]
+    needs: [prepare]
     uses: ./.github/workflows/test-integration-distributed.yml
   e2e:
     name: E2E Tests
-    needs: [check]
+    needs: [prepare]
     uses: ./.github/workflows/e2e.yml
 
   result:
     name: Continuous Integration
     runs-on: ubuntu-24.04
     needs:
-      [vuln-check, detect_fodc_e2e_changes, test-banyand, test-bydbctl, test-fodc, test-fodc-e2e, test-pkg, test-integration-standalone, test-integration-distributed, e2e]
+      - check
+      - vuln-check
+      - detect_fodc_e2e_changes
+      - test-banyand
+      - test-bydbctl
+      - test-fodc
+      - test-fodc-e2e
+      - test-pkg
+      - test-integration-standalone
+      - test-integration-distributed
+      - e2e
     steps:
       - run: echo 'success'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,7 +41,9 @@ jobs:
         uses: ./.github/actions/setup-build-env
         with:
           download-artifacts: 'true'
+          setup-node: 'false'
           setup-docker: 'true'
+          setup-qemu: 'false'
       - name: Build and upload docker image
         uses: ./.github/actions/build-docker-image
         with:
@@ -95,14 +97,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-tags: true
       - name: Load env
         run: grep -v '^#' test/e2e-v2/script/env >> "$GITHUB_ENV"
       - name: Setup build environment
         uses: ./.github/actions/setup-build-env
         with:
-          download-artifacts: 'true'
+          download-artifacts: 'false'
+          setup-node: 'false'
           setup-docker: 'false'
       - name: Download docker image artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/prepare.yml
+++ b/.github/workflows/prepare.yml
@@ -33,7 +33,7 @@ jobs:
         id: cache-tool
         with:
           path: bin
-          key: ${{ runner.os }}-generate-tool-${{ hashFiles('**/version.mk') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-generate-tool-${{ hashFiles('scripts/build/version.mk') }}
       - uses: actions/setup-node@v6
         with:
           node-version: 24.6.0
@@ -49,11 +49,7 @@ jobs:
       - name: Generate codes
         run: make generate
       - name: Build UI
-        run: |
-          cd ui
-          npm ci
-          npm run build
-          cd ..
+        run: make -C ui build
       - name: Upload generated files
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/test-fodc-e2e.yml
+++ b/.github/workflows/test-fodc-e2e.yml
@@ -58,7 +58,9 @@ jobs:
         uses: ./.github/actions/setup-build-env
         with:
           download-artifacts: 'true'
+          setup-node: 'false'
           setup-docker: 'true'
+          setup-qemu: 'false'
 
       - name: Install kubectl
         run: |
@@ -167,7 +169,9 @@ jobs:
         uses: ./.github/actions/setup-build-env
         with:
           download-artifacts: 'true'
+          setup-node: 'false'
           setup-docker: 'true'
+          setup-qemu: 'false'
 
       - name: Build BanyanDB image
         run: |

--- a/.github/workflows/test-integration-distributed.yml
+++ b/.github/workflows/test-integration-distributed.yml
@@ -22,14 +22,24 @@ on:
 jobs:
   test-integration-distributed:
     strategy:
+      fail-fast: false
       matrix:
         tz: ["UTC", "America/Los_Angeles"]
+        lane:
+          - name: Query
+            pkg: ./test/integration/distributed/query/... ./test/integration/distributed/querybench/...
+            extra-options: ''
+          - name: Multi Segments
+            pkg: ./test/integration/distributed/multi_segments/...
+            extra-options: ''
+          - name: Remainder
+            pkg: ./test/integration/distributed/...
+            extra-options: --skip-package=/query,/multi_segments
     uses: ./.github/workflows/test.yml
     with:
-      test-name: Integration Distributed
-      options: --vv --fail-fast --label-filter \\!slow
+      test-name: Integration Distributed - ${{ matrix.lane.name }}
+      options: --vv --fail-fast --label-filter \\!slow ${{ matrix.lane.extra-options }}
       timeout-minutes: 60
-      pkg: ./test/integration/distributed/...
+      pkg: ${{ matrix.lane.pkg }}
       coverage-flag: integration-distributed
       timezone: ${{ matrix.tz }}
-

--- a/.github/workflows/test-integration-standalone.yml
+++ b/.github/workflows/test-integration-standalone.yml
@@ -22,14 +22,24 @@ on:
 jobs:
   test-integration-standalone:
     strategy:
+      fail-fast: false
       matrix:
         tz: ["UTC", "America/Los_Angeles"]
+        lane:
+          - name: Query
+            pkg: ./test/integration/standalone/query/...
+            extra-options: ''
+          - name: Multi Segments
+            pkg: ./test/integration/standalone/multi_segments/...
+            extra-options: ''
+          - name: Remainder
+            pkg: ./test/integration/standalone/...
+            extra-options: --skip-package=/query,/multi_segments
     uses: ./.github/workflows/test.yml
     with:
-      test-name: Integration Standalone
-      options: --vv --fail-fast --label-filter \\!slow
+      test-name: Integration Standalone - ${{ matrix.lane.name }}
+      options: --vv --fail-fast --label-filter \\!slow ${{ matrix.lane.extra-options }}
       timeout-minutes: 60
-      pkg: ./test/integration/standalone/...
+      pkg: ${{ matrix.lane.pkg }}
       coverage-flag: integration-standalone
       timezone: ${{ matrix.tz }}
-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,21 +54,20 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-tags: true
       - name: Set timezone
         run: sudo timedatectl set-timezone ${{ inputs.timezone || 'UTC' }}
       - name: Setup build environment
         uses: ./.github/actions/setup-build-env
         with:
           download-artifacts: 'true'
+          setup-node: 'false'
           setup-docker: 'false'
       - name: Cache tools
         uses: actions/cache@v4
         id: cache-tool
         with:
           path: bin
-          key: ${{ runner.os }}-test-tool-${{ hashFiles('**version.mk') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-test-tool-${{ hashFiles('scripts/build/version.mk') }}
       - name: Test integration and banyand
         env:
           LOAD_TEST_MINUTES: ${{ inputs.load-test-minutes }}

--- a/Makefile
+++ b/Makefile
@@ -274,10 +274,8 @@ include scripts/build/vuln.mk
 vuln-check: $(GOVULNCHECK)
 	$(GOVULNCHECK) -show color,verbose ./...	
 
-check: ## Check that the status is consistent with CI
-	$(MAKE) license-check
+check-format: ## Check that generated and formatted files are consistent with CI
 	$(MAKE) format
-	$(MAKE) tidy
 	git add --renormalize .
 	mkdir -p /tmp/artifacts
 	git diff >/tmp/artifacts/check.diff 2>&1
@@ -287,6 +285,10 @@ check: ## Check that the status is consistent with CI
 		cat /tmp/artifacts/check.diff; \
 		exit 1; \
 	fi
+
+check: ## Check that the status is consistent with CI
+	$(MAKE) license-check
+	$(MAKE) check-format
 
 pre-push: ## Check source files before pushing to the remote repo
 	$(MAKE) check-req
@@ -374,7 +376,7 @@ PUSH_RELEASE_SCRIPTS := $(mk_dir)/scripts/push-release.sh
 release-push-candidate: ## Push release candidate
 	${PUSH_RELEASE_SCRIPTS}
 	
-.PHONY: all $(PROJECTS) clean build  default nuke
+.PHONY: all $(PROJECTS) clean build check-format default nuke
 .PHONY: lint check tidy format pre-push generate-test-cases capture-test-cases generate-trace-test-cases capture-trace-test-cases generate-stream-test-cases capture-stream-test-cases check-import-boundaries
 .PHONY: test test-race test-coverage test-ci test-docker
 .PHONY: build-trace-pipeline-plugin build-trace-pipeline-telemetry-plugins build-trace-pipeline-server test-trace-pipeline

--- a/mcp/Makefile
+++ b/mcp/Makefile
@@ -18,6 +18,7 @@
 
 NAME := mcp
 DIST_INDEX := dist/index.js
+NODE_MODULES_STAMP := node_modules/.package-lock.json
 
 IMG_NAME := skywalking-banyandb-mcp
 
@@ -33,8 +34,11 @@ check-version: install
 	@node tools/checkversion
 
 .PHONY: install
-install:
-	npm ci
+install: $(NODE_MODULES_STAMP)
+
+$(NODE_MODULES_STAMP): package.json package-lock.json
+	npm ci --include=dev
+	touch $@
 
 .PHONY: lint
 lint: install
@@ -54,7 +58,7 @@ all: build
 .PHONY: generate
 generate: install
 
-$(DIST_INDEX): install
+$(DIST_INDEX): $(NODE_MODULES_STAMP)
 	@echo "Building $(NAME)"
 	npm run format:check
 	npm run lint

--- a/test/docker/Makefile
+++ b/test/docker/Makefile
@@ -28,7 +28,7 @@ IMG := $(HUB)/skywalking-banyandb:$(TAG)-testing
 build:
 	@echo "Building $(IMG)"
 	@pwd
-	time docker buildx build --load --no-cache -t $(IMG) -f Dockerfile --provenance=false ../../
+	time docker buildx build --load -t $(IMG) -f Dockerfile --provenance=false ../../
 
 push:
 	@echo "Pushing $(IMG) with platform linux/amd64,linux/arm64"

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -18,6 +18,7 @@
 
 NAME := ui
 DIST_INDEX := dist/index.html
+NODE_MODULES_STAMP := node_modules/.package-lock.json
 
 include ../scripts/build/version.mk
 include ../scripts/build/base.mk
@@ -29,8 +30,11 @@ check-version: install
 	@node tools/checkversion
 
 .PHONY: install
-install:
-	npm install 
+install: $(NODE_MODULES_STAMP)
+
+$(NODE_MODULES_STAMP): package.json package-lock.json
+	npm ci --include=dev
+	touch $@
 
 .PHONY: all
 all: build
@@ -38,7 +42,7 @@ all: build
 .PHONY: generate
 generate: install
 
-$(DIST_INDEX): install
+$(DIST_INDEX): $(NODE_MODULES_STAMP)
 	@echo "Building $(NAME)"
 	npm run build
 	@echo "Done building $(NAME)"


### PR DESCRIPTION
## What changed

- let test jobs run alongside the main check job after shared preparation completes
- shard standalone and distributed integration suites into balanced lanes
- cancel superseded pull request runs
- avoid unused Node.js and QEMU setup
- reuse npm installations and purpose-specific tool caches
- build only the binaries required by the testing image and enable BuildKit cache reuse

## Why

Pull request CI currently takes about 50 minutes because independent tests wait for the full check job, the largest integration suites are not sharded, and repeated setup and image builds discard reusable work.

## Impact

This shortens the critical path without reducing test coverage. Both supported time zones, race-enabled integration tests, querybench, license checks, and the full end-to-end matrix remain enabled.

## Validation

- `actionlint` on all changed workflows
- `git diff --check`
- Ginkgo dry runs for every integration shard, with package coverage checked for omissions and duplicates
- `go test ./scripts/ci/check/...`
- `make check-req`
- `make generate` with no tracked drift
- UI and MCP install/build targets
- targeted static binary builds
- local testing Docker image build

This draft PR is intended to collect an actual GitHub Actions timing before review.
