### PR TITLE
Fix Canopy behind path-prefix proxies

### DIFF
--- a/banyand/internal/benchmark/tracebaseline/readiness_test.go
+++ b/banyand/internal/benchmark/tracebaseline/readiness_test.go
@@ -294,7 +294,7 @@ func readyTestSuite() SuiteReport {
 			LogicalWriteAmplification: 1.0009,
 			Primary:                   PhaseResult{InputBytes: 100, DrainNanos: int64(100 * time.Millisecond)},
 			Environment: Environment{
-				Commit: "abc123", GoVersion: "go1.25.12", Kernel: "5.15.0",
+				Commit: "abc123", GoVersion: "go1.25.13", Kernel: "5.15.0",
 				GOMAXPROCS: 2, MemoryMax: "4294967296", MemorySwapMax: "0", PIDsMax: "512", OneShardOnly: true,
 				DataNodeCgroup: "/data", ControllerCgroup: "/controller", CPUSet: "0-1",
 				Filesystem: "ext4", StorageDevice: "/dev/sda1", ImageDigest: "sha256:image",

--- a/canopy/.env.example
+++ b/canopy/.env.example
@@ -24,6 +24,10 @@ MONITOR_TARGET=http://127.0.0.1:2121
 # Canopy BFF server port
 PORT=4000
 
+# Optional public URL path prefix when Canopy is served behind a reverse proxy.
+# The proxy must preserve this prefix. Defaults to /.
+CANOPY_BASE_PATH=/
+
 # REQUIRED: random secret for session cookie encryption (min 32 chars)
 # Generate: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 SESSION_SECRET=

--- a/canopy/README.md
+++ b/canopy/README.md
@@ -29,6 +29,20 @@ BANYANDB_TARGET=http://<host>:17913 SESSION_SECRET=<secret> CANOPY_USERS=/etc/ca
 # open http://localhost:4000
 ```
 
+### Reverse proxy path prefix
+
+To expose Canopy below a shared host path, set `CANOPY_BASE_PATH` and preserve
+that path when proxying requests:
+
+```bash
+CANOPY_BASE_PATH=/canopy
+```
+
+For the BanyanDB Helm chart, pass it through the existing `canopy.env` value.
+Route `/canopy` to the Canopy service without an nginx rewrite or a trailing
+slash on `proxy_pass`. The root `/healthz` endpoint remains available for
+container and Kubernetes probes.
+
 ## Environment variables
 
 See `.env.example` for all env vars.

--- a/canopy/e2e/auth/auth.setup.ts
+++ b/canopy/e2e/auth/auth.setup.ts
@@ -30,21 +30,15 @@
 // itself is validated against an auth-enabled server.
 
 import { test as setup, expect } from '@playwright/test';
-import { LoginPage } from '../framework/pages/LoginPage.js';
 import { STORAGE_STATE } from '../framework/paths.js';
 
 setup('authenticate once', async ({ page }) => {
-  const login = new LoginPage(page);
-  await page.goto('/');
-  // The app renders the login form inline (there is no /login route) whenever
-  // GET /auth/session returns no session. NOAUTH does NOT auto-create one — it
-  // only accepts the dev admin/admin credentials — so we must actually Connect
-  // to obtain the session cookie. Skip only if a prior storageState already
-  // authenticated us (no form on screen).
-  if (await login.username().isVisible().catch(() => false)) {
-    await login.fill();
-    await login.submit().click();
-    await expect(login.username()).toBeHidden({ timeout: 30_000 });
-  }
+  // Authenticate through the context-bound request client so the resulting
+  // cookie is guaranteed to be present before storageState is serialized.
+  // The dedicated auth specs cover the login form itself.
+  const response = await page.request.post('./auth/login', {
+    data: { username: 'admin', password: 'admin' },
+  });
+  expect(response.ok()).toBeTruthy();
   await page.context().storageState({ path: STORAGE_STATE });
 });

--- a/canopy/e2e/framework/pages/IndexRulePage.ts
+++ b/canopy/e2e/framework/pages/IndexRulePage.ts
@@ -36,7 +36,7 @@ export class IndexRulePage extends BasePage {
   }
 
   async goto(type: MetaType, group: string): Promise<void> {
-    await this.page.goto(`/metadata/${type}/${group}/Index`);
+    await this.page.goto(`./metadata/${type}/${group}/Index`);
     await expect(this.ruleTab()).toBeVisible();
   }
 

--- a/canopy/e2e/framework/pages/LoginPage.ts
+++ b/canopy/e2e/framework/pages/LoginPage.ts
@@ -67,7 +67,7 @@ export class LoginPage extends BasePage {
   }
 
   async goto(): Promise<void> {
-    await this.page.goto('/login');
+    await this.page.goto('./login');
   }
 
   // Fill the login form (role + credentials) without submitting.

--- a/canopy/e2e/framework/pages/PipelinesPage.ts
+++ b/canopy/e2e/framework/pages/PipelinesPage.ts
@@ -63,17 +63,17 @@ export class PipelinesPage extends BasePage {
 
   // ── Navigation ─────────────────────────────────────────────────────────────
   async gotoOverview(): Promise<void> {
-    await this.page.goto('/pipelines');
+    await this.page.goto('./pipelines');
     await expect(this.page.getByRole('heading', { level: 1, name: 'Pipelines' })).toBeVisible();
   }
 
   async gotoList(): Promise<void> {
-    await this.page.goto('/pipelines/topn');
+    await this.page.goto('./pipelines/topn');
     await expect(this.page.getByRole('heading', { level: 1, name: 'TopN' })).toBeVisible();
   }
 
   async gotoDetail(group: string, name: string): Promise<void> {
-    await this.page.goto(`/pipelines/topn/${group}/${name}`);
+    await this.page.goto(`./pipelines/topn/${group}/${name}`);
     await expect(this.page.getByRole('heading', { level: 1, name })).toBeVisible();
   }
 

--- a/canopy/e2e/framework/pages/PropertyPage.ts
+++ b/canopy/e2e/framework/pages/PropertyPage.ts
@@ -38,16 +38,16 @@ export class PropertyPage extends BasePage {
 
   // ── Navigation ─────────────────────────────────────────────────────────────
   async gotoOverview(): Promise<void> {
-    await this.page.goto('/properties');
+    await this.page.goto('./properties');
   }
 
   async gotoGroup(group: string): Promise<void> {
-    await this.page.goto(`/properties/${group}`);
+    await this.page.goto(`./properties/${group}`);
     await expect(this.pageTitle(group)).toBeVisible();
   }
 
   async gotoDetail(group: string, name: string): Promise<void> {
-    await this.page.goto(`/properties/${group}/${name}`);
+    await this.page.goto(`./properties/${group}/${name}`);
     await expect(this.pageTitle(name)).toBeVisible();
   }
 

--- a/canopy/e2e/framework/pages/QueryConsolePage.ts
+++ b/canopy/e2e/framework/pages/QueryConsolePage.ts
@@ -106,7 +106,7 @@ export class QueryConsolePage extends BasePage {
 
   // ── Actions (app-action style: intent, not clicks) ─────────────────────────
   async goto(): Promise<void> {
-    await this.page.goto('/query');
+    await this.page.goto('./query');
     await expect(this.builder()).toBeVisible();
   }
 

--- a/canopy/e2e/framework/pages/SchemaPage.ts
+++ b/canopy/e2e/framework/pages/SchemaPage.ts
@@ -53,17 +53,17 @@ export class SchemaPage extends BasePage {
 
   // ── Navigation ─────────────────────────────────────────────────────────────
   async gotoOverview(type: MetaType): Promise<void> {
-    await this.page.goto(`/metadata/${type}`);
+    await this.page.goto(`./metadata/${type}`);
     await expect(this.newGroupButton()).toBeVisible();
   }
 
   async gotoGroup(type: MetaType, group: string): Promise<void> {
-    await this.page.goto(`/metadata/${type}/${group}`);
+    await this.page.goto(`./metadata/${type}/${group}`);
     await expect(this.pageTitle(group)).toBeVisible();
   }
 
   async gotoResource(type: MetaType, group: string, name: string): Promise<void> {
-    await this.page.goto(`/metadata/${type}/${group}/${name}`);
+    await this.page.goto(`./metadata/${type}/${group}/${name}`);
     await expect(this.pageTitle(name)).toBeVisible();
   }
 

--- a/canopy/e2e/framework/pages/ShellPage.ts
+++ b/canopy/e2e/framework/pages/ShellPage.ts
@@ -73,7 +73,7 @@ export class ShellPage extends BasePage {
 
   // ── Actions ────────────────────────────────────────────────────────────────
   async goto(): Promise<void> {
-    await this.page.goto('/');
+    await this.page.goto('./');
     await expect(this.sidebar()).toBeVisible();
   }
 

--- a/canopy/e2e/framework/seed/factory.ts
+++ b/canopy/e2e/framework/seed/factory.ts
@@ -87,7 +87,7 @@ export class SeedFactory {
   async createGroup(prefix: string, catalog: Catalog = 'CATALOG_MEASURE'): Promise<string> {
     const name = this.uniqueName(prefix);
     const isProperty = catalog === 'CATALOG_PROPERTY';
-    const res = await this.request.post('/api/v1/group/schema', {
+    const res = await this.request.post('./api/v1/group/schema', {
       data: {
         group: {
           metadata: { name },
@@ -112,7 +112,7 @@ export class SeedFactory {
   // Create a minimal measure in `group`. Returns the measure name.
   async createMeasure(group: string, prefix = 'm', fields: readonly string[] = ['value']): Promise<string> {
     const name = this.uniqueName(prefix);
-    const res = await this.request.post('/api/v1/measure/schema', {
+    const res = await this.request.post('./api/v1/measure/schema', {
       data: {
         measure: {
           metadata: { group, name },
@@ -131,7 +131,7 @@ export class SeedFactory {
     if (!res.ok()) {
       throw new Error(`seed createMeasure(${group}/${name}) failed: ${res.status()} ${await res.text()}`);
     }
-    this.createdResources.push({ path: `/api/v1/measure/schema/${encodeURIComponent(group)}/${encodeURIComponent(name)}` });
+    this.createdResources.push({ path: `./api/v1/measure/schema/${encodeURIComponent(group)}/${encodeURIComponent(name)}` });
     return name;
   }
 
@@ -139,7 +139,7 @@ export class SeedFactory {
   // entity. Returns the stream name.
   async createStream(group: string, prefix = 's', entityTag = 'host'): Promise<string> {
     const name = this.uniqueName(prefix);
-    const res = await this.request.post('/api/v1/stream/schema', {
+    const res = await this.request.post('./api/v1/stream/schema', {
       data: {
         stream: {
           metadata: { name, group },
@@ -151,7 +151,7 @@ export class SeedFactory {
     if (!res.ok()) {
       throw new Error(`seed createStream(${group}/${name}) failed: ${res.status()} ${await res.text()}`);
     }
-    this.createdResources.push({ path: `/api/v1/stream/schema/${encodeURIComponent(group)}/${encodeURIComponent(name)}` });
+    this.createdResources.push({ path: `./api/v1/stream/schema/${encodeURIComponent(group)}/${encodeURIComponent(name)}` });
     return name;
   }
 
@@ -162,13 +162,13 @@ export class SeedFactory {
   // validation. Documents aren't validated against these declared tags.
   async createPropertySchema(group: string, prefix = 'p'): Promise<string> {
     const name = this.uniqueName(prefix);
-    const res = await this.request.post('/api/v1/property/schema', {
+    const res = await this.request.post('./api/v1/property/schema', {
       data: { property: { metadata: { name, group }, tags: [{ name: '_placeholder', type: 'TAG_TYPE_STRING' }] } },
     });
     if (!res.ok()) {
       throw new Error(`seed createPropertySchema(${group}/${name}) failed: ${res.status()} ${await res.text()}`);
     }
-    this.createdResources.push({ path: `/api/v1/property/schema/${encodeURIComponent(group)}/${encodeURIComponent(name)}` });
+    this.createdResources.push({ path: `./api/v1/property/schema/${encodeURIComponent(group)}/${encodeURIComponent(name)}` });
     return name;
   }
 
@@ -183,20 +183,20 @@ export class SeedFactory {
     // The registry rejects Apply with undeclared tag keys, so declare any
     // missing keys on the collection schema first — mirroring the product's
     // applyPropertyDocument auto-grow. Seed tags are always `str`.
-    const getRes = await this.request.get(`/api/v1/property/schema/${encodeURIComponent(group)}/${encodeURIComponent(name)}`);
+    const getRes = await this.request.get(`./api/v1/property/schema/${encodeURIComponent(group)}/${encodeURIComponent(name)}`);
     if (getRes.ok()) {
       const body = await getRes.json() as { property?: { tags?: { name: string; type: string }[] } };
       const declared = body.property?.tags ?? [];
       const have = new Set(declared.map((t) => t.name));
       const missing = Object.keys(tags).filter((k) => !have.has(k));
       if (missing.length) {
-        await this.request.put(`/api/v1/property/schema/${encodeURIComponent(group)}/${encodeURIComponent(name)}`, {
+        await this.request.put(`./api/v1/property/schema/${encodeURIComponent(group)}/${encodeURIComponent(name)}`, {
           data: { property: { metadata: { group, name }, tags: [...declared, ...missing.map((k) => ({ name: k, type: 'TAG_TYPE_STRING' }))] } },
         });
       }
     }
     const res = await this.request.put(
-      `/api/v1/property/data/${encodeURIComponent(group)}/${encodeURIComponent(name)}/${encodeURIComponent(id)}`,
+      `./api/v1/property/data/${encodeURIComponent(group)}/${encodeURIComponent(name)}/${encodeURIComponent(id)}`,
       {
         data: {
           property: {
@@ -214,7 +214,7 @@ export class SeedFactory {
     // Tracked for cleanup as a resource (not a group) — deleted via the
     // property/v1 Delete endpoint, reverse-order before its collection schema.
     this.createdResources.push({
-      path: `/api/v1/property/data/${encodeURIComponent(group)}/${encodeURIComponent(name)}/${encodeURIComponent(id)}`,
+      path: `./api/v1/property/data/${encodeURIComponent(group)}/${encodeURIComponent(name)}/${encodeURIComponent(id)}`,
     });
   }
 
@@ -230,7 +230,7 @@ export class SeedFactory {
     opts: { readonly fieldValueSort?: 'SORT_DESC' | 'SORT_ASC' | 'SORT_UNSPECIFIED'; readonly groupByTagNames?: readonly string[] } = {},
   ): Promise<string> {
     const name = this.uniqueName(prefix);
-    const res = await this.request.post('/api/v1/topn-agg/schema', {
+    const res = await this.request.post('./api/v1/topn-agg/schema', {
       data: {
         topNAggregation: {
           metadata: { name, group },
@@ -246,20 +246,20 @@ export class SeedFactory {
     if (!res.ok()) {
       throw new Error(`seed createTopNAggregation(${group}/${name}) failed: ${res.status()} ${await res.text()}`);
     }
-    this.createdResources.push({ path: `/api/v1/topn-agg/schema/${encodeURIComponent(group)}/${encodeURIComponent(name)}` });
+    this.createdResources.push({ path: `./api/v1/topn-agg/schema/${encodeURIComponent(group)}/${encodeURIComponent(name)}` });
     return name;
   }
 
   // Create an index rule over `tags` in `group`. Returns the rule name.
   async createIndexRule(group: string, tags: readonly string[], prefix = 'rule', type: IndexRuleType = 'TYPE_TREE'): Promise<string> {
     const name = this.uniqueName(prefix);
-    const res = await this.request.post('/api/v1/index-rule/schema', {
+    const res = await this.request.post('./api/v1/index-rule/schema', {
       data: { indexRule: { metadata: { name, group }, tags: [...tags], type } },
     });
     if (!res.ok()) {
       throw new Error(`seed createIndexRule(${group}/${name}) failed: ${res.status()} ${await res.text()}`);
     }
-    this.createdResources.push({ path: `/api/v1/index-rule/schema/${encodeURIComponent(group)}/${encodeURIComponent(name)}` });
+    this.createdResources.push({ path: `./api/v1/index-rule/schema/${encodeURIComponent(group)}/${encodeURIComponent(name)}` });
     return name;
   }
 
@@ -302,7 +302,7 @@ export class SeedFactory {
     }
     this.createdResources.length = 0;
     for (const name of this.createdGroups.reverse()) {
-      const res = await this.request.delete(`/api/v1/group/schema/${encodeURIComponent(name)}`);
+      const res = await this.request.delete(`./api/v1/group/schema/${encodeURIComponent(name)}`);
       if (!res.ok() && res.status() !== 404) {
         // eslint-disable-next-line no-console
         console.warn(`[seed] cleanup: delete group ${name} → ${res.status()}`);

--- a/canopy/e2e/playwright.config.ts
+++ b/canopy/e2e/playwright.config.ts
@@ -35,6 +35,8 @@ import { join } from 'node:path';
 import { STORAGE_STATE } from './framework/paths.js';
 
 const isCI = !!process.env.CI;
+const configuredURL = process.env.CANOPY_URL || 'http://localhost:4000/';
+const canopyURL = configuredURL.endsWith('/') ? configuredURL : `${configuredURL}/`;
 
 export default defineConfig({
   testDir: '.',
@@ -70,10 +72,13 @@ export default defineConfig({
       BANYANDB_TARGET: process.env.BANYANDB_TARGET || 'http://127.0.0.1:17913',
       PORT: '4000',
       LOG_LEVEL: 'warn',
+      CANOPY_BASE_PATH: process.env.CANOPY_BASE_PATH || '/',
     },
   },
   use: {
-    baseURL: process.env.CANOPY_URL || 'http://localhost:4000',
+    // Application URLs in the suite are relative so a baseURL ending in a
+    // reverse-proxy prefix (for example /canopy/) is preserved.
+    baseURL: canopyURL,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',

--- a/canopy/e2e/setup/global-setup.ts
+++ b/canopy/e2e/setup/global-setup.ts
@@ -62,14 +62,16 @@ async function waitForReady(url: string, maxAttempts = 60): Promise<void> {
 // BanyanDB data writes are gRPC-only, so this uses the native seeder
 // (cmd/m4-seed) rather than the HTTP BFF. Idempotent (the seeder ignores
 // already-exists) and skippable with E2E_SKIP_SEED for schema-only runs.
-function seedDemoData(): void {
+function seedDemoData(buildRoot: string): void {
   if (process.env.E2E_SKIP_SEED) {
     console.log('[e2e] E2E_SKIP_SEED set — skipping demo data seed');
     return;
   }
   console.log(`[e2e] Seeding demo data via cmd/m4-seed → 127.0.0.1:${GRPC_PORT}`);
   execSync(`go run ./cmd/m4-seed --addr 127.0.0.1:${GRPC_PORT} --rows 80`, {
-    cwd: REPO_ROOT,
+    // Use the same generated-source worktree as the server build. Generated
+    // protobuf files are intentionally absent from feature worktrees.
+    cwd: buildRoot,
     stdio: 'inherit',
     timeout: 180_000,
   });
@@ -116,7 +118,7 @@ export default async function globalSetup() {
   await waitForReady(BANYANDB_TARGET);
   console.log('[e2e] BanyanDB ready');
 
-  seedDemoData();
+  seedDemoData(buildRoot);
 
   writeFileSync(join(tmpdir(), 'canopy-e2e-state.json'), JSON.stringify({
     banyandbTarget: BANYANDB_TARGET,

--- a/canopy/e2e/tests/boot.spec.ts
+++ b/canopy/e2e/tests/boot.spec.ts
@@ -32,7 +32,7 @@ test.describe('boot @e2e @boot @smoke', () => {
   });
 
   test('SPA boots with the dark theme applied', async ({ page }) => {
-    await page.goto('/');
+    await page.goto('./');
     // The theme sets the body background to #0d120e = rgb(13, 18, 14).
     const bgColor = await page.evaluate(() => window.getComputedStyle(document.body).backgroundColor);
     expect(bgColor).toMatch(/rgb\(13,\s*18,\s*14\)/);

--- a/canopy/e2e/tests/index-rule.spec.ts
+++ b/canopy/e2e/tests/index-rule.spec.ts
@@ -33,35 +33,35 @@ test.describe('index rule API @e2e @index-rule @seed', () => {
     const group = await seed.createGroup('e2e-ira', 'CATALOG_STREAM');
     await seed.createStream(group, 's');
     const ruleName = seed.uniqueName('rule');
-    seed.trackResource(`/api/v1/index-rule/schema/${group}/${ruleName}`);
+    seed.trackResource(`./api/v1/index-rule/schema/${group}/${ruleName}`);
 
-    const createRes = await request.post('/api/v1/index-rule/schema', {
+    const createRes = await request.post('./api/v1/index-rule/schema', {
       data: { indexRule: { metadata: { name: ruleName, group }, tags: ['host'], type: 'TYPE_TREE' } },
     });
     expect(createRes.ok(), `create failed: ${await createRes.text()}`).toBeTruthy();
 
-    const getRes = await request.get(`/api/v1/index-rule/schema/${group}/${ruleName}`);
+    const getRes = await request.get(`./api/v1/index-rule/schema/${group}/${ruleName}`);
     expect(getRes.ok()).toBeTruthy();
     const got = (await getRes.json()) as { indexRule: { tags: string[]; type: string } };
     expect(got.indexRule.tags).toEqual(['host']);
     expect(got.indexRule.type).toBe('TYPE_TREE');
 
-    const listRes = await request.get(`/api/v1/index-rule/schema/lists/${group}`);
+    const listRes = await request.get(`./api/v1/index-rule/schema/lists/${group}`);
     expect(listRes.ok()).toBeTruthy();
     const listed = (await listRes.json()) as { indexRule: Array<{ metadata: { name: string } }> };
     expect(listed.indexRule?.map((r) => r.metadata.name)).toContain(ruleName);
 
-    const updRes = await request.put(`/api/v1/index-rule/schema/${group}/${ruleName}`, {
+    const updRes = await request.put(`./api/v1/index-rule/schema/${group}/${ruleName}`, {
       data: { indexRule: { metadata: { name: ruleName, group }, tags: ['host', 'svc'], type: 'TYPE_INVERTED' } },
     });
     expect(updRes.ok(), `update failed: ${await updRes.text()}`).toBeTruthy();
-    const updGot = (await (await request.get(`/api/v1/index-rule/schema/${group}/${ruleName}`)).json()) as { indexRule: { tags: string[]; type: string } };
+    const updGot = (await (await request.get(`./api/v1/index-rule/schema/${group}/${ruleName}`)).json()) as { indexRule: { tags: string[]; type: string } };
     expect(updGot.indexRule.tags).toEqual(['host', 'svc']);
     expect(updGot.indexRule.type).toBe('TYPE_INVERTED');
 
-    const delRes = await request.delete(`/api/v1/index-rule/schema/${group}/${ruleName}`);
+    const delRes = await request.delete(`./api/v1/index-rule/schema/${group}/${ruleName}`);
     expect(delRes.ok()).toBeTruthy();
-    const afterDel = await request.get(`/api/v1/index-rule/schema/${group}/${ruleName}`);
+    const afterDel = await request.get(`./api/v1/index-rule/schema/${group}/${ruleName}`);
     expect(afterDel.status()).toBe(404);
   });
 
@@ -70,9 +70,9 @@ test.describe('index rule API @e2e @index-rule @seed', () => {
     const stream = await seed.createStream(group, 's');
     const ruleName = await seed.createIndexRule(group, ['host'], 'rl');
     const bindingName = seed.uniqueName('bind');
-    seed.trackResource(`/api/v1/index-rule-binding/schema/${group}/${bindingName}`);
+    seed.trackResource(`./api/v1/index-rule-binding/schema/${group}/${bindingName}`);
 
-    const bindRes = await request.post('/api/v1/index-rule-binding/schema', {
+    const bindRes = await request.post('./api/v1/index-rule-binding/schema', {
       data: {
         indexRuleBinding: {
           metadata: { name: bindingName, group },
@@ -85,18 +85,18 @@ test.describe('index rule API @e2e @index-rule @seed', () => {
     });
     expect(bindRes.ok(), `create binding failed: ${await bindRes.text()}`).toBeTruthy();
 
-    const got = await request.get(`/api/v1/index-rule-binding/schema/${group}/${bindingName}`);
+    const got = await request.get(`./api/v1/index-rule-binding/schema/${group}/${bindingName}`);
     expect(got.ok()).toBeTruthy();
     const gotJson = (await got.json()) as { indexRuleBinding: { rules: string[]; subject: { name: string } } };
     expect(gotJson.indexRuleBinding.rules).toEqual([ruleName]);
     expect(gotJson.indexRuleBinding.subject.name).toBe(stream);
 
-    const list = await request.get(`/api/v1/index-rule-binding/schema/lists/${group}`);
+    const list = await request.get(`./api/v1/index-rule-binding/schema/lists/${group}`);
     expect(list.ok()).toBeTruthy();
     const listJson = (await list.json()) as { indexRuleBinding: Array<{ metadata: { name: string } }> };
     expect(listJson.indexRuleBinding?.map((b) => b.metadata.name)).toContain(bindingName);
 
-    const upd = await request.put(`/api/v1/index-rule-binding/schema/${group}/${bindingName}`, {
+    const upd = await request.put(`./api/v1/index-rule-binding/schema/${group}/${bindingName}`, {
       data: {
         indexRuleBinding: {
           metadata: { name: bindingName, group },
@@ -110,9 +110,9 @@ test.describe('index rule API @e2e @index-rule @seed', () => {
     // The server may accept or reject empty rules — either is a valid authority outcome.
     expect([200, 400, 422].includes(upd.status())).toBeTruthy();
 
-    const del = await request.delete(`/api/v1/index-rule-binding/schema/${group}/${bindingName}`);
+    const del = await request.delete(`./api/v1/index-rule-binding/schema/${group}/${bindingName}`);
     expect(del.ok()).toBeTruthy();
-    const afterDel = await request.get(`/api/v1/index-rule-binding/schema/${group}/${bindingName}`);
+    const afterDel = await request.get(`./api/v1/index-rule-binding/schema/${group}/${bindingName}`);
     expect(afterDel.status()).toBe(404);
   });
 
@@ -126,8 +126,8 @@ test.describe('index rule API @e2e @index-rule @seed', () => {
     const stream = await seed.createStream(group, 's');
     const ruleName = await seed.createIndexRule(group, ['host'], 'rl');
     const bindingName = seed.uniqueName('bind-bad');
-    seed.trackResource(`/api/v1/index-rule-binding/schema/${group}/${bindingName}`);
-    const bad = await request.post('/api/v1/index-rule-binding/schema', {
+    seed.trackResource(`./api/v1/index-rule-binding/schema/${group}/${bindingName}`);
+    const bad = await request.post('./api/v1/index-rule-binding/schema', {
       data: {
         indexRuleBinding: {
           metadata: { name: bindingName, group },
@@ -148,8 +148,8 @@ test.describe('index rule API @e2e @index-rule @seed', () => {
     const group = await seed.createGroup('e2e-irz', 'CATALOG_STREAM');
     await seed.createStream(group, 's');
     const ruleName = seed.uniqueName('rule-z');
-    seed.trackResource(`/api/v1/index-rule/schema/${group}/${ruleName}`);
-    const res = await request.post('/api/v1/index-rule/schema', {
+    seed.trackResource(`./api/v1/index-rule/schema/${group}/${ruleName}`);
+    const res = await request.post('./api/v1/index-rule/schema', {
       data: { indexRule: { metadata: { name: ruleName, group }, tags: ['undeclared_tag'], type: 'TYPE_TREE' } },
     });
     expect(res.ok()).toBeTruthy();
@@ -163,7 +163,7 @@ test.describe('index rule UI @e2e @index-rule @seed', () => {
     const group = await seed.createGroup('e2e-uir', 'CATALOG_STREAM');
     await seed.createStream(group, 's');
     const ruleName = seed.uniqueName('r');
-    seed.trackResource(`/api/v1/index-rule/schema/${group}/${ruleName}`);
+    seed.trackResource(`./api/v1/index-rule/schema/${group}/${ruleName}`);
 
     await indexRulePage.goto('streams', group);
     await indexRulePage.openRuleTab();
@@ -209,7 +209,7 @@ test.describe('index rule UI @e2e @index-rule @seed', () => {
     await indexRulePage.openRuleTab();
     await indexRulePage.deleteRule(ruleName);
     await expect(indexRulePage.ruleRow(ruleName)).toHaveCount(0);
-    const apiCheck = await request.get(`/api/v1/index-rule/schema/${group}/${ruleName}`);
+    const apiCheck = await request.get(`./api/v1/index-rule/schema/${group}/${ruleName}`);
     expect(apiCheck.status()).toBe(404);
   });
 
@@ -219,7 +219,7 @@ test.describe('index rule UI @e2e @index-rule @seed', () => {
     const rule1 = await seed.createIndexRule(group, ['host'], 'ra');
     const rule2 = await seed.createIndexRule(group, ['host'], 'rb');
     const bindingName = seed.uniqueName('b');
-    seed.trackResource(`/api/v1/index-rule-binding/schema/${group}/${bindingName}`);
+    seed.trackResource(`./api/v1/index-rule-binding/schema/${group}/${bindingName}`);
 
     await indexRulePage.goto('streams', group);
     await indexRulePage.openBindingTab();
@@ -241,8 +241,8 @@ test.describe('index rule UI @e2e @index-rule @seed', () => {
     const rule1 = await seed.createIndexRule(group, ['host'], 'ra');
     const rule2 = await seed.createIndexRule(group, ['host'], 'rb');
     const bindingName = seed.uniqueName('b');
-    seed.trackResource(`/api/v1/index-rule-binding/schema/${group}/${bindingName}`);
-    const create = await request.post('/api/v1/index-rule-binding/schema', {
+    seed.trackResource(`./api/v1/index-rule-binding/schema/${group}/${bindingName}`);
+    const create = await request.post('./api/v1/index-rule-binding/schema', {
       data: {
         indexRuleBinding: {
           metadata: { name: bindingName, group },
@@ -276,7 +276,7 @@ test.describe('index rule UI @e2e @index-rule @seed', () => {
     const stream = await seed.createStream(group, 's');
     const ruleName = await seed.createIndexRule(group, ['host'], 'r');
     const bindingName = seed.uniqueName('b');
-    seed.trackResource(`/api/v1/index-rule-binding/schema/${group}/${bindingName}`);
+    seed.trackResource(`./api/v1/index-rule-binding/schema/${group}/${bindingName}`);
 
     await indexRulePage.goto('streams', group);
     await indexRulePage.openRuleTab();

--- a/canopy/e2e/tests/lifecycle.spec.ts
+++ b/canopy/e2e/tests/lifecycle.spec.ts
@@ -28,7 +28,7 @@ import { test, expect } from '../framework/fixtures.js';
 import type { APIRequestContext } from '@playwright/test';
 
 async function seedGroupWithStage(request: APIRequestContext, name: string): Promise<void> {
-  const res = await request.post('/api/v1/group/schema', {
+  const res = await request.post('./api/v1/group/schema', {
     data: {
       group: {
         metadata: { name },

--- a/canopy/e2e/tests/pipelines.spec.ts
+++ b/canopy/e2e/tests/pipelines.spec.ts
@@ -52,7 +52,7 @@ test.describe('Pipelines + TopN CRUD @e2e @pipelines @seed', () => {
       rank: 'bottomN',
       groupByTags: ['id'],
     });
-    seed.trackResource(`/api/v1/topn-agg/schema/${encodeURIComponent(group)}/${encodeURIComponent(name)}`);
+    seed.trackResource(`./api/v1/topn-agg/schema/${encodeURIComponent(group)}/${encodeURIComponent(name)}`);
 
     // Create navigates straight to the new aggregation's detail page.
     await expect(pipelinesPage.page).toHaveURL(new RegExp(`/pipelines/topn/${group}/${name}$`));

--- a/canopy/e2e/tests/properties.spec.ts
+++ b/canopy/e2e/tests/properties.spec.ts
@@ -31,7 +31,7 @@ test.describe('property CRUD + query @e2e @property @seed', () => {
     const name = seed.uniqueName('e2e-coll');
     await propertyPage.gotoGroup(group);
     await propertyPage.createCollection(group, name);
-    seed.trackResource(`/api/v1/property/schema/${encodeURIComponent(group)}/${encodeURIComponent(name)}`);
+    seed.trackResource(`./api/v1/property/schema/${encodeURIComponent(group)}/${encodeURIComponent(name)}`);
     await expect(propertyPage.page).toHaveURL(new RegExp(`/properties/${group}/${name}`));
   });
 

--- a/canopy/e2e/tests/schema.spec.ts
+++ b/canopy/e2e/tests/schema.spec.ts
@@ -62,7 +62,7 @@ test.describe('group crud @e2e @schema @seed', () => {
 
   test('API resourceOpts update is reflected in the GroupPage meta chips', async ({ schemaPage, seed, request }) => {
     const name = await seed.createGroup('e2e-opts', 'CATALOG_MEASURE');
-    const res = await request.put(`/api/v1/group/schema/${name}`, {
+    const res = await request.put(`./api/v1/group/schema/${name}`, {
       data: {
         group: {
           metadata: { name },
@@ -131,7 +131,7 @@ test.describe('measure crud @e2e @schema @seed', () => {
     await schemaPage.gotoGroup('measures', group);
     const name = seed.uniqueName('m');
     await schemaPage.createMeasure(name, 't1', true);
-    seed.trackResource(`/api/v1/measure/schema/${group}/${name}`);
+    seed.trackResource(`./api/v1/measure/schema/${group}/${name}`);
     await expect(schemaPage.resourceRow(name)).toBeVisible();
   });
 
@@ -146,7 +146,7 @@ test.describe('measure crud @e2e @schema @seed', () => {
   test('API tag addition is reflected in the measure detail page', async ({ schemaPage, seed, request, page }) => {
     const group = await seed.createGroup('e2e-mtag', 'CATALOG_MEASURE');
     const name = await seed.createMeasure(group, 'm');
-    const res = await request.put(`/api/v1/measure/schema/${group}/${name}`, {
+    const res = await request.put(`./api/v1/measure/schema/${group}/${name}`, {
       data: {
         measure: {
           metadata: { name, group },
@@ -205,7 +205,7 @@ test.describe('stream crud @e2e @schema @seed', () => {
     await schemaPage.gotoGroup('streams', group);
     const name = seed.uniqueName('s');
     await schemaPage.createStream(name, 't1');
-    seed.trackResource(`/api/v1/stream/schema/${group}/${name}`);
+    seed.trackResource(`./api/v1/stream/schema/${group}/${name}`);
     await expect(schemaPage.resourceRow(name)).toBeVisible();
   });
 
@@ -244,7 +244,7 @@ test.describe('stream crud @e2e @schema @seed', () => {
 test.describe('trace crud @e2e @schema @seed', () => {
   // Create a trace schema over HTTP (all three reserved tags mapped).
   async function seedTrace(request: import('@playwright/test').APIRequestContext, group: string, name: string) {
-    const res = await request.post('/api/v1/trace/schema', {
+    const res = await request.post('./api/v1/trace/schema', {
       data: {
         trace: {
           metadata: { name, group },
@@ -277,7 +277,7 @@ test.describe('trace crud @e2e @schema @seed', () => {
     await schemaPage.gotoGroup('traces', group);
     const name = seed.uniqueName('t');
     await schemaPage.createTrace(name, ['tid', 'sid', 'ts']);
-    seed.trackResource(`/api/v1/trace/schema/${group}/${name}`);
+    seed.trackResource(`./api/v1/trace/schema/${group}/${name}`);
     await expect(schemaPage.resourceRow(name)).toBeVisible();
   });
 
@@ -285,7 +285,7 @@ test.describe('trace crud @e2e @schema @seed', () => {
     const group = await seed.createGroup('e2e-tdet', 'CATALOG_TRACE');
     const name = seed.uniqueName('t');
     await seedTrace(request, group, name);
-    seed.trackResource(`/api/v1/trace/schema/${group}/${name}`);
+    seed.trackResource(`./api/v1/trace/schema/${group}/${name}`);
     await schemaPage.gotoResource('traces', group, name);
     await expect(page.getByText('trace id')).toBeVisible();
     await expect(page.getByText('span id')).toBeVisible();
@@ -295,7 +295,7 @@ test.describe('trace crud @e2e @schema @seed', () => {
     const group = await seed.createGroup('e2e-tedit', 'CATALOG_TRACE');
     const name = seed.uniqueName('t');
     await seedTrace(request, group, name);
-    seed.trackResource(`/api/v1/trace/schema/${group}/${name}`);
+    seed.trackResource(`./api/v1/trace/schema/${group}/${name}`);
     await schemaPage.gotoResource('traces', group, name);
     await schemaPage.editResourceButton().click();
     const dlg = schemaPage.dialog('Edit trace');
@@ -311,7 +311,7 @@ test.describe('trace crud @e2e @schema @seed', () => {
     const group = await seed.createGroup('e2e-tdel', 'CATALOG_TRACE');
     const name = seed.uniqueName('t');
     await seedTrace(request, group, name);
-    seed.trackResource(`/api/v1/trace/schema/${group}/${name}`);
+    seed.trackResource(`./api/v1/trace/schema/${group}/${name}`);
     await schemaPage.gotoResource('traces', group, name);
     await schemaPage.deleteResource('traces');
     await expect(page).toHaveURL(new RegExp(`/metadata/traces/${group}$`));
@@ -344,7 +344,7 @@ test.describe('resource pagination @e2e @schema @seed', () => {
     // Distinct, zero-padded names so 'pg-5' matches exactly pg-50..pg-54.
     const names = Array.from({ length: COUNT }, (_, i) => `${group}-pg-${String(i).padStart(2, '0')}`);
     await Promise.all(names.map(async (measureName) => {
-      const res = await request.post('/api/v1/measure/schema', {
+      const res = await request.post('./api/v1/measure/schema', {
         data: {
           measure: {
             metadata: { name: measureName, group },
@@ -356,7 +356,7 @@ test.describe('resource pagination @e2e @schema @seed', () => {
         },
       });
       if (!res.ok()) throw new Error(`seed measure ${measureName} failed: ${res.status()}`);
-      seed.trackResource(`/api/v1/measure/schema/${group}/${measureName}`);
+      seed.trackResource(`./api/v1/measure/schema/${group}/${measureName}`);
     }));
 
     await schemaPage.gotoGroup('measures', group);

--- a/canopy/server/src/config.ts
+++ b/canopy/server/src/config.ts
@@ -38,6 +38,27 @@ export interface Config {
   readonly users: CanopyUser[];
   readonly devNoAuth: boolean;
   readonly blockRfc1918: boolean;
+  readonly basePath: string;
+  readonly baseHref: string;
+}
+
+export function normalizeBasePath(value: string | undefined): { basePath: string; baseHref: string } {
+  const input = value?.trim() || '/';
+  if (input.startsWith('//') || !/^\/?[A-Za-z0-9._~/-]+$/.test(input) || /(?:^|\/)\.\.?($|\/)/.test(input)) {
+    throw new Error('CANOPY_BASE_PATH must be a URL path without a query, fragment, backslash, or traversal segment');
+  }
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(input);
+  } catch {
+    throw new Error('CANOPY_BASE_PATH must contain valid URL encoding');
+  }
+  if (decoded.startsWith('//') || !/^\/?[A-Za-z0-9._~/-]+$/.test(decoded) || /(?:^|\/)\.\.?($|\/)/.test(decoded)) {
+    throw new Error('CANOPY_BASE_PATH must not contain encoded traversal segments');
+  }
+  const withLeadingSlash = input.startsWith('/') ? input : `/${input}`;
+  const basePath = withLeadingSlash.replace(/\/+$/, '') || '/';
+  return { basePath, baseHref: basePath === '/' ? '/' : `${basePath}/` };
 }
 
 function loadUsers(canopyUsersPath: string | undefined, devNoAuth: boolean): CanopyUser[] {
@@ -88,6 +109,7 @@ export function loadConfig(): Config {
   const users = loadUsers(process.env.CANOPY_USERS, devNoAuth);
 
   const upstreamPassword = resolveUpstreamPassword();
+  const { basePath, baseHref } = normalizeBasePath(process.env.CANOPY_BASE_PATH);
 
   return {
     port: parseInt(process.env.PORT || '4000', 10),
@@ -100,5 +122,7 @@ export function loadConfig(): Config {
     users,
     devNoAuth,
     blockRfc1918: process.env.BLOCK_RFC1918 === 'true',
+    basePath,
+    baseHref,
   };
 }

--- a/canopy/server/src/index.ts
+++ b/canopy/server/src/index.ts
@@ -56,10 +56,12 @@ app.addHook('onSend', async (_request, reply) => {
 app.get('/healthz', async () => ({ status: 'ok' }));
 
 async function start() {
-  await registerSession(app, config);
-  await registerAuth(app, config);
-  await registerProxy(app, config);
-  await registerStatic(app);
+  await app.register(async scopedApp => {
+    await registerSession(scopedApp, config);
+    await registerAuth(scopedApp, config);
+    await registerProxy(scopedApp, config);
+    await registerStatic(scopedApp, config);
+  }, config.basePath === '/' ? {} : { prefix: config.basePath });
 
   await app.listen({ port: config.port, host: '0.0.0.0' });
   app.log.info(`Canopy BFF listening on port ${config.port}`);

--- a/canopy/server/src/plugins/proxy.ts
+++ b/canopy/server/src/plugins/proxy.ts
@@ -162,13 +162,18 @@ export async function registerProxy(app: FastifyInstance, config: Config): Promi
   // /api/* — proxied VERBATIM to config.banyandbTarget (no prefix add/strip)
   app.all('/api/*', { preHandler: [requireAuth, enforceRole] }, async (request, reply) => {
     const upstreamBase = getSessionEndpoint(request, config);
-    const upstreamPath = request.url; // VERBATIM — includes /api/v1/... prefix
+    const upstreamPath = stripBasePath(request.url, config.basePath);
     await forwardRequest(upstreamBase, upstreamPath, request, reply, config, upstreamAuth);
   });
 
   // /monitoring/* — forwarded to MONITOR_TARGET with /monitoring prefix STRIPPED
   app.all('/monitoring/*', { preHandler: [requireAuth] }, async (request, reply) => {
-    const stripped = request.url.replace(/^\/monitoring/, '');
+    const scopedPath = stripBasePath(request.url, config.basePath);
+    const stripped = scopedPath.replace(/^\/monitoring/, '');
     await forwardRequest(config.monitorTarget, stripped, request, reply, config, undefined);
   });
+}
+
+function stripBasePath(requestURL: string, basePath: string): string {
+  return basePath === '/' ? requestURL : requestURL.slice(basePath.length) || '/';
 }

--- a/canopy/server/src/plugins/proxy.ts
+++ b/canopy/server/src/plugins/proxy.ts
@@ -159,7 +159,7 @@ export async function registerProxy(app: FastifyInstance, config: Config): Promi
     }
   }
 
-  // /api/* — proxied VERBATIM to config.banyandbTarget (no prefix add/strip)
+  // /api/* — strip Canopy's mount prefix, then preserve the remaining path verbatim.
   app.all('/api/*', { preHandler: [requireAuth, enforceRole] }, async (request, reply) => {
     const upstreamBase = getSessionEndpoint(request, config);
     const upstreamPath = stripBasePath(request.url, config.basePath);

--- a/canopy/server/src/plugins/session.ts
+++ b/canopy/server/src/plugins/session.ts
@@ -34,7 +34,7 @@ export async function registerSession(app: FastifyInstance, config: Config): Pro
     secret: config.sessionSecret,
     salt: 'canopy-sess-salt',
     cookie: {
-      path: '/',
+      path: config.baseHref,
       httpOnly: true,
       sameSite: 'strict',
       // Preserve Secure cookies over HTTPS while allowing an HTTP-only

--- a/canopy/server/src/plugins/static.ts
+++ b/canopy/server/src/plugins/static.ts
@@ -35,7 +35,19 @@ export async function registerStatic(app: FastifyInstance, config: Config): Prom
     return;
   }
 
-  const indexTemplate = readFileSync(join(WEB_DIST, 'index.html'), 'utf8');
+  const indexPath = join(WEB_DIST, 'index.html');
+  if (!existsSync(indexPath)) {
+    app.log.warn(`[static] index.html not found at ${indexPath} — SPA serving disabled (run npm run build in web/)`);
+    return;
+  }
+
+  let indexTemplate: string;
+  try {
+    indexTemplate = readFileSync(indexPath, 'utf8');
+  } catch (error) {
+    app.log.warn({ error }, `[static] failed to read ${indexPath} — SPA serving disabled`);
+    return;
+  }
   const runtimeIndex = indexTemplate
     .replace('<base href="/" />', `<base href="${config.baseHref}" />`)
     .replace('<meta name="canopy-base-path" content="/" />', `<meta name="canopy-base-path" content="${config.basePath}" />`);

--- a/canopy/server/src/plugins/static.ts
+++ b/canopy/server/src/plugins/static.ts
@@ -17,24 +17,39 @@
  * under the License.
  */
 
+import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { existsSync } from 'node:fs';
-import type { FastifyInstance } from 'fastify';
+
+import type { FastifyInstance, FastifyReply } from 'fastify';
 import fastifyStatic from '@fastify/static';
+
+import type { Config } from '../config.js';
 
 // Anchor to process.cwd() (always the server package dir) rather than __dirname so
 // the path is correct both in ts-node (src/plugins/) and compiled (dist/src/plugins/).
 const WEB_DIST = join(process.cwd(), '..', 'web', 'dist');
 
-export async function registerStatic(app: FastifyInstance): Promise<void> {
+export async function registerStatic(app: FastifyInstance, config: Config): Promise<void> {
   if (!existsSync(WEB_DIST)) {
     app.log.warn(`[static] web/dist not found at ${WEB_DIST} — SPA serving disabled (run npm run build in web/)`);
     return;
   }
 
+  const indexTemplate = readFileSync(join(WEB_DIST, 'index.html'), 'utf8');
+  const runtimeIndex = indexTemplate
+    .replace('<base href="/" />', `<base href="${config.baseHref}" />`)
+    .replace('<meta name="canopy-base-path" content="/" />', `<meta name="canopy-base-path" content="${config.basePath}" />`);
+  const sendIndex = async (reply: FastifyReply) => {
+    reply.header('Content-Type', 'text/html; charset=utf-8');
+    reply.header('Cache-Control', 'no-store, must-revalidate');
+    reply.header('Pragma', 'no-cache');
+    await reply.send(runtimeIndex);
+  };
+
   await app.register(fastifyStatic, {
     root: WEB_DIST,
     prefix: '/',
+    index: false,
     // SPA assets must always revalidate. Without these headers the browser
     // caches the index.html + the hash-named bundle, so a `npm run -w web build`
     // that swaps the bundle filename does NOT clear the browser's view of the
@@ -55,9 +70,11 @@ export async function registerStatic(app: FastifyInstance): Promise<void> {
     // to ensure /api, /auth, /monitoring, /healthz are NOT shadowed.
   });
 
+  app.get('/', async (_request, reply) => sendIndex(reply));
+
   // SPA fallback: serve index.html for any path not matching API/auth/monitoring/healthz
   app.setNotFoundHandler(async (request, reply) => {
-    const path = request.url;
+    const path = config.basePath === '/' ? request.url : request.url.slice(config.basePath.length) || '/';
     if (
       path.startsWith('/api/') ||
       path.startsWith('/auth/') ||
@@ -71,6 +88,6 @@ export async function registerStatic(app: FastifyInstance): Promise<void> {
     // SPA fallback — always re-validate the HTML.
     reply.header('Cache-Control', 'no-store, must-revalidate');
     reply.header('Pragma', 'no-cache');
-    await reply.sendFile('index.html', WEB_DIST);
+    await sendIndex(reply);
   });
 }

--- a/canopy/server/test/bff.test.ts
+++ b/canopy/server/test/bff.test.ts
@@ -61,6 +61,8 @@ async function buildTestApp(configOverrides: Partial<Config> = {}): Promise<Fast
     ],
     devNoAuth: false,
     blockRfc1918: false,
+    basePath: '/',
+    baseHref: '/',
     ...configOverrides,
   };
 
@@ -223,7 +225,7 @@ describe('SPA fallback scoping', () => {
 
   beforeEach(async () => {
     app = await buildTestApp();
-    await registerStatic(app);
+    await registerStatic(app, { basePath: '/', baseHref: '/' } as Config);
   });
 
   afterEach(async () => { await app.close(); });

--- a/canopy/server/test/config.test.ts
+++ b/canopy/server/test/config.test.ts
@@ -1,0 +1,72 @@
+/*
+ * Licensed to Apache Software Foundation (ASF) under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. The ASF licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { loadConfig } from '../src/config.js';
+
+const TEST_SECRET = 'test-secret-32-chars-minimum-xxxxx';
+let originalEnv: NodeJS.ProcessEnv;
+
+describe('CANOPY_BASE_PATH', () => {
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+    process.env.NODE_ENV = 'test';
+    process.env.SESSION_SECRET = TEST_SECRET;
+    process.env.CANOPY_DEV_NOAUTH = 'true';
+    delete process.env.CANOPY_BASE_PATH;
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    [undefined, '/', '/'],
+    ['/', '/', '/'],
+    ['canopy', '/canopy', '/canopy/'],
+    ['/canopy', '/canopy', '/canopy/'],
+    ['/canopy/', '/canopy', '/canopy/'],
+    ['/tools/banyandb/canopy', '/tools/banyandb/canopy', '/tools/banyandb/canopy/'],
+  ])('normalizes %s', (configuredPath, expectedPath, expectedHref) => {
+    if (configuredPath !== undefined) {
+      process.env.CANOPY_BASE_PATH = configuredPath;
+    }
+
+    const config = loadConfig();
+
+    expect(config.basePath).toBe(expectedPath);
+    expect(config.baseHref).toBe(expectedHref);
+  });
+
+  it.each([
+    'http://example.com/canopy',
+    '//example.com/canopy',
+    '/canopy?mode=admin',
+    '/canopy#settings',
+    '/canopy/../admin',
+    '/canopy\\admin',
+    '/%2e%2e/admin',
+  ])('rejects invalid value %j', configuredPath => {
+    process.env.CANOPY_BASE_PATH = configuredPath;
+
+    expect(() => loadConfig()).toThrow(/CANOPY_BASE_PATH/);
+  });
+});

--- a/canopy/server/test/session.test.ts
+++ b/canopy/server/test/session.test.ts
@@ -30,6 +30,8 @@ const TEST_CONFIG: Config = {
   users: [],
   devNoAuth: false,
   blockRfc1918: false,
+  basePath: '/',
+  baseHref: '/',
 };
 
 function cookieHeader(setCookie: string | string[] | undefined): string {
@@ -46,10 +48,10 @@ describe('session cookies', () => {
     await Promise.all(apps.splice(0).map(app => app.close()));
   });
 
-  async function buildApp(): Promise<FastifyInstance> {
+  async function buildApp(config: Config = TEST_CONFIG): Promise<FastifyInstance> {
     const app = Fastify({ trustProxy: true });
     apps.push(app);
-    await registerSession(app, TEST_CONFIG);
+    await registerSession(app, config);
     app.get('/login', async request => {
       request.session.user = 'admin';
       request.session.role = 'admin';
@@ -58,6 +60,15 @@ describe('session cookies', () => {
     });
     return app;
   }
+
+  it('scopes the session cookie to the configured base path', async () => {
+    const app = await buildApp({ ...TEST_CONFIG, basePath: '/canopy', baseHref: '/canopy/' });
+
+    const response = await app.inject({ method: 'GET', url: '/login' });
+
+    expect(response.statusCode).toBe(200);
+    expect(cookieHeader(response.headers['set-cookie'])).toContain('; Path=/canopy/');
+  });
 
   it('sets a Secure cookie when TLS is terminated by a proxy', async () => {
     const app = await buildApp();

--- a/canopy/web/index.html
+++ b/canopy/web/index.html
@@ -21,6 +21,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <base href="/" />
+    <meta name="canopy-base-path" content="/" />
     <title>Canopy — BanyanDB Console</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/canopy/web/src/App.tsx
+++ b/canopy/web/src/App.tsx
@@ -18,6 +18,7 @@
  */
 import React, { useState } from 'react';
 import { BrowserRouter, Routes, Route, useParams, useNavigate } from 'react-router';
+import { canopyBasePath } from './runtime-config.js';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import { AuthProvider, useAuth } from './auth/AuthContext.js';
@@ -563,7 +564,7 @@ function AppContent() {
 export default function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
+      <BrowserRouter basename={canopyBasePath}>
         <AuthProvider>
           <AppContent />
         </AuthProvider>

--- a/canopy/web/src/auth/AuthContext.tsx
+++ b/canopy/web/src/auth/AuthContext.tsx
@@ -17,6 +17,7 @@
  * under the License.
  */
 import React, { createContext, useContext, useEffect, useState } from 'react';
+import { canopyPath } from '../runtime-config.js';
 
 export interface Session {
   readonly user: string;
@@ -41,7 +42,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetch('/auth/session')
+    fetch(canopyPath('/auth/session'))
       .then(res => (res.ok ? res.json() as Promise<Session> : null))
       .then(s => { setSession(s); setLoading(false); })
       .catch(() => setLoading(false));

--- a/canopy/web/src/components/Sidebar.tsx
+++ b/canopy/web/src/components/Sidebar.tsx
@@ -23,6 +23,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import { CanopyMark } from './CanopyMark.js';
 import { useAuth } from '../auth/AuthContext.js';
+import { canopyPath } from '../runtime-config.js';
 import { apiDataSource } from '../data/api.js';
 import {
   IconHome, IconMetadata, IconMeasures, IconStreams, IconTraces,
@@ -421,7 +422,7 @@ export function Sidebar({ collapsed, onToggleCollapse }: SidebarProps) {
     let cancelled = false;
     const probe = async () => {
       try {
-        const res = await fetch('/api/meta');
+        const res = await fetch(canopyPath('/api/meta'));
         if (!res.ok) return;
         const d = await res.json() as { banyandbTarget?: string; reachable?: boolean };
         if (cancelled) return;
@@ -438,7 +439,7 @@ export function Sidebar({ collapsed, onToggleCollapse }: SidebarProps) {
   const displayHost = banyandbTarget.replace(/^https?:\/\//, '');
 
   const signOut = async () => {
-    try { await fetch('/auth/logout', { method: 'POST' }); } catch { /* ignore */ }
+    try { await fetch(canopyPath('/auth/logout'), { method: 'POST' }); } catch { /* ignore */ }
     setSession(null);
     navigate('/');
   };

--- a/canopy/web/src/data/api.ts
+++ b/canopy/web/src/data/api.ts
@@ -34,9 +34,10 @@ import type {
 } from 'canopy-shared';
 
 import type { DataSource } from './DataSource.js';
+import { canopyPath } from '../runtime-config.js';
 
 async function apiFetch<T>(url: string, init?: RequestInit): Promise<T> {
-  const res = await fetch(url, init);
+  const res = await fetch(canopyPath(url), init);
   if (!res.ok) {
     let msg = `${res.status} ${res.statusText}`;
     try {

--- a/canopy/web/src/pages/LoginPage.tsx
+++ b/canopy/web/src/pages/LoginPage.tsx
@@ -21,6 +21,7 @@ import React, { useState, useEffect } from 'react';
 
 import { CanopyMark } from '../components/CanopyMark.js';
 import { useAuth } from '../auth/AuthContext.js';
+import { canopyPath } from '../runtime-config.js';
 import { IconShield, IconViewer } from '../components/icons.js';
 
 type Role = 'admin' | 'readonly';
@@ -113,7 +114,7 @@ export function LoginPage() {
   // The BanyanDB target itself is configured server-side (BANYANDB_TARGET)
   // and is no longer a per-session input.
   useEffect(() => {
-    fetch('/api/meta')
+    fetch(canopyPath('/api/meta'))
       .then(r => r.ok ? r.json() as Promise<{ banyanVersion: string | null; reachable?: boolean }> : null)
       .then(d => {
         if (!d) { setBanyanReachable(false); setBanyanVersion(null); return; }
@@ -153,7 +154,7 @@ export function LoginPage() {
     // so the result is authoritative even if the mount-time probe is stale.
     let preflightReachable = banyanReachable;
     try {
-      const probe = await fetch('/api/meta');
+      const probe = await fetch(canopyPath('/api/meta'));
       if (probe.ok) {
         const meta = await probe.json() as { reachable?: boolean };
         preflightReachable = typeof meta.reachable === 'boolean' ? meta.reachable : preflightReachable;
@@ -170,7 +171,7 @@ export function LoginPage() {
     setStatus('connecting');
     setErrorMsg('');
     try {
-      const res = await fetch('/auth/login', {
+      const res = await fetch(canopyPath('/auth/login'), {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ username: username.trim(), password }),

--- a/canopy/web/src/runtime-config.ts
+++ b/canopy/web/src/runtime-config.ts
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor
+ * license agreements. See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership. The ASF licenses this file to You under
+ * the Apache License, Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific
+ * language governing permissions and limitations under the License.
+ */
+
+const configuredBasePath = document.querySelector<HTMLMetaElement>('meta[name="canopy-base-path"]')?.content || '/';
+
+export const canopyBasePath = configuredBasePath === '/' ? undefined : configuredBasePath;
+
+export function canopyPath(path: string): string {
+  const relativePath = path.replace(/^\/+/, '');
+  const url = new URL(relativePath, document.baseURI);
+  return `${url.pathname}${url.search}${url.hash}`;
+}

--- a/canopy/web/vite.config.ts
+++ b/canopy/web/vite.config.ts
@@ -21,6 +21,7 @@ import react from '@vitejs/plugin-react';
 import { resolve } from 'node:path';
 
 export default defineConfig({
+  base: './',
   plugins: [react()],
   resolve: {
     alias: {

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -147,7 +147,7 @@ would measure a trace from a later span and understate it.
 A Go plugin is loaded via `plugin.Open`, which requires the `.so` and the
 host process to share the **exact same**:
 
-- Go toolchain version (this repo pins `go 1.25.12` via `go.mod`; `GOTOOLCHAIN=auto`
+- Go toolchain version (this repo pins `go 1.25.13` via `go.mod`; `GOTOOLCHAIN=auto`
   resolves it identically in CI, in the `-plugins` Docker builder stage, and
   in a local `make build-plugins`),
 - `pkg/pipeline/sdk` package build (and its full transitive module graph),

--- a/scripts/run-trace-merge-baseline.sh
+++ b/scripts/run-trace-merge-baseline.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 FIXTURE=${FIXTURE:-"$ROOT/.scratch/trace-pipeline-merge-performance/generated-fixture-2x-v2-timestamps"}
 OUTPUT=${OUTPUT:-"$ROOT/.scratch/trace-pipeline-merge-performance/baseline-report"}
-IMAGE=${IMAGE:-golang:1.25.12}
+IMAGE=${IMAGE:-golang:1.25.13}
 DATA_CPUS=${DATA_CPUS:-0-1}
 DATA_CPU_LIMIT=${DATA_CPU_LIMIT:-2}
 DATA_MEMORY=${DATA_MEMORY:-4g}

--- a/scripts/run-trace-merge-controlled-seed.sh
+++ b/scripts/run-trace-merge-controlled-seed.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 FIXTURE=${FIXTURE:-"$ROOT/.scratch/trace-pipeline-merge-performance/generated-fixture-2x-v2-timestamps"}
 OUTPUT=${OUTPUT:-"$ROOT/.scratch/trace-pipeline-merge-performance/baseline-report"}
-IMAGE=${IMAGE:-golang:1.25.12}
+IMAGE=${IMAGE:-golang:1.25.13}
 DATA_CPUS=${DATA_CPUS:-0-1}
 DATA_CPU_LIMIT=${DATA_CPU_LIMIT:-2}
 DATA_MEMORY=${DATA_MEMORY:-4g}


### PR DESCRIPTION
### Fix Canopy routing behind an Nginx path-prefix proxy

- [x] Add unit and end-to-end coverage to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.

Canopy previously assumed it was mounted at `/`. That made browser routes, BFF requests, static assets, redirects, and the session cookie escape the configured Nginx location when Canopy was exposed under a prefix such as `/canopy/`.

This change adds runtime `CANOPY_BASE_PATH` support without requiring a Helm chart change. The server scopes its routes and cookie to the normalized prefix, strips the prefix before proxying to BanyanDB, and injects the runtime base into the served HTML. The web application consumes that value for React Router, API requests, assets, redirects, and navigation. Playwright helpers and tests now work with a prefixed base URL.

It also updates remaining Go 1.25 references to Go 1.25.13, matching the current secure patch release.

#### User impact

Operators can deploy the existing image behind an Nginx path-prefix proxy by setting `CANOPY_BASE_PATH=/canopy`; no Helm template changes are required.

#### Validation

- `make pre-push`
- Local Nginx proxy mounted at `/canopy/`
- Playwright suite executed against Nginx: 64 passed; 11 existing selector/data-dependent cases failed (10 remained on a single-worker retry)
- `govulncheck`: no reachable vulnerabilities

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Fixes apache/skywalking#<issue number>.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking-banyandb/blob/main/CHANGES.md).
