### PR TITLE
fix(canopy): support HTTP session cookies

### DIFF
--- a/canopy/server/src/index.ts
+++ b/canopy/server/src/index.ts
@@ -27,6 +27,9 @@ import { registerAuth } from './routes/auth.js';
 const config = loadConfig();
 
 const app = Fastify({
+  // TLS is commonly terminated by an ingress. This lets secure-session's
+  // secure: 'auto' option use the proxy's X-Forwarded-Proto value.
+  trustProxy: true,
   logger: {
     level: process.env.LOG_LEVEL || 'info',
     redact: ['req.headers.authorization', 'res.headers.authorization'],

--- a/canopy/server/src/plugins/session.ts
+++ b/canopy/server/src/plugins/session.ts
@@ -37,7 +37,9 @@ export async function registerSession(app: FastifyInstance, config: Config): Pro
       path: '/',
       httpOnly: true,
       sameSite: 'strict',
-      secure: process.env.NODE_ENV === 'production',
+      // Preserve Secure cookies over HTTPS while allowing an HTTP-only
+      // deployment to establish a session.
+      secure: 'auto',
       maxAge: 8 * 60 * 60, // 8 hours TTL
     },
   });

--- a/canopy/server/test/session.test.ts
+++ b/canopy/server/test/session.test.ts
@@ -1,0 +1,83 @@
+/*
+ * Licensed to Apache Software Foundation (ASF) under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Fastify, { type FastifyInstance } from 'fastify';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import type { Config } from '../src/config.js';
+import { registerSession } from '../src/plugins/session.js';
+
+const TEST_CONFIG: Config = {
+  port: 4000,
+  sessionSecret: 'test-secret-32-chars-minimum-xxxxx',
+  banyandbTarget: 'http://127.0.0.1:17913',
+  monitorTarget: 'http://127.0.0.1:2121',
+  upstreamTimeoutMs: 120000,
+  users: [],
+  devNoAuth: false,
+  blockRfc1918: false,
+};
+
+function cookieHeader(setCookie: string | string[] | undefined): string {
+  if (Array.isArray(setCookie)) {
+    return setCookie[0];
+  }
+  return setCookie ?? '';
+}
+
+describe('session cookies', () => {
+  const apps: FastifyInstance[] = [];
+
+  afterEach(async () => {
+    await Promise.all(apps.splice(0).map(app => app.close()));
+  });
+
+  async function buildApp(): Promise<FastifyInstance> {
+    const app = Fastify({ trustProxy: true });
+    apps.push(app);
+    await registerSession(app, TEST_CONFIG);
+    app.get('/login', async request => {
+      request.session.user = 'admin';
+      request.session.role = 'admin';
+      request.session.banyanVersion = null;
+      return { ok: true };
+    });
+    return app;
+  }
+
+  it('sets a Secure cookie when TLS is terminated by a proxy', async () => {
+    const app = await buildApp();
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/login',
+      headers: { 'x-forwarded-proto': 'https' },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(cookieHeader(response.headers['set-cookie'])).toContain('; Secure');
+  });
+
+  it('does not set a Secure cookie over HTTP', async () => {
+    const app = await buildApp();
+
+    const response = await app.inject({ method: 'GET', url: '/login' });
+
+    expect(response.statusCode).toBe(200);
+    expect(cookieHeader(response.headers['set-cookie'])).not.toContain('; Secure');
+  });
+});


### PR DESCRIPTION
## Summary
- set Canopy session cookies with `secure: 'auto'` rather than tying them to `NODE_ENV`
- trust the TLS-terminating proxy's `X-Forwarded-Proto` value
- cover direct HTTP and forwarded HTTPS cookie behavior with server tests

## Root cause
The Helm deployment always sets `NODE_ENV=production`, so Canopy marked the session cookie `Secure` even when accessed over plain HTTP. Browsers reject that cookie, making a successful login non-persistent.

## Validation
- `npm run -w server test`
- `npm run -w server typecheck`
- `npm run -w server lint`
- `npm run build`
- verified on the local kind cluster: browser login over HTTP persisted the session; forwarded HTTPS retained the `Secure` attribute.
