### PR TITLE
ci: skip tests on main pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,48 +150,61 @@ jobs:
           fi
 
           echo "should_run=${should_run}" >> "${GITHUB_OUTPUT}"
+  test-gate:
+    name: Enable Tests
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo 'Tests enabled'
   test-banyand:
     name: Test Banyand
-    needs: [prepare]
+    needs: [prepare, test-gate]
     uses: ./.github/workflows/test-banyand.yml
   test-bydbctl:
     name: Test Bydbctl
-    needs: [prepare]
+    needs: [prepare, test-gate]
     uses: ./.github/workflows/test-bydbctl.yml
   test-fodc:
     name: Test FODC
-    needs: [prepare]
+    needs: [prepare, test-gate]
     uses: ./.github/workflows/test-fodc.yml
   test-fodc-e2e:
     name: Test FODC E2E
-    needs: [prepare, detect_fodc_e2e_changes]
+    needs: [prepare, detect_fodc_e2e_changes, test-gate]
     uses: ./.github/workflows/test-fodc-e2e.yml
     with:
       should_run: ${{ github.event_name != 'pull_request' || needs.detect_fodc_e2e_changes.outputs.should_run == 'true' }}
   test-pkg:
     name: Test Pkg
-    needs: [prepare]
+    needs: [prepare, test-gate]
     uses: ./.github/workflows/test-pkg.yml
   test-integration-standalone:
     name: Test Integration Standalone
-    needs: [prepare]
+    needs: [prepare, test-gate]
     uses: ./.github/workflows/test-integration-standalone.yml
   test-integration-distributed:
     name: Test Integration Distributed
-    needs: [prepare]
+    needs: [prepare, test-gate]
     uses: ./.github/workflows/test-integration-distributed.yml
   e2e:
     name: E2E Tests
-    needs: [prepare]
+    needs: [prepare, test-gate]
     uses: ./.github/workflows/e2e.yml
 
   result:
     name: Continuous Integration
     runs-on: ubuntu-24.04
+    if: |
+      always() &&
+      needs.check.result == 'success' &&
+      needs.vuln-check.result == 'success' &&
+      needs.detect_fodc_e2e_changes.result == 'success' &&
+      (needs.test-gate.result == 'skipped' || success())
     needs:
       - check
       - vuln-check
       - detect_fodc_e2e_changes
+      - test-gate
       - test-banyand
       - test-bydbctl
       - test-fodc


### PR DESCRIPTION
## What changed

- add one pull-request-only test gate
- make unit, integration, FODC, and end-to-end jobs depend on that gate, so they skip transitively on `push` events to `main`
- keep pull request test behavior unchanged
- keep preparation, consistency checks, vulnerability scanning, FODC change detection, and the final CI result on `main`
- allow the final result job to accept the skipped gate on `main` while still requiring every test to pass on pull requests

## Why

Pull request checks are mandatory and direct pushes to `main` are prohibited, so running the complete test matrix again after every merge duplicates the already-required validation. The previous main CI run consumed approximately 277 runner-minutes.

The gate keeps the workflow maintainable: the event condition is declared once rather than repeated on every test job.

## Validation

- `actionlint .github/workflows/ci.yml`
- YAML parsing
- `git diff --check`
- real push-event validation of the gate on a temporary fork branch: [run 31287490378](https://github.com/owenwillison-vajra/skywalking-banyandb/actions/runs/31287490378)
  - Prepare, Check, Vulnerability Scan, FODC detection, and Continuous Integration passed
  - Enable Tests and all eight test/E2E jobs were skipped

The temporary test branch was deleted after validation. Only `.github/workflows/ci.yml` is changed.
