### PR TITLE
Fix flaky trace snapshot fallback tests by awaiting manifest persistence

### DIFF
--- a/banyand/trace/snapshot_tstable_test.go
+++ b/banyand/trace/snapshot_tstable_test.go
@@ -22,17 +22,14 @@ import (
 	"path/filepath"
 	"sort"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/apache/skywalking-banyandb/api/common"
-	"github.com/apache/skywalking-banyandb/banyand/internal/storage"
 	"github.com/apache/skywalking-banyandb/banyand/protector"
 	"github.com/apache/skywalking-banyandb/pkg/fs"
 	"github.com/apache/skywalking-banyandb/pkg/logger"
 	"github.com/apache/skywalking-banyandb/pkg/test"
-	"github.com/apache/skywalking-banyandb/pkg/test/flags"
 	"github.com/apache/skywalking-banyandb/pkg/timestamp"
 )
 
@@ -189,16 +186,7 @@ func TestTraceTolerantLoaderFallbackToOlderSnapshot(t *testing.T) {
 		timestamp.TimeRange{}, traceSnapshotOption(), nil)
 	require.NoError(t, err)
 	tst.mustAddTraces(tsTS1, nil)
-	time.Sleep(100 * time.Millisecond)
-	require.Eventually(t, func() bool {
-		dd := fileSystem.ReadDir(tabDir)
-		for _, d := range dd {
-			if d.IsDir() && d.Name() != sidxDirName && d.Name() != storage.FailedPartsDirName {
-				return true
-			}
-		}
-		return false
-	}, flags.EventuallyTimeout, time.Millisecond, "wait for part")
+	waitForPersistedSnapshot(t, fileSystem, tabDir)
 	tst.Close()
 	snapshots := make([]uint64, 0)
 	for _, e := range fileSystem.ReadDir(tabDir) {
@@ -234,16 +222,7 @@ func TestTraceInitTSTableDeletesMultipleFailedSnapshotsOnFallback(t *testing.T) 
 		timestamp.TimeRange{}, traceSnapshotOption(), nil)
 	require.NoError(t, err)
 	tst.mustAddTraces(tsTS1, nil)
-	time.Sleep(100 * time.Millisecond)
-	require.Eventually(t, func() bool {
-		dd := fileSystem.ReadDir(tabDir)
-		for _, d := range dd {
-			if d.IsDir() && d.Name() != sidxDirName && d.Name() != storage.FailedPartsDirName {
-				return true
-			}
-		}
-		return false
-	}, flags.EventuallyTimeout, time.Millisecond, "wait for part")
+	waitForPersistedSnapshot(t, fileSystem, tabDir)
 	tst.Close()
 	snapshots := make([]uint64, 0)
 	for _, e := range fileSystem.ReadDir(tabDir) {


### PR DESCRIPTION
## Summary

- wait for the trace snapshot manifest before closing the table in snapshot fallback tests
- remove the sleep and premature part-directory readiness check from both affected tests

## Root cause

The tests assumed that a part directory meant the asynchronous flush was complete. That directory is created before the flushed part is introduced and before its snapshot manifest is persisted, so closing the table could cancel the flusher and leave the fixture without a valid snapshot. The parse warnings in the failure log came from the corrupt snapshots deliberately created by the tests and were not partial production writes.

## Testing

- 200 race-enabled repetitions of both trace snapshot fallback tests
- `make lint`
- `make check` license and formatting stages; its clean-tree assertion detected only the intentional test-file change

No production lifecycle behavior was changed.

Flaky-Test: github.com/apache/skywalking-banyandb/banyand/trace.TestTraceTolerantLoaderFallbackToOlderSnapshot
