### PR TITLE
fix(test): await schema barrier before standalone writes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -133,6 +133,7 @@ Release Notes.
 - Fix the measure schema-change merge test, which was time-of-day dependent rather than flaky. It wrote its two batches at `now-2h` and `now-1h` and waited for the part count to drop, but `sw_metric` uses a 1-day segment aligned to local midnight and a merge only ever combines parts within one segment, so any run starting within two hours of midnight split the batches across yesterday's and today's segments and the count could never drop. The budget had been raised twice (10x, then 20x) blaming merger starvation, which no budget could have cured; both offsets are now compressed into the elapsed part of the current segment.
 - Fix the flaky distributed schema clamp test: it queried once immediately after `AwaitRevision`/`AwaitApplied`, which confirm the schema cache but not that the data node has loaded the group's query topology, so the query could still fail with "group not found". It now retries until the query resolves, the same treatment the multi-group spec in the same file already had.
 - Stop the TopN test overriding the configured eventually timeout. It passed `flags.EventuallyTimeout` and then chained `WithTimeout(10s)`, which takes precedence, so the spec always ran on a 10s budget even though CI builds the integration suites with `-X ...flags.eventuallyTimeout=30s` to give slow runners room. It was the only case in `test/cases` opting out.
+- Await SchemaBarrier applied state after standalone schema preload so measure/stream/trace writes no longer race local caches.
 
 ### Document
 

--- a/pkg/test/setup/setup.go
+++ b/pkg/test/setup/setup.go
@@ -32,10 +32,12 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	grpcmetadata "google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/types/known/durationpb"
 	"gopkg.in/yaml.v3"
 
 	commonv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/common/v1"
 	databasev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
+	schemav1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/schema/v1"
 	"github.com/apache/skywalking-banyandb/banyand/metadata"
 	"github.com/apache/skywalking-banyandb/banyand/metadata/discovery/file"
 	"github.com/apache/skywalking-banyandb/banyand/metadata/schema"
@@ -809,16 +811,94 @@ func waitForSchemaSyncWithAuth(grpcAddr, username, password string, opts ...grpc
 	}()
 	groupClient := databasev1.NewGroupRegistryServiceClient(conn)
 	gomega.Eventually(func(g gomega.Gomega) {
-		ctx := context.Background()
-		if username != "" && password != "" {
-			md := grpcmetadata.Pairs("username", username, "password", password)
-			ctx = grpcmetadata.NewOutgoingContext(ctx, md)
-		}
+		ctx := authContext(username, password)
 		resp, listErr := groupClient.List(ctx, &databasev1.GroupRegistryServiceListRequest{})
 		g.Expect(listErr).NotTo(gomega.HaveOccurred())
 		g.Expect(resp.GetGroup()).NotTo(gomega.BeEmpty(),
 			"no groups found in standalone schema registry")
 	}, testflags.EventuallyTimeout).Should(gomega.Succeed())
