### PR TITLE
Fix wrong log level in trace lifecycle migration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -135,6 +135,7 @@ Release Notes.
 - Fix the flaky distributed schema clamp test: it queried once immediately after `AwaitRevision`/`AwaitApplied`, which confirm the schema cache but not that the data node has loaded the group's query topology, so the query could still fail with "group not found". It now retries until the query resolves, the same treatment the multi-group spec in the same file already had.
 - Stop the TopN test overriding the configured eventually timeout. It passed `flags.EventuallyTimeout` and then chained `WithTimeout(10s)`, which takes precedence, so the spec always ran on a 10s budget even though CI builds the integration suites with `-X ...flags.eventuallyTimeout=30s` to give slow runners room. It was the only case in `test/cases` opting out.
 - Await SchemaBarrier applied state after standalone schema preload so measure/stream/trace writes no longer race local caches.
+- Fix wrong log level in trace lifecycle migration.
 
 ### Document
 

--- a/banyand/backup/lifecycle/service.go
+++ b/banyand/backup/lifecycle/service.go
@@ -1422,7 +1422,7 @@ func (l *lifecycleService) deleteExpiredTraceSegments(ctx context.Context, g *co
 		return
 	}
 
-	l.l.Warn().Msgf("deleted %d expired segments in group %s, suffixes: %s", resp.Deleted, g.Metadata.Name, segmentSuffixes)
+	l.l.Info().Msgf("deleted %d expired segments in group %s, suffixes: %s", resp.Deleted, g.Metadata.Name, segmentSuffixes)
 	progress.MarkTraceGroupDeleted(g.Metadata.Name)
 	progress.Save(l.progressFilePath, l.l)
 }


### PR DESCRIPTION


- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Fixes apache/skywalking#<issue number>.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-banyandb/blob/main/CHANGES.md).
