### PR TITLE
Fix flaky schema-merge tests near midnight

### DIFF
--- a/banyand/measure/metadata_test.go
+++ b/banyand/measure/metadata_test.go
@@ -521,14 +521,16 @@ var _ = Describe("Schema Change", func() {
 			if elapsed := now.Sub(midnight); elapsed <= firstOffset {
 				firstOffset, secondOffset = elapsed/2, elapsed/4
 			}
+			firstBatchTime := now.Add(-firstOffset).Truncate(time.Millisecond)
+			secondBatchTime := now.Add(-secondOffset).Truncate(time.Millisecond)
 
 			env := setupSchemaChangeMeasure(svcs, measureName, measureSetupOptions{withExtraTag: true})
-			writeSchemaChangeMeasureData(svcs, measureName, now.Add(-firstOffset), 5,
+			writeSchemaChangeMeasureData(svcs, measureName, firstBatchTime, 5,
 				measureWriteDataOptions{withExtraTag: true})
 			filePartCountAfterFirstBatch, filePartCountErr := getMeasureFilePartCount(svcs, groupName)
 			Expect(filePartCountErr).ShouldNot(HaveOccurred())
 			changeExtraMeasureTagType(svcs, measureName)
-			writeSchemaChangeMeasureData(svcs, measureName, now.Add(-secondOffset), 3,
+			writeSchemaChangeMeasureData(svcs, measureName, secondBatchTime, 3,
 				measureWriteDataOptions{withExtraTagString: true, entityIDPrefix: "entity_new_"})
 			// Wait for the second batch to flush to disk, creating additional
 			// file parts that the merge loop can pick up. Without this gate the

--- a/banyand/stream/metadata_test.go
+++ b/banyand/stream/metadata_test.go
@@ -509,12 +509,21 @@ var _ = Describe("Schema Change", func() {
 		It("querying data should return correct values after parts with different types are merged", func() {
 			streamName := "schema_change_tag_type_merge"
 			now := timestamp.NowMilli()
+			// Keep both batches in today's segment when the test runs near midnight;
+			// parts from different day segments cannot be merged.
+			firstOffset, secondOffset := 2*time.Hour, time.Hour
+			midnight := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+			if elapsed := now.Sub(midnight); elapsed <= firstOffset {
+				firstOffset, secondOffset = elapsed/2, elapsed/4
+			}
+			firstBatchTime := now.Add(-firstOffset).Truncate(time.Millisecond)
+			secondBatchTime := now.Add(-secondOffset).Truncate(time.Millisecond)
 
 			env := setupSchemaChangeStream(svcs, streamName, groupName, streamSetupOptions{withExtraTag: true})
-			writeSchemaChangeData(svcs, streamName, groupName, now.Add(-2*time.Hour), 5,
+			writeSchemaChangeData(svcs, streamName, groupName, firstBatchTime, 5,
 				writeDataOptions{extraTag: extraTagInt})
 			changeExtraTagType(svcs, streamName, groupName)
-			writeSchemaChangeData(svcs, streamName, groupName, now.Add(-1*time.Hour), 3,
+			writeSchemaChangeData(svcs, streamName, groupName, secondBatchTime, 3,
 				writeDataOptions{extraTag: extraTagString, traceIDPrefix: "trace_new_", elementIDOffset: 5})
 			partCountBeforeMerge, partCountErr := getTotalStreamPartCount(svcs, groupName)
 			Expect(partCountErr).ShouldNot(HaveOccurred())


### PR DESCRIPTION
### Fix flaky schema-merge tests near midnight

- [x] Add test verification that the fixes work.
- [x] Explain briefly why the bugs exist and how to fix them.

The measure schema-merge test starts with a millisecond-aligned timestamp, but near midnight it divides the elapsed-since-midnight duration by two and four to keep both batches in the same segment. Duration division can introduce fractional milliseconds, causing BanyanDB to reject the generated writes with `invalid timestamp: time is not millisecond precision`.

Normalize the final measure batch timestamps to millisecond precision after applying the calculated offsets. This preserves the intended ordering and segment placement while satisfying the write API contract.

The equivalent stream schema-merge test always used `now-2h` and `now-1h`. During the first two hours after midnight those batches occupy different day segments, whose parts can never merge. Apply the same near-midnight offset strategy and millisecond normalization so both stream batches remain in one segment.

#### Validation

```text
go test ./banyand/measure -run TestMeasure -ginkgo.focus='Measure schema with changed tag type after merge' -count=1
go test ./banyand/stream -run TestStream -ginkgo.focus='Stream schema with changed tag type after merge' -count=1
```

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Fixes apache/skywalking#<issue number>.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking-banyandb/blob/main/CHANGES.md).