+	// Registry List succeeding is not enough: writes validate against the liaison
+	// entityRepo / NodeRepoRegistry, which can lag the property schema store.
+	// Wait for catalog contents, then barrier until local caches have applied them.
+	for _, kind := range []schema.Kind{schema.KindStream, schema.KindMeasure, schema.KindTrace} {
+		waitForSchemaKind(conn, kind, username, password)
+	}
+	awaitPreloadedSchemasApplied(conn, username, password)
+}
+
+func authContext(username, password string) context.Context {
+	ctx := context.Background()
+	if username != "" && password != "" {
+		md := grpcmetadata.Pairs("username", username, "password", password)
+		ctx = grpcmetadata.NewOutgoingContext(ctx, md)
+	}
+	return ctx
+}
+
+func awaitPreloadedSchemasApplied(conn *grpclib.ClientConn, username, password string) {
+	keys, minRevisions := collectPreloadedSchemaKeys(conn, username, password)
+	if len(keys) == 0 {
+		return
+	}
+	barrierClient := schemav1.NewSchemaBarrierServiceClient(conn)
+	ctx := authContext(username, password)
+	resp, awaitErr := barrierClient.AwaitSchemaApplied(ctx, &schemav1.AwaitSchemaAppliedRequest{
+		Keys:         keys,
+		MinRevisions: minRevisions,
+		Timeout:      durationpb.New(testflags.EventuallyTimeout),
+	})
+	gomega.Expect(awaitErr).NotTo(gomega.HaveOccurred())
+	gomega.Expect(resp.GetApplied()).To(gomega.BeTrue(),
+		"preloaded schemas not applied to local caches; laggards=%v", resp.GetLaggards())
+}
+
+func collectPreloadedSchemaKeys(conn *grpclib.ClientConn, username, password string) ([]*schemav1.SchemaKey, []int64) {
+	ctx := authContext(username, password)
+	groupResp, groupErr := databasev1.NewGroupRegistryServiceClient(conn).List(
+		ctx, &databasev1.GroupRegistryServiceListRequest{})
+	gomega.Expect(groupErr).NotTo(gomega.HaveOccurred())
+	var keys []*schemav1.SchemaKey
+	var minRevisions []int64
+	for _, grp := range groupResp.GetGroup() {
+		groupName := grp.GetMetadata().GetName()
+		switch grp.GetCatalog() {
+		case commonv1.Catalog_CATALOG_STREAM:
+			streamResp, listErr := databasev1.NewStreamRegistryServiceClient(conn).List(
+				ctx, &databasev1.StreamRegistryServiceListRequest{Group: groupName})
+			gomega.Expect(listErr).NotTo(gomega.HaveOccurred())
+			for _, stream := range streamResp.GetStream() {
+				meta := stream.GetMetadata()
+				keys = append(keys, &schemav1.SchemaKey{
+					Kind: "stream", Group: groupName, Name: meta.GetName(),
+				})
+				minRevisions = append(minRevisions, meta.GetModRevision())
+			}
+		case commonv1.Catalog_CATALOG_MEASURE:
+			measureResp, listErr := databasev1.NewMeasureRegistryServiceClient(conn).List(
+				ctx, &databasev1.MeasureRegistryServiceListRequest{Group: groupName})
+			gomega.Expect(listErr).NotTo(gomega.HaveOccurred())
+			for _, measure := range measureResp.GetMeasure() {
+				meta := measure.GetMetadata()
+				keys = append(keys, &schemav1.SchemaKey{
+					Kind: "measure", Group: groupName, Name: meta.GetName(),
+				})
+				minRevisions = append(minRevisions, meta.GetModRevision())
+			}
+		case commonv1.Catalog_CATALOG_TRACE:
+			traceResp, listErr := databasev1.NewTraceRegistryServiceClient(conn).List(
+				ctx, &databasev1.TraceRegistryServiceListRequest{Group: groupName})
+			gomega.Expect(listErr).NotTo(gomega.HaveOccurred())
+			for _, trace := range traceResp.GetTrace() {
+				meta := trace.GetMetadata()
+				keys = append(keys, &schemav1.SchemaKey{
+					Kind: "trace", Group: groupName, Name: meta.GetName(),
+				})
+				minRevisions = append(minRevisions, meta.GetModRevision())
+			}
+		default:
+		}
+	}
+	return keys, minRevisions
 }
 
 func waitForNodeDiscovery(grpcAddr string, dialOpts ...grpclib.DialOption) {
@@ -886,20 +966,20 @@ func waitForActiveDataNodes(grpcAddr string, config *ClusterConfig) {
 			"no active data nodes in tire2 route table")
 	}, testflags.EventuallyTimeout).Should(gomega.Succeed())
 	for _, kind := range config.getLoadedKinds() {
-		waitForSchemaKind(conn, kind)
+		waitForSchemaKind(conn, kind, "", "")
 	}
 	time.Sleep(5 * time.Second)
 }
 
