### PR TITLE
Fix lifecycle migration test source readiness

### DIFF
--- a/test/integration/distributed/lifecycle/common.go
+++ b/test/integration/distributed/lifecycle/common.go
@@ -45,6 +45,7 @@ import (
 	"github.com/apache/skywalking-banyandb/pkg/timestamp"
 	test_cases "github.com/apache/skywalking-banyandb/test/cases"
 	caseslifecycle "github.com/apache/skywalking-banyandb/test/cases/lifecycle"
+	measureTestData "github.com/apache/skywalking-banyandb/test/cases/measure/data"
 )
 
 type setupResult struct {
@@ -141,7 +142,27 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 		BaseTime:      result.tenDaysBeforeNow,
 		MetadataFlags: result.metadataFlags,
 	}
+	awaitLifecycleSourceMeasureData()
 })
+
+func awaitLifecycleSourceMeasureData() {
+	liaisonConnection, connectionErr := grpchelper.Conn(result.liaisonAddr, 10*time.Second,
+		grpclib.WithTransportCredentials(insecure.NewCredentials()))
+	gomega.Expect(connectionErr).NotTo(gomega.HaveOccurred())
+	defer func() { _ = liaisonConnection.Close() }()
+	sharedContext := helpers.SharedContext{
+		Connection: liaisonConnection,
+		BaseTime:   result.tenDaysBeforeNow,
+	}
+	test.EventuallyConsistently(func(innerGm gomega.Gomega) {
+		measureTestData.VerifyFn(innerGm, sharedContext, helpers.Args{
+			Input:    "all",
+			Duration: 25 * time.Minute,
+			Offset:   -20 * time.Minute,
+			Stages:   []string{"hot"},
+		})
+	}, flags.EventuallyTimeout).Should(gomega.Succeed())
+}
 
 func verifyClusterNodeRoles(liaisonAddr string) {
 	conn, connErr := grpchelper.Conn(liaisonAddr, 10*time.Second,


### PR DESCRIPTION
## Summary

- Await the complete hot-stage measure fixture before lifecycle migration begins.
- Prevent the lifecycle test from taking a source snapshot during fixture ingestion.

## Testing

- Focused lifecycle migration suite under `-race`, repeated three times.
- Full distributed lifecycle package under `-race`.
- `make lint`

Flaky-Test: github.com/apache/skywalking-banyandb/test/integration/distributed/lifecycle.Lifecycle should migrate data once correctly (TestPropertyLifecycle)
