### PR TITLE
Fix liaison batch timeout for long-lived write streams

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -67,6 +67,8 @@ Release Notes.
 
 ### Bug Fixes
 
+- Prevent long-lived client write streams from failing whole liaison batches when the write timeout expires; start the liaison admission timeout
+  only after the batch is sealed and raise its default to two minutes. (apache/skywalking#13982)
 - Stabilize measure, stream, and trace snapshot tests by waiting for persisted manifests and all flushed memory parts rather than directory creation or the latest snapshot creator, eliminating asynchronous-flush and fallback races.
 - Prevent merge-time trace sampling from dropping fragments when the same trace ID may remain in unselected parts. Provisional drops are now checked against time bounds and
   trace-ID Bloom filters in candidate outside parts whose time bounds intersect the trace's max-fragment-gap-expanded range, revalidated before publication, and retained on

--- a/banyand/liaison/grpc/server.go
+++ b/banyand/liaison/grpc/server.go
@@ -67,6 +67,7 @@ import (
 
 const (
 	defaultRecvSize         = 16 << 20
+	defaultWriteTimeout     = 2 * time.Minute
 	maxReasonableBufferSize = 1 << 30 // 1GB
 )
 
@@ -452,9 +453,9 @@ func (s *server) FlagSet() *run.FlagSet {
 	fs.BoolVar(&s.enableQueryAccessLog, "enable-query-access-log", false, "enable query access log")
 	fs.StringVar(&s.accessLogRootPath, "access-log-root-path", "", "access log root path")
 	fs.BoolVar(&s.accessLogSampled, "access-log-sampled", false, "if true, requests may be dropped when the channel is full; if false, requests are never dropped")
-	fs.DurationVar(&s.streamSVC.writeTimeout, "stream-write-timeout", time.Minute, "timeout for writing stream among liaison nodes")
-	fs.DurationVar(&s.measureSVC.writeTimeout, "measure-write-timeout", time.Minute, "timeout for writing measure among liaison nodes")
-	fs.DurationVar(&s.traceSVC.writeTimeout, "trace-write-timeout", time.Minute, "timeout for writing trace among liaison nodes")
+	fs.DurationVar(&s.streamSVC.writeTimeout, "stream-write-timeout", defaultWriteTimeout, "timeout for writing stream among liaison nodes")
+	fs.DurationVar(&s.measureSVC.writeTimeout, "measure-write-timeout", defaultWriteTimeout, "timeout for writing measure among liaison nodes")
+	fs.DurationVar(&s.traceSVC.writeTimeout, "trace-write-timeout", defaultWriteTimeout, "timeout for writing trace among liaison nodes")
 	fs.DurationVar(&s.measureSVC.maxWaitDuration, "measure-metadata-cache-wait-duration", 0,
 		"the maximum duration to wait for metadata cache to load (for testing purposes)")
 	fs.DurationVar(&s.streamSVC.maxWaitDuration, "stream-metadata-cache-wait-duration", 0,

--- a/banyand/liaison/grpc/server_test.go
+++ b/banyand/liaison/grpc/server_test.go
@@ -58,6 +58,26 @@ func TestGrpcBufferMemoryRatioFlagDefault(t *testing.T) {
 	assert.Equal(t, "0.1", flag.DefValue)
 }
 
+// TestLiaisonWriteTimeoutFlagDefaults verifies the safety margin for tier-1 admission.
+func TestLiaisonWriteTimeoutFlagDefaults(t *testing.T) {
+	s := &server{
+		streamSVC:      &streamService{},
+		measureSVC:     &measureService{},
+		traceSVC:       &traceService{},
+		propertyServer: &propertyServer{},
+	}
+	flagSet := s.FlagSet()
+	expectedTimeout := 2 * time.Minute
+	for _, flagName := range []string{"stream-write-timeout", "measure-write-timeout", "trace-write-timeout"} {
+		timeoutFlag := flagSet.Lookup(flagName)
+		require.NotNil(t, timeoutFlag)
+		assert.Equal(t, expectedTimeout.String(), timeoutFlag.DefValue)
+	}
+	assert.Equal(t, expectedTimeout, s.streamSVC.writeTimeout)
+	assert.Equal(t, expectedTimeout, s.measureSVC.writeTimeout)
+	assert.Equal(t, expectedTimeout, s.traceSVC.writeTimeout)
+}
+
 // TestGrpcBufferMemoryRatioValidation verifies validation logic.
 func TestGrpcBufferMemoryRatioValidation(t *testing.T) {
 	tests := []struct {

--- a/banyand/queue/pub/batch.go
+++ b/banyand/queue/pub/batch.go
@@ -59,6 +59,7 @@ const (
 type writeStream struct {
 	client         clusterv1.Service_SendClient
 	ctxDoneCh      <-chan struct{}
+	cancel         context.CancelFunc
 	batchStart     time.Time
 	firstFrameSent bool // false until the first frame is sent; the first frame carries the sender_* identity labels
 }
@@ -73,6 +74,7 @@ type batchPublisher struct {
 }
 
 // NewBatchPublisher returns a new batch publisher.
+// The timeout bounds acknowledgement after Close seals the batch, not the time between Publish calls.
 func (p *pub) NewBatchPublisher(timeout time.Duration) queue.BatchPublisher {
 	return &batchPublisher{
 		pub:     p,
@@ -181,14 +183,12 @@ func (bp *batchPublisher) Publish(ctx context.Context, topic bus.Topic, messages
 			continue
 		}
 
-		streamCtx, cancel := context.WithTimeout(ctx, bp.timeout)
+		streamCtx, cancel := context.WithCancel(ctx)
 		// this assignment is for getting around the go vet lint
 		deferFn := cancel
 		stream, errCreateStream := nodeClient.client.Send(streamCtx)
 		if errCreateStream != nil {
-			// Release the timeout context when Send() fails; otherwise listenBatchResponse,
-			// which normally invokes deferFn on exit, is never spawned and streamCtx leaks
-			// until bp.timeout expires, accumulating timer goroutines under repeated failures.
+			// Release the stream context when Send fails because no response listener will own it.
 			cancel()
 			err = multierr.Append(err, fmt.Errorf("failed to get stream for node %s: %w", node, errCreateStream))
 			continue
@@ -197,6 +197,7 @@ func (bp *batchPublisher) Publish(ctx context.Context, topic bus.Topic, messages
 		bp.streams[node] = writeStream{
 			client:     stream,
 			ctxDoneCh:  streamCtx.Done(),
+			cancel:     cancel,
 			batchStart: streamBatchStart,
 		}
 		var batchOp string
@@ -323,8 +324,25 @@ func (bp *batchPublisher) Close() (cee map[string]*common.Error, err error) {
 		stream := bp.streams[nodeName]
 		err = multierr.Append(err, stream.client.CloseSend())
 	}
-	for i := range bp.streams {
-		<-bp.streams[i].ctxDoneCh
+	if len(bp.streams) > 0 {
+		admissionTimer := time.NewTimer(bp.timeout)
+		defer admissionTimer.Stop()
+		admissionTimedOut := false
+		for nodeName := range bp.streams {
+			select {
+			case <-bp.streams[nodeName].ctxDoneCh:
+			case <-admissionTimer.C:
+				for pendingNodeName := range bp.streams {
+					if bp.streams[pendingNodeName].cancel != nil {
+						bp.streams[pendingNodeName].cancel()
+					}
+				}
+				admissionTimedOut = true
+			}
+			if admissionTimedOut {
+				break
+			}
+		}
 	}
 	batchEvents := bp.f.get()
 	if len(batchEvents) < 1 {

--- a/banyand/queue/pub/pub_test.go
+++ b/banyand/queue/pub/pub_test.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/apache/skywalking-banyandb/api/common"
 	"github.com/apache/skywalking-banyandb/api/data"
+	databasev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
 	modelv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/model/v1"
 	streamv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/stream/v1"
 	"github.com/apache/skywalking-banyandb/pkg/bus"
@@ -193,6 +194,38 @@ var _ = ginkgo.Describe("Publish and Broadcast", func() {
 			gomega.Consistently(func() int {
 				return p.connMgr.ActiveCount()
 			}, "1s").Should(gomega.Equal(2))
+		})
+
+		ginkgo.It("should start the tier-1 liaison admission timeout when the batch is sealed", func() {
+			address := getAddress()
+			// This fixture exposes only cluster.v1.Service.Send; data-node ChunkedSyncService is not involved.
+			closeServer := setup(address, codes.OK, 0)
+			publisher := newPub(databasev1.Role_ROLE_LIAISON)
+			defer func() {
+				publisher.GracefulStop()
+				closeServer()
+			}()
+
+			liaisonNode := getDataNode("liaison1", address)
+			liaisonNode.Spec.(*databasev1.Node).Roles = []databasev1.Role{databasev1.Role_ROLE_LIAISON}
+			publisher.OnAddOrUpdate(liaisonNode)
+			gomega.Eventually(func() int {
+				return publisher.connMgr.ActiveCount()
+			}, flags.EventuallyTimeout).Should(gomega.Equal(1))
+
+			admissionTimeout := 500 * time.Millisecond
+			batchPublisher := publisher.NewBatchPublisher(admissionTimeout)
+			_, publishErr := batchPublisher.Publish(context.Background(), data.TopicStreamWrite,
+				bus.NewBatchMessageWithNode(bus.MessageID(1), "liaison1", &streamv1.InternalWriteRequest{}),
+			)
+			gomega.Expect(publishErr).ShouldNot(gomega.HaveOccurred())
+
+			// Client ingestion may keep the tier-1 batch open longer than the liaison admission timeout.
+			time.Sleep(2 * admissionTimeout)
+
+			failedNodes, closeErr := batchPublisher.Close()
+			gomega.Expect(closeErr).ShouldNot(gomega.HaveOccurred())
+			gomega.Expect(failedNodes).Should(gomega.BeEmpty())
 		})
 	})
 

--- a/banyand/queue/queue.go
+++ b/banyand/queue/queue.go
@@ -61,6 +61,7 @@ type Client interface {
 	bus.Publisher
 	bus.Broadcaster
 	route.TableProvider
+	// NewBatchPublisher creates a batch publisher whose timeout starts when Close seals the batch.
 	NewBatchPublisher(timeout time.Duration) BatchPublisher
 	NewChunkedSyncClient(node string, chunkSize uint32) (ChunkedSyncClient, error)
 	// SetSelfNode stamps the publisher's own node identity onto the wire

--- a/docs/operation/configuration.md
+++ b/docs/operation/configuration.md
@@ -83,11 +83,11 @@ The following flags are used to configure access logs for the data ingestion:
 - `--enable-ingestion-access-log`: Enable ingestion access log.
 - `--access-log-sampled`: if true, requests may be dropped when the channel is full; if false, requests are never dropped
 
-The following flags are used to configure the timeout of data sending from liaison to data servers:
+The following flags configure the tier-1 write admission timeout between liaison nodes:
 
-- `--stream-write-timeout duration`: Stream write timeout (default: 1m).
-- `--measure-write-timeout duration`: Measure write timeout (default: 1m).
-- `--trace-write-timeout duration`: Trace write timeout (default: 1m).
+- `--stream-write-timeout duration`: Stream write timeout (default: 2m).
+- `--measure-write-timeout duration`: Measure write timeout (default: 2m).
+- `--trace-write-timeout duration`: Trace write timeout (default: 2m).
 
 The following flags tune the BydbQL prepared-statement cache on the query path. The cache stores parsed statements keyed by query text so repeated, parameterized (`?`) queries skip re-parsing; literal queries without placeholders are never cached. It is bounded by both an entry count and the estimated in-memory size of the cached statements, evicting least-recently-used entries when either bound is exceeded. Effectiveness is observable via the `bydbql_prepared_cache_*` metrics (a `hit`/`miss`/`bypass` counter plus hit-ratio, entry-count, and byte-size gauges).
 


### PR DESCRIPTION
### Fix apache/skywalking#13982

- [x] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.

`batchPublisher` created the tier-1 liaison gRPC deadline when the first frame was published. Because the publisher lives for the external client's entire streaming write RPC, a normal long-lived client stream could consume the full timeout before its batch was sealed. Closing the publisher then surfaced one `STATUS_INTERNAL_ERROR` for every message routed through the expired per-liaison stream, even when the target liaison had already admitted the batch.

This change keeps the internal stream derived from the caller context but starts a bounded admission timer only after `CloseSend` seals the batch. Pending streams are canceled if the target liaison does not acknowledge within that window. It also raises the configurable stream, measure, and trace write timeout defaults from one minute to two minutes for additional load headroom. Data-node `ChunkedSyncService` synchronization is unchanged.

The regression uses an explicit `ROLE_LIAISON` target and only `cluster.v1.Service.Send`; it holds the publisher open beyond a short timeout, seals it, and verifies successful admission.

- [x] Fixes apache/skywalking#13982.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-banyandb/blob/main/CHANGES.md).

### Verification

- `go test ./banyand/queue/pub -count=1`
- `go test ./banyand/liaison/grpc -count=1`
- Focused regression with `-race`
- `make pre-push`