-func waitForSchemaKind(conn *grpclib.ClientConn, kind schema.Kind) {
+func waitForSchemaKind(conn *grpclib.ClientConn, kind schema.Kind, username, password string) {
 	catalog := kindToCatalog(kind)
 	if catalog == commonv1.Catalog_CATALOG_UNSPECIFIED {
 		return
 	}
 	groupClient := databasev1.NewGroupRegistryServiceClient(conn)
 	gomega.Eventually(func(g gomega.Gomega) {
-		groupResp, groupListErr := groupClient.List(
-			context.Background(), &databasev1.GroupRegistryServiceListRequest{})
+		ctx := authContext(username, password)
+		groupResp, groupListErr := groupClient.List(ctx, &databasev1.GroupRegistryServiceListRequest{})
 		g.Expect(groupListErr).NotTo(gomega.HaveOccurred())
 		var matchingGroups int
 		var syncedGroups int
@@ -909,7 +989,7 @@ func waitForSchemaKind(conn *grpclib.ClientConn, kind schema.Kind) {
 			}
 			matchingGroups++
 			groupName := grp.GetMetadata().GetName()
-			found, schemaErr := hasSchemaInGroup(conn, kind, groupName)
+			found, schemaErr := hasSchemaInGroup(conn, kind, groupName, username, password)
 			g.Expect(schemaErr).NotTo(gomega.HaveOccurred())
 			if found {
 				syncedGroups++
@@ -936,8 +1016,8 @@ func kindToCatalog(kind schema.Kind) commonv1.Catalog {
 	}
 }
 
-func hasSchemaInGroup(conn *grpclib.ClientConn, kind schema.Kind, group string) (bool, error) {
-	ctx := context.Background()
+func hasSchemaInGroup(conn *grpclib.ClientConn, kind schema.Kind, group, username, password string) (bool, error) {
+	ctx := authContext(username, password)
 	switch kind {
 	case schema.KindStream:
 		client := databasev1.NewStreamRegistryServiceClient(conn)

--- a/test/cases/measure/data/data.go
+++ b/test/cases/measure/data/data.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"embed"
 	"encoding/json"
+	"errors"
 	"io"
 	"regexp"
 	"slices"
@@ -43,6 +44,7 @@ import (
 	commonv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/common/v1"
 	databasev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
 	measurev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/measure/v1"
+	modelv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/model/v1"
 	metadatapkg "github.com/apache/skywalking-banyandb/banyand/metadata"
 	"github.com/apache/skywalking-banyandb/banyand/metadata/schema"
 	"github.com/apache/skywalking-banyandb/pkg/bydbql"
@@ -283,28 +285,44 @@ func Write(conn *grpclib.ClientConn, name, group, dataFile string,
 func WriteWithAuth(conn *grpclib.ClientConn, name, group, dataFile string,
 	baseTime time.Time, interval time.Duration, username, password string,
 ) {
-	ctx := context.Background()
-	md := metadata.Pairs("username", username, "password", password)
-	ctx = metadata.NewOutgoingContext(ctx, md)
-	metadata := &commonv1.Metadata{
+	ctx, cancel := context.WithTimeout(context.Background(), flags.EventuallyTimeout)
+	defer cancel()
+	ctx = metadata.NewOutgoingContext(ctx, metadata.Pairs("username", username, "password", password))
+	meta := &commonv1.Metadata{
 		Name:  name,
 		Group: group,
 	}
 
-	schema := databasev1.NewMeasureRegistryServiceClient(conn)
-	resp, err := schema.Get(ctx, &databasev1.MeasureRegistryServiceGetRequest{Metadata: metadata})
+	schemaClient := databasev1.NewMeasureRegistryServiceClient(conn)
+	resp, err := schemaClient.Get(ctx, &databasev1.MeasureRegistryServiceGetRequest{Metadata: meta})
 	gm.Expect(err).NotTo(gm.HaveOccurred())
-	metadata = resp.GetMeasure().GetMetadata()
+	meta = resp.GetMeasure().GetMetadata()
 
 	c := measurev1.NewMeasureServiceClient(conn)
 	writeClient, err := c.Write(ctx)
 	gm.Expect(err).NotTo(gm.HaveOccurred())
-	loadData(metadata, writeClient, dataFile, baseTime, interval)
+	loadData(meta, writeClient, dataFile, baseTime, interval)
 	gm.Expect(writeClient.CloseSend()).To(gm.Succeed())
-	gm.Eventually(func() error {
-		_, err := writeClient.Recv()
-		return err
-	}, flags.EventuallyTimeout).Should(gm.Equal(io.EOF))
+	expectWriteSucceeded(writeClient)
+}
+
+func expectWriteSucceeded(writeClient measurev1.MeasureService_WriteClient) {
+	// Setup already waited on SchemaBarrier AwaitSchemaApplied; a NOT_FOUND
+	// here means the barrier contract was violated and must fail loudly.
+	// Callers must open Write with a deadline so a stalled Recv cannot hang forever.
+	var statuses []string
+	for {
+		ack, recvErr := writeClient.Recv()
+		if errors.Is(recvErr, io.EOF) {
+			break
+		}
+		gm.Expect(recvErr).NotTo(gm.HaveOccurred())
+		statuses = append(statuses, ack.GetStatus())
+	}
+	gm.Expect(statuses).NotTo(gm.BeEmpty())
+	for _, writeStatus := range statuses {
+		gm.Expect(writeStatus).To(gm.Equal(modelv1.Status_STATUS_SUCCEED.String()))
+	}
 }
 
 // WriteOnly write data into the server and return the write client.
@@ -338,7 +356,8 @@ type WriteSpec struct {
 
 // WriteWithSpec writes data using multiple data_point_specs to specify tag and field names.
 func WriteWithSpec(conn *grpclib.ClientConn, baseTime time.Time, interval time.Duration, writeSpecs ...WriteSpec) {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), flags.EventuallyTimeout)
+	defer cancel()
 	schemaClient := databasev1.NewMeasureRegistryServiceClient(conn)
 	c := measurev1.NewMeasureServiceClient(conn)
 	writeClient, err := c.Write(ctx)
@@ -384,15 +403,13 @@ func WriteWithSpec(conn *grpclib.ClientConn, baseTime time.Time, interval time.D
 	}
 
 	gm.Expect(writeClient.CloseSend()).To(gm.Succeed())
-	gm.Eventually(func() error {
-		_, recvErr := writeClient.Recv()
-		return recvErr
-	}, flags.EventuallyTimeout).Should(gm.Equal(io.EOF))
+	expectWriteSucceeded(writeClient)
 }
 
 // WriteMixed writes measure data in schema order first, and then in spec order.
 func WriteMixed(conn *grpclib.ClientConn, baseTime time.Time, interval time.Duration, writeSpecs ...WriteSpec) {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), flags.EventuallyTimeout)
+	defer cancel()
 	schemaClient := databasev1.NewMeasureRegistryServiceClient(conn)
 	c := measurev1.NewMeasureServiceClient(conn)
 	writeClient, err := c.Write(ctx)
@@ -426,8 +443,5 @@ func WriteMixed(conn *grpclib.ClientConn, baseTime time.Time, interval time.Dura
 	}
 
 	gm.Expect(writeClient.CloseSend()).To(gm.Succeed())
-	gm.Eventually(func() error {
-		_, recvErr := writeClient.Recv()
-		return recvErr
-	}, flags.EventuallyTimeout).Should(gm.Equal(io.EOF))
+	expectWriteSucceeded(writeClient)
 }

--- a/test/cases/stream/data/data.go
+++ b/test/cases/stream/data/data.go
@@ -23,6 +23,7 @@ import (
 	"embed"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"regexp"
@@ -64,6 +65,25 @@ var dataFS embed.FS
 
 //go:embed input/*.ql
 var qlFS embed.FS
+
+func expectWriteSucceeded(writeClient streamv1.StreamService_WriteClient) {
+	// Setup already waited on SchemaBarrier AwaitSchemaApplied; a NOT_FOUND
+	// here means the barrier contract was violated and must fail loudly.
+	// Callers must open Write with a deadline so a stalled Recv cannot hang forever.
+	var statuses []string
+	for {
+		ack, recvErr := writeClient.Recv()
+		if errors.Is(recvErr, io.EOF) {
+			break
+		}
+		gm.Expect(recvErr).NotTo(gm.HaveOccurred())
+		statuses = append(statuses, ack.GetStatus())
+	}
+	gm.Expect(statuses).NotTo(gm.BeEmpty())
+	for _, writeStatus := range statuses {
+		gm.Expect(writeStatus).To(gm.Equal(modelv1.Status_STATUS_SUCCEED.String()))
+	}
+}
 
 // VerifyFn verify whether the query response matches the wanted result.
 // It also validates that the corresponding QL file can produce the same QueryRequest.
@@ -297,16 +317,14 @@ func WriteToGroup(conn *grpclib.ClientConn, name, group, fileName string, baseTi
 	metadata = resp.GetStream().GetMetadata()
 
 	c := streamv1.NewStreamServiceClient(conn)
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), flags.EventuallyTimeout)
+	defer cancel()
 	writeClient, err := c.Write(ctx)
 	gm.Expect(err).NotTo(gm.HaveOccurred())
 	elementCounter := 0
 	loadData(writeClient, metadata, fmt.Sprintf("%s.json", fileName), baseTime, interval, &elementCounter)
 	gm.Expect(writeClient.CloseSend()).To(gm.Succeed())
-	gm.Eventually(func() error {
-		_, err := writeClient.Recv()
-		return err
-	}, flags.EventuallyTimeout).Should(gm.Equal(io.EOF))
+	expectWriteSucceeded(writeClient)
 }
 
 // WriteSpec defines the specification for writing stream data.
@@ -318,7 +336,8 @@ type WriteSpec struct {
 
 // WriteMixed writes stream data in schema order first, and then in spec order.
 func WriteMixed(conn *grpclib.ClientConn, baseTime time.Time, interval time.Duration, writeSpecs ...WriteSpec) {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), flags.EventuallyTimeout)
+	defer cancel()
 	schemaClient := databasev1.NewStreamRegistryServiceClient(conn)
 	c := streamv1.NewStreamServiceClient(conn)
 	writeClient, err := c.Write(ctx)
@@ -353,10 +372,7 @@ func WriteMixed(conn *grpclib.ClientConn, baseTime time.Time, interval time.Dura
 	}
 
 	gm.Expect(writeClient.CloseSend()).To(gm.Succeed())
-	gm.Eventually(func() error {
-		_, recvErr := writeClient.Recv()
-		return recvErr
-	}, flags.EventuallyTimeout).Should(gm.Equal(io.EOF))
+	expectWriteSucceeded(writeClient)
 }
 
 // loadDataWithElementIDMap loads data with element IDs specified in the data file for deduplication tests.
@@ -466,13 +482,11 @@ func WriteDeduplicationTest(conn *grpclib.ClientConn, name string, baseTime time
 	metadata = resp.GetStream().GetMetadata()
 
 	c := streamv1.NewStreamServiceClient(conn)
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), flags.EventuallyTimeout)
+	defer cancel()
 	writeClient, err := c.Write(ctx)
 	gm.Expect(err).NotTo(gm.HaveOccurred())
 	loadDataWithElementIDMap(writeClient, metadata, fmt.Sprintf("%s.json", name), baseTime, interval)
 	gm.Expect(writeClient.CloseSend()).To(gm.Succeed())
-	gm.Eventually(func() error {
-		_, err := writeClient.Recv()
-		return err
-	}, flags.EventuallyTimeout).Should(gm.Equal(io.EOF))
+	expectWriteSucceeded(writeClient)
 }

--- a/test/cases/trace/data/data.go
+++ b/test/cases/trace/data/data.go
@@ -24,6 +24,7 @@ import (
 	"embed"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"regexp"
@@ -64,6 +65,25 @@ var qlFS embed.FS
 
 //go:embed testdata/*.json
 var dataFS embed.FS
+
+func expectWriteSucceeded(writeClient tracev1.TraceService_WriteClient) {
+	// Setup already waited on SchemaBarrier AwaitSchemaApplied; a NOT_FOUND
+	// here means the barrier contract was violated and must fail loudly.
+	// Callers must open Write with a deadline so a stalled Recv cannot hang forever.
+	var statuses []string
+	for {
+		ack, recvErr := writeClient.Recv()
+		if errors.Is(recvErr, io.EOF) {
+			break
+		}
+		gm.Expect(recvErr).NotTo(gm.HaveOccurred())
+		statuses = append(statuses, ack.GetStatus())
+	}
+	gm.Expect(statuses).NotTo(gm.BeEmpty())
+	for _, writeStatus := range statuses {
+		gm.Expect(writeStatus).To(gm.Equal(modelv1.Status_STATUS_SUCCEED.String()))
+	}
+}
 
 // VerifyFn verify whether the query response matches the wanted result.
 var VerifyFn = func(innerGm gm.Gomega, sharedContext helpers.SharedContext, args helpers.Args) {
@@ -380,16 +400,14 @@ func WriteToGroup(conn *grpclib.ClientConn, name, group, fileName string, baseTi
 	metadata = resp.GetTrace().GetMetadata()
 
 	c := tracev1.NewTraceServiceClient(conn)
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), flags.EventuallyTimeout)
+	defer cancel()
 	writeClient, err := c.Write(ctx)
 	gm.Expect(err).NotTo(gm.HaveOccurred())
 	version := uint64(1)
 	loadData(writeClient, metadata, fmt.Sprintf("%s.json", fileName), baseTime, interval, &version)
 	gm.Expect(writeClient.CloseSend()).To(gm.Succeed())
-	gm.Eventually(func() error {
-		_, err := writeClient.Recv()
-		return err
-	}, flags.EventuallyTimeout).Should(gm.Equal(io.EOF))
+	expectWriteSucceeded(writeClient)
 }
 
 // WriteSpec defines the specification for writing trace data.
@@ -401,7 +419,8 @@ type WriteSpec struct {
 
 // WriteMixed writes trace data in schema order first, and then in spec order.
 func WriteMixed(conn *grpclib.ClientConn, baseTime time.Time, interval time.Duration, writeSpecs ...WriteSpec) {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), flags.EventuallyTimeout)
+	defer cancel()
 	schemaClient := databasev1.NewTraceRegistryServiceClient(conn)
 	c := tracev1.NewTraceServiceClient(conn)
 	writeClient, err := c.Write(ctx)
@@ -436,10 +455,7 @@ func WriteMixed(conn *grpclib.ClientConn, baseTime time.Time, interval time.Dura
 	}
 
 	gm.Expect(writeClient.CloseSend()).To(gm.Succeed())
-	gm.Eventually(func() error {
-		_, recvErr := writeClient.Recv()
-		return recvErr
-	}, flags.EventuallyTimeout).Should(gm.Equal(io.EOF))
+	expectWriteSucceeded(writeClient)
 }
 
 // unmarshalYAMLWithSpanEncoding decodes YAML with special handling for span data.


### PR DESCRIPTION
## Summary
- After standalone schema preload, wait for stream/measure/trace schemas and block on `SchemaBarrierService.AwaitSchemaApplied` (with min revisions) so liaison caches are ready before tests write.
- Pass auth credentials through `waitForSchemaKind` / registry list calls so `StandaloneWithAuth` does not fail with `Unauthenticated`.
- Assert every measure/stream/trace write ack is `STATUS_SUCCEED`, and open write streams with `context.WithTimeout(flags.EventuallyTimeout)` so a stalled `Recv` cannot hang forever.

Supersedes #1295.

## Test plan
- [x] Local auth integration focus: `Query service_cpm_minute with authentication`
- [x] Local bydbctl measure/stream/trace data query suites
- [x] `make pre-push` (prior iteration)
- [ ] CI bydbctl + integration standalone remainder (incl. auth) green


Made with [Cursor](https://cursor.com)