### PR TITLE
Fix merge benchmark observer test setup

### DIFF
--- a/banyand/trace/merge_benchmark_observer_test.go
+++ b/banyand/trace/merge_benchmark_observer_test.go
@@ -370,6 +370,9 @@ func runObservedBenchmarkMerge(t *testing.T, mature bool) (mergeBenchmarkEvent, 
 	for _, indexName := range []string{"latency", "start_time"} {
 		table.mustGetOrCreateSidx(indexName)
 	}
+	var jsonLines bytes.Buffer
+	observer := newMergeBenchmarkObserver(&jsonLines, mergeBenchmarkObserverOptions{Phase: mergePhasePrimary, Attribution: true})
+	require.True(t, table.setMergeBenchmarkObserver(observer))
 	table.observePartID(partIDs[len(partIDs)-1])
 	for _, partID := range partIDs {
 		require.NoError(t, os.Rename(filepath.Join(prepared, formatExternalPartID(partID)), filepath.Join(root, formatExternalPartID(partID))))
@@ -394,9 +397,6 @@ func runObservedBenchmarkMerge(t *testing.T, mature bool) (mergeBenchmarkEvent, 
 		table.setMergeNow(base.Add(time.Minute))
 	}
 
-	var jsonLines bytes.Buffer
-	observer := newMergeBenchmarkObserver(&jsonLines, mergeBenchmarkObserverOptions{Phase: mergePhasePrimary, Attribution: true})
-	require.True(t, table.setMergeBenchmarkObserver(observer))
 	require.NoError(t, table.triggerMerge())
 	waitCtx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 	defer cancel()


### PR DESCRIPTION
## Summary

- Install the merge benchmark observer before external parts can trigger the merge loop.
- Keep the budget-triggered staging test bound to the merge it creates.

## Testing

- `go test -race -count=20 -run '^TestMergeBenchmarkObserverReportsBudgetTriggeredBatches$' ./banyand/trace/...`
- `make lint`

Flaky-Test: github.com/apache/skywalking-banyandb/banyand/trace.TestMergeBenchmarkObserverReportsBudgetTriggeredBatches
