### PR TITLE
docs: refine native index delivery plan

### DIFF
--- a/docs/design/archive/0.12.0/native-inverted-index/README.md
+++ b/docs/design/archive/0.12.0/native-inverted-index/README.md
@@ -1,6 +1,6 @@
 # Native Inverted Index Design
 
-This folder preserves the 0.12.0 design package for replacing Bluge and ICE with a minimal BanyanDB-owned inverted index.
+This folder preserves revision 0.2 of the 0.12.0 design package for replacing Bluge and ICE with a minimal BanyanDB-owned inverted index.
 
 ## Review entry points
 

--- a/docs/design/archive/0.12.0/native-inverted-index/delivery-review.html
+++ b/docs/design/archive/0.12.0/native-inverted-index/delivery-review.html
@@ -21,7 +21,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="Four live cutovers, operational signals, accepted decisions, release gates, and source traceability.">
+  <meta name="description" content="Five bounded cutovers, operational signals, accepted decisions, release gates, and source traceability.">
   <title>BDB Native Index Spec — Delivery and review</title>
   <link rel="stylesheet" href="spec.css">
 </head>
@@ -38,7 +38,7 @@
       </div>
       <div class="rail-status">
         <b>REVIEW</b>
-        <span>BDB-NIDX-SPEC-001<br>Revision 0.1 · 2026-08-24</span>
+        <span>BDB-NIDX-SPEC-001<br>Revision 0.2 · 2026-08-25</span>
         <span class="page-label">CHAPTER 05/05 · DELIVERY + REVIEW</span>
       </div>
       <nav aria-label="Specification sections">
@@ -208,8 +208,8 @@
       <section class="chapter-hero" id="chapter-top" data-chapter="05">
         <div class="chapter-kicker">BDB-NIDX-SPEC-001 · chapter 05 of 05</div>
         <h1>Delivery and review</h1>
-        <p class="chapter-summary">Four live cutovers, operational signals, accepted decisions, release gates, and source traceability.</p>
-        <p class="chapter-range">SECTIONS 18–22 · REVISION 0.1 · REVIEW DRAFT</p>
+        <p class="chapter-summary">Five bounded cutovers, operational signals, accepted decisions, release gates, and source traceability.</p>
+        <p class="chapter-range">SECTIONS 18–22 · REVISION 0.2 · AMENDED DESIGN</p>
         <nav class="chapter-tabs" aria-label="Specification chapters">
           <a href="index.html#status">01 Overview</a>
           <a href="write-format.html#fields">02 Write + format</a>
@@ -224,43 +224,50 @@
             <aside class="section-side">
               <div>
                 <div class="section-no">18</div>
-                <span class="section-state">Four mergeable tickets</span>
-                <p>Every merge cuts over one live Bluge path; no dormant foundation phase is allowed.</p>
+                <span class="section-state">Five mergeable tickets</span>
+                <p>Every merge replaces named live Bluge callers; no dormant foundation phase is allowed.</p>
               </div>
             </aside>
             <div class="section-main">
               <h2>Implementation tickets and rollback</h2>
-              <p class="section-lede">Four vertical cutovers replace the live Bluge surface. Each ticket is one reviewable main-branch merge unit.</p>
+              <p class="section-lede">Five bounded cutovers replace the live Bluge surface. Each ticket is one reviewable main-branch merge unit.</p>
 
               <div class="callout danger">
                 <b>!</b>
-                <p><strong>Merge law:</strong> a parser, writer, query IR, shadow executor, benchmark, or fuzz harness cannot land as its own ticket. It must
-                  ship inside the first ticket whose named production constructor calls it and selects it by default for that index role.</p>
+                <p><strong>Merge law:</strong> a parser, writer, query IR, shadow executor, benchmark, or fuzz harness cannot land without a named production
+                  caller switching to it in the same merge. NIDX-01 is a valid production slice because it removes direct Bluge readers from named read-only,
+                  schema, repair, and verification operations; it is not permission to merge an unused general reader.</p>
               </div>
 
-              <div class="ticket-chain" aria-label="Four-ticket dependency chain">
+              <div class="ticket-chain" aria-label="Five-ticket dependency chain">
                 <div class="ticket-node">
                   <b>NIDX-01</b>
-                  <strong>Property</strong>
-                  <span>first complete native vertical</span>
+                  <strong>Read-only access</strong>
+                  <span>count · walk · repair · verify</span>
                 </div>
                 <div class="ticket-arrow" aria-hidden="true">→</div>
                 <div class="ticket-node">
                   <b>NIDX-02</b>
+                  <strong>Property</strong>
+                  <span>write · query · lifecycle</span>
+                </div>
+                <div class="ticket-arrow" aria-hidden="true">→</div>
+                <div class="ticket-node">
+                  <b>NIDX-03</b>
                   <strong>Series <code>sidx</code></strong>
                   <span>Measure · Stream · Trace</span>
                 </div>
                 <div class="ticket-arrow" aria-hidden="true">→</div>
                 <div class="ticket-node">
-                  <b>NIDX-03</b>
+                  <b>NIDX-04</b>
                   <strong>Stream element <code>idx</code></strong>
                   <span>filters · postings · sort</span>
                 </div>
                 <div class="ticket-arrow" aria-hidden="true">→</div>
                 <div class="ticket-node">
-                  <b>NIDX-04</b>
+                  <b>NIDX-05</b>
                   <strong>Admin + removal</strong>
-                  <span>last callers and dependencies</span>
+                  <span>last writers and dependencies</span>
                 </div>
               </div>
 
@@ -268,18 +275,53 @@
                 <article class="ticket-card" id="nidx-01">
                   <header class="ticket-head">
                     <span class="ticket-number">NIDX-01</span>
-                    <h3>Replace the Property shard index</h3>
+                    <h3>Replace bounded read-only index access</h3>
                   </header>
-                  <p class="ticket-cutover"><b>Live Bluge feature replaced</b><code>property/db.newShard</code> selects the native store for existing and new
-                    Property shards; Property repair scans use the same native reader.</p>
+                  <p class="ticket-cutover"><b>Live Bluge feature replaced</b><code>inverted.ReadOnlyDocCount</code>, schema-property
+                    <code>reader.WalkShard</code>/<code>WalkDocs</code>, the Property repair scan, migration verification counts, and the source-read sides of
+                    index-mode copy and series union open committed directories through the native reader.</p>
                   <div class="ticket-scope">
                     <div>
                       <h4>Inside this ticket</h4>
                       <ul>
-                        <li>Bounded ICE v3 and snapshot readers plus compatible segment/snapshot publication.</li>
+                        <li>Bounded read-only open of the latest complete ICE v3/snapshot v3 generation without an exclusive writer lock.</li>
+                        <li>Live-document count, match-all, exact term and exact-term OR, deletion masks, stored-field visit, and typed scalar decoding.</li>
+                        <li>Ascending tuple sort and strict search-after for Property repair: group, name, entity ID, and timestamp.</li>
+                        <li>Streaming iteration, concurrent-writer inspection, file-immutability proof, typed corruption errors, and CRC32 ignore behavior.</li>
+                      </ul>
+                    </div>
+                    <div>
+                      <h4>Explicit boundary</h4>
+                      <ul>
+                        <li>No insert, update, delete, batch, callback, near-real-time refresh, segment write, publication, merge, expiry, or GC.</li>
+                        <li>No numeric/date range, prefix, wildcard, MATCH, NOT, HAVING, IN, analyzer, scoring, or generic collector surface.</li>
+                        <li>No external-segment introduction and no native destination writer for copy, union, rebuild, or migration.</li>
+                        <li>No runtime dependency deletion and no unused general query abstraction.</li>
+                      </ul>
+                    </div>
+                  </div>
+                  <div class="ticket-proof"><b>Merge proof · </b>Named production callers return fixture-pinned counts, schema revisions, repair tuple/SHA
+                    pages, and migration-source documents from historical directories. File hashes and mtimes remain unchanged, concurrent writable indexes can
+                    be inspected, deleted documents remain absent, malformed data fails within bounds, and CRC32 values are ignored.</div>
+                  <p class="ticket-rollback"><b>Rollback:</b> select the retained legacy reader in the named callers. No writer drain, replay, conversion, or
+                    file change is required because NIDX-01 emits no index bytes.</p>
+                </article>
+
+                <article class="ticket-card" id="nidx-02">
+                  <header class="ticket-head">
+                    <span class="ticket-number">NIDX-02</span>
+                    <h3>Replace the Property shard index</h3>
+                  </header>
+                  <p class="ticket-cutover"><b>Live Bluge feature replaced</b><code>property/db.newShard</code> selects the native store for existing and new
+                    Property shards; its query and repair paths build on the bounded reader merged by NIDX-01.</p>
+                  <div class="ticket-scope">
+                    <div>
+                      <h4>Inside this ticket</h4>
+                      <ul>
+                        <li>Compatible ICE segment and snapshot publication for Property writes.</li>
                         <li>Property upsert/replacement, delete masks, stored fields, exact/boolean/range filter, and explicit sort.</li>
-                        <li>Durable callbacks, snapshots, recovery, merge-time expiry, reference-safe GC, repair scan, and file snapshot.</li>
-                        <li>Only analyzers, term codecs, query nodes, and format sections exercised by Property.</li>
+                        <li>Durable callbacks, snapshots, recovery, merge-time expiry, reference-safe GC, repair integration, and file snapshot.</li>
+                        <li>Only analyzers, term codecs, query nodes, and write-format sections exercised by Property.</li>
                       </ul>
                     </div>
                     <div>
@@ -288,7 +330,7 @@
                         <li>No series wildcard/dictionary surface.</li>
                         <li>No Stream element postings or MATCH analyzer family.</li>
                         <li>No external-segment receiver.</li>
-                        <li>No general migration or schema-reader API.</li>
+                        <li>No general union, copy, verify, dump, or migration writer.</li>
                       </ul>
                     </div>
                   </div>
@@ -298,9 +340,9 @@
                     Startup fails instead of rewriting if the named rollback binary cannot accept the directory.</p>
                 </article>
 
-                <article class="ticket-card" id="nidx-02">
+                <article class="ticket-card" id="nidx-03">
                   <header class="ticket-head">
-                    <span class="ticket-number">NIDX-02</span>
+                    <span class="ticket-number">NIDX-03</span>
                     <h3>Replace the per-segment series index</h3>
                   </header>
                   <p class="ticket-cutover"><b>Live Bluge feature replaced</b><code>internal/storage.newSeriesIndex</code> selects native <code>sidx</code> for
@@ -311,7 +353,7 @@
                       <ul>
                         <li>Field-set-aware insert-if-absent, update, version/timestamp, delete, and projection.</li>
                         <li>Exact/prefix/wildcard identity, field dictionaries, composed filters, stored lookup, and series/index/time sort.</li>
-                        <li>Index-mode Measure reads and writes, stats, read-only count, file snapshot, and cache reset.</li>
+                        <li>Index-mode Measure reads and writes, stats, file snapshot, and cache reset.</li>
                         <li>Crash-safe external segment receive, validation, deduplication, introduction, and mixed-version replication.</li>
                       </ul>
                     </div>
@@ -320,7 +362,7 @@
                       <ul>
                         <li>No Stream element <code>idx</code> batch or paired posting API.</li>
                         <li>No element MATCH analyzer override.</li>
-                        <li>No general schema, union, copy, verify, dump, or rebuild command.</li>
+                        <li>No general union, copy, verify, dump, or rebuild writer.</li>
                         <li>No removal of the legacy adapter.</li>
                       </ul>
                     </div>
@@ -331,9 +373,9 @@
                     retained legacy series constructor; no document replay or format conversion is allowed.</p>
                 </article>
 
-                <article class="ticket-card" id="nidx-03">
+                <article class="ticket-card" id="nidx-04">
                   <header class="ticket-head">
-                    <span class="ticket-number">NIDX-03</span>
+                    <span class="ticket-number">NIDX-04</span>
                     <h3>Replace the Stream element index</h3>
                   </header>
                   <p class="ticket-cutover"><b>Live Bluge feature replaced</b><code>stream.newElementIndex</code> selects the native <code>idx</code> writer,
@@ -353,8 +395,8 @@
                       <ul>
                         <li>No BM25, boosts, phrase, fuzzy, geo, highlighting, facet, or explanation surface.</li>
                         <li>No generic Bluge collector or plugin compatibility layer.</li>
-                        <li>No remaining offline migration callers.</li>
-                        <li>No dependency deletion before NIDX-04.</li>
+                        <li>No remaining offline migration destination writers.</li>
+                        <li>No dependency deletion before NIDX-05.</li>
                       </ul>
                     </div>
                   </div>
@@ -364,19 +406,19 @@
                     the same compatible snapshot after the writer is drained.</p>
                 </article>
 
-                <article class="ticket-card" id="nidx-04">
+                <article class="ticket-card" id="nidx-05">
                   <header class="ticket-head">
-                    <span class="ticket-number">NIDX-04</span>
-                    <h3>Replace admin/migration and remove Bluge</h3>
+                    <span class="ticket-number">NIDX-05</span>
+                    <h3>Replace remaining admin/migration writers and remove Bluge</h3>
                   </header>
-                  <p class="ticket-cutover"><b>Live Bluge feature replaced</b>Schema loading, union/rebuild, index-mode copy, migration verification, dump, and
-                    read-only count call native administration APIs; runtime and offline Bluge dependencies are deleted.</p>
+                  <p class="ticket-cutover"><b>Live Bluge feature replaced</b>Union/rebuild, index-mode copy, migration output, dump, and every remaining
+                    maintenance/CLI caller use native administration APIs; runtime and offline Bluge dependencies are deleted.</p>
                   <div class="ticket-scope">
                     <div>
                       <h4>Inside this ticket</h4>
                       <ul>
-                        <li>Bounded read-only open/count, latest generation, document walk, stored/doc-value visitation, and sorted search-after.</li>
-                        <li>Native verify, staged rebuild, union/dedup, index-mode reconstruction, and migration verification.</li>
+                        <li>Native verify, staged rebuild, union/dedup, index-mode reconstruction, and migration destination writing.</li>
+                        <li>Complete document walk, stored/doc-value visitation, and sorted search-after extensions not already required by NIDX-01.</li>
                         <li>Rewire every remaining production and CLI caller; remove legacy query bridges, segment API types, modules, and replacements.</li>
                         <li>Retain a pinned legacy oracle binary and fixture corpus only as isolated compatibility test inputs.</li>
                       </ul>
@@ -398,6 +440,63 @@
                 </article>
               </div>
 
+              <h3>NIDX-01 read-only operation contract</h3>
+              <p>NIDX-01 is an operation slice, not a general reader layer. Its public surface is limited to the following production needs; migration copy and
+                union continue to publish through their retained legacy writers until their destination paths are replaced by later tickets.</p>
+              <div class="table-wrap">
+                <table>
+                  <thead>
+                    <tr>
+                      <th>Operation</th>
+                      <th>Named callers</th>
+                      <th>Native behavior</th>
+                      <th>Result and bound</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td>Open committed generation</td>
+                      <td>All NIDX-01 callers</td>
+                      <td>Inspect snapshot generations newest-first and pin the newest structurally complete ICE v3/snapshot v3 view without acquiring
+                        <code>bluge.pid</code>.</td>
+                      <td>Immutable snapshot handle; bounded record and section validation; no directory entry, byte, or mtime change.</td>
+                    </tr>
+                    <tr>
+                      <td>Visible-document count</td>
+                      <td><code>inverted.ReadOnlyDocCount</code> and migration verification</td>
+                      <td>Combine segment document counts with the pinned snapshot's deletion masks.</td>
+                      <td>One count in O(number of segments + deletion masks), without visiting stored documents.</td>
+                    </tr>
+                    <tr>
+                      <td>Match-all document walk</td>
+                      <td>Schema walk, index-mode copy, and series union source reads</td>
+                      <td>Stream live local document numbers and visit every repeated stored field as raw name/value bytes.</td>
+                      <td>Caller-owned document callback; one document plus configured decode buffers in memory.</td>
+                    </tr>
+                    <tr>
+                      <td>Exact term and exact-term OR</td>
+                      <td>Kind-filtered schema <code>WalkShard</code></td>
+                      <td>Resolve exact FST terms, union the selected postings, remove snapshot deletions, and visit stored source/tombstone fields.</td>
+                      <td>Streaming matches; OR fan-out is bounded by the caller-supplied term count.</td>
+                    </tr>
+                    <tr>
+                      <td>Stored and typed value access</td>
+                      <td>Schema decode, copy, union, and Property repair</td>
+                      <td>Preserve repeated raw values and expose only the scalar decoders required by the named adapters; internal-field policy stays in those
+                        adapters.</td>
+                      <td>Borrowed values are valid only during the visit callback; callers copy values they retain.</td>
+                    </tr>
+                    <tr>
+                      <td>Ascending tuple page</td>
+                      <td>Property repair</td>
+                      <td>Order by <code>(group, name, entityID, timestamp)</code>, return the stored SHA value, and resume strictly after all four prior sort
+                        components on the same pinned generation.</td>
+                      <td>At most the configured repair page size plus bounded sort state; no unbounded offset scan.</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+
               <h3>Ticket dependency and activation contract</h3>
               <div class="table-wrap">
                 <table>
@@ -412,27 +511,33 @@
                   <tbody>
                     <tr>
                       <td>NIDX-01</td>
-                      <td>Approved format fixtures and DEC gates</td>
-                      <td>Native is the default Property constructor; legacy is an explicit rollback choice.</td>
-                      <td>Codec, IR, writer, or fuzz code used only by tests.</td>
+                      <td>Approved read fixtures and DEC gates</td>
+                      <td>Every named read-only caller uses native open/count/walk/search-after; no file is modified.</td>
+                      <td>A reader used only by tests, shadow comparison, or a future writer.</td>
                     </tr>
                     <tr>
                       <td>NIDX-02</td>
                       <td>NIDX-01</td>
-                      <td>Native is the default per-segment <code>sidx</code> constructor for all three TS products.</td>
-                      <td>Series executor without live write, snapshot, and replication paths.</td>
+                      <td>Native is the default Property constructor; legacy is an explicit rollback choice.</td>
+                      <td>A writer or query extension without the live Property write/lifecycle cutover.</td>
                     </tr>
                     <tr>
                       <td>NIDX-03</td>
                       <td>NIDX-02</td>
+                      <td>Native is the default per-segment <code>sidx</code> constructor for all three TS products.</td>
+                      <td>Series executor without live write, snapshot, and replication paths.</td>
+                    </tr>
+                    <tr>
+                      <td>NIDX-04</td>
+                      <td>NIDX-03</td>
                       <td>Native is the default Stream element <code>idx</code> constructor.</td>
                       <td>Shadow-only filter or test-only element writer.</td>
                     </tr>
                     <tr>
-                      <td>NIDX-04</td>
-                      <td>NIDX-01 through NIDX-03 plus retirement approval</td>
-                      <td>Every admin/migration caller is native and runtime Bluge code is absent.</td>
-                      <td>A dependency cleanup that leaves a production Bluge bypass.</td>
+                      <td>NIDX-05</td>
+                      <td>NIDX-01 through NIDX-04 plus retirement approval</td>
+                      <td>Every remaining admin/migration caller is native and runtime Bluge code is absent.</td>
+                      <td>A dependency cleanup that leaves a production or CLI Bluge bypass.</td>
                     </tr>
                   </tbody>
                 </table>
@@ -442,17 +547,22 @@
               <div class="checklist">
                 <label class="check">
                   <input type="checkbox" disabled>
-                  <span><b>Live call-graph proof</b>Every new production component is reachable from the constructor named by the ticket.</span>
+                  <span><b>Live call-graph proof</b>Every new production component is reachable from the named activation points in its ticket.</span>
                   <span class="tag stable">required</span>
                 </label>
                 <label class="check">
                   <input type="checkbox" disabled>
-                  <span><b>Role-complete contract</b>The ticket replaces every Bluge operation used by that role; it does not split read and write authority.</span>
+                  <span><b>Bounded read slice</b>NIDX-01 replaces every listed direct Bluge read operation, writes no bytes, and exposes no unused general API.</span>
                   <span class="tag stable">required</span>
                 </label>
                 <label class="check">
                   <input type="checkbox" disabled>
-                  <span><b>Bidirectional files</b>Native opens legacy files and the named rollback binary opens, mutates, merges, and restarts native files.</span>
+                  <span><b>Role-complete write contract</b>NIDX-02 through NIDX-04 replace every read/write operation used by their named role.</span>
+                  <span class="tag stable">required</span>
+                </label>
+                <label class="check">
+                  <input type="checkbox" disabled>
+                  <span><b>Bidirectional files</b>Writing tickets open legacy files and the named rollback binary opens, mutates, merges, and restarts native files.</span>
                   <span class="tag fixture">required</span>
                 </label>
                 <label class="check">
@@ -462,11 +572,51 @@
                 </label>
                 <label class="check">
                   <input type="checkbox" disabled>
-                  <span><b>Reserved CRC field gate</b>The named rollback binary accepts native files while CRC32 remains uncalculated and unvalidated.</span>
+                  <span><b>Reserved CRC field gate</b>Readers ignore CRC32; named rollback binaries accept uncalculated/unvalidated fields from writing tickets.</span>
                   <span class="tag out">blocking</span>
                 </label>
               </div>
               <div class="clause-list">
+                <div class="clause">
+                  <div class="clause-key">
+                    <span class="clause-id">READ-001</span>
+                    <span class="verb must">MUST</span>
+                  </div>
+                  <div class="clause-body">
+                    <p>NIDX-01 shall select and pin the newest structurally complete committed generation, apply its deletion masks, and leave file bytes,
+                      mtimes, and directory entries unchanged.</p>
+                  </div>
+                </div>
+                <div class="clause">
+                  <div class="clause-key">
+                    <span class="clause-id">READ-002</span>
+                    <span class="verb must">MUST</span>
+                  </div>
+                  <div class="clause-body">
+                    <p>NIDX-01 shall bound memory by configured page, block, section, term-count, and decode limits and return typed errors for malformed offsets,
+                      lengths, varints, and scalar encodings.</p>
+                  </div>
+                </div>
+                <div class="clause">
+                  <div class="clause-key">
+                    <span class="clause-id">READ-003</span>
+                    <span class="verb must">MUST</span>
+                  </div>
+                  <div class="clause-body">
+                    <p>NIDX-01 shall expose only committed-generation open, visible count, match-all, exact term, exact-term OR, stored-field visitation, required
+                      scalar decoding, and the Property repair tuple search-after.</p>
+                  </div>
+                </div>
+                <div class="clause">
+                  <div class="clause-key">
+                    <span class="clause-id">READ-004</span>
+                    <span class="verb must">MUST</span>
+                  </div>
+                  <div class="clause-body">
+                    <p>NIDX-01 shall remain safe beside an active legacy writer, shall not acquire the exclusive writer lock, and shall close all files and mapped
+                      regions when its pinned snapshot and iterators close.</p>
+                  </div>
+                </div>
                 <div class="clause">
                   <div class="clause-key">
                     <span class="clause-id">ROLL-001</span>
@@ -493,8 +643,18 @@
                     <span class="verb must">MUST</span>
                   </div>
                   <div class="clause-body">
-                    <p>Each ticket must switch its named production role to native in the same merge. Future-role code, disabled-only paths, and test-only
-                      implementations are prohibited from that ticket.</p>
+                    <p>Each ticket must switch every production operation named by its boundary to native in the same merge. Future-role code, disabled-only
+                      paths, and test-only implementations are prohibited from that ticket.</p>
+                  </div>
+                </div>
+                <div class="clause">
+                  <div class="clause-key">
+                    <span class="clause-id">ROLL-004</span>
+                    <span class="verb must">MUST</span>
+                  </div>
+                  <div class="clause-body">
+                    <p>No blocked ticket may merge before its predecessor merges and satisfies its production activation gate; an open pull request does not
+                      satisfy this dependency.</p>
                   </div>
                 </div>
               </div>
@@ -586,13 +746,14 @@
             <aside class="section-side">
               <div>
                 <div class="section-no">20</div>
-                <span class="section-state">Review required</span>
-                <p>Selections persist locally in this browser and can be exported.</p>
+                <span class="section-state">Disposition recorded</span>
+                <p>Revision 0.2 records all decisions; reviewers may persist and export local overrides.</p>
               </div>
             </aside>
             <div class="section-main">
-              <h2>Open maintainer decisions</h2>
-              <p class="section-lede">These choices must be explicit; the implementation must not decide them accidentally.</p>
+              <h2>Maintainer decisions</h2>
+              <p class="section-lede">These recorded choices are normative for the implementation. DEC-007 retains its explicit block disposition while the
+                specification enforces the requested field-only CRC32 compatibility behavior.</p>
 
               <div class="decision-grid">
                 <article class="decision-card">
@@ -605,7 +766,7 @@
                     <label for="dec-001">Disposition</label>
                     <select id="dec-001" data-decision="DEC-001">
                       <option value="">Not reviewed</option>
-                      <option>Accept recommendation</option>
+                      <option selected>Accept recommendation</option>
                       <option>Needs discussion</option>
                       <option>Block specification</option>
                     </select>
@@ -620,7 +781,7 @@
                     <label for="dec-002">Disposition</label>
                     <select id="dec-002" data-decision="DEC-002">
                       <option value="">Not reviewed</option>
-                      <option>Accept recommendation</option>
+                      <option selected>Accept recommendation</option>
                       <option>Needs discussion</option>
                       <option>Block specification</option>
                     </select>
@@ -634,7 +795,7 @@
                   <label for="dec-003">Disposition</label>
                   <select id="dec-003" data-decision="DEC-003">
                     <option value="">Not reviewed</option>
-                    <option>Accept recommendation</option>
+                    <option selected>Accept recommendation</option>
                     <option>Needs discussion</option>
                     <option>Block specification</option>
                   </select>
@@ -650,7 +811,7 @@
                     <label for="dec-004">Disposition</label>
                     <select id="dec-004" data-decision="DEC-004">
                       <option value="">Not reviewed</option>
-                      <option>Accept recommendation</option>
+                      <option selected>Accept recommendation</option>
                       <option>Needs discussion</option>
                       <option>Block specification</option>
                     </select>
@@ -665,7 +826,7 @@
                     <label for="dec-005">Disposition</label>
                     <select id="dec-005" data-decision="DEC-005">
                       <option value="">Not reviewed</option>
-                      <option>Accept recommendation</option>
+                      <option selected>Accept recommendation</option>
                       <option>Needs discussion</option>
                       <option>Block specification</option>
                     </select>
@@ -680,7 +841,7 @@
                     <label for="dec-006">Disposition</label>
                     <select id="dec-006" data-decision="DEC-006">
                       <option value="">Not reviewed</option>
-                      <option>Accept recommendation</option>
+                      <option selected>Accept recommendation</option>
                       <option>Needs discussion</option>
                       <option>Block specification</option>
                     </select>
@@ -711,7 +872,7 @@
                     <label for="dec-008">Disposition</label>
                     <select id="dec-008" data-decision="DEC-008">
                       <option value="">Not reviewed</option>
-                      <option>Accept recommendation</option>
+                      <option selected>Accept recommendation</option>
                       <option>Needs discussion</option>
                       <option>Block specification</option>
                     </select>
@@ -726,7 +887,7 @@
                     <label for="dec-009">Disposition</label>
                     <select id="dec-009" data-decision="DEC-009">
                       <option value="">Not reviewed</option>
-                      <option>Accept recommendation</option>
+                      <option selected>Accept recommendation</option>
                       <option>Needs discussion</option>
                       <option>Block specification</option>
                     </select>
@@ -741,11 +902,26 @@
                     <label for="dec-010">Disposition</label>
                     <select id="dec-010" data-decision="DEC-010">
                       <option value="">Not reviewed</option>
-                      <option>Accept recommendation</option>
+                      <option selected>Accept recommendation</option>
                       <option>Needs discussion</option>
                       <option>Block specification</option>
                     </select>
                   </article>
+                <article class="decision-card">
+                  <header>
+                    <h3>Read-only-first delivery slice</h3>
+                    <span class="decision-id">DEC-011</span>
+                  </header>
+                  <p><strong>Disposition:</strong> split bounded native read-only operations from the Property writer/lifecycle cutover. The read-only ticket
+                    may merge only when every named production caller switches in the same merge and no unused general reader surface is exposed.</p>
+                  <label for="dec-011">Disposition</label>
+                  <select id="dec-011" data-decision="DEC-011">
+                    <option value="">Not reviewed</option>
+                    <option selected>Accept recommendation</option>
+                    <option>Needs discussion</option>
+                    <option>Block specification</option>
+                  </select>
+                </article>
               </div>
 
               <div class="review-console">
@@ -785,6 +961,13 @@
                   <input type="checkbox" disabled>
                   <span>
                     <b>Product conformance</b>Series, Stream, Property, index-mode Measure, admin, migration, repair, and backup suites pass.</span>
+                    <span class="tag fixture">required</span>
+                  </label>
+                <label class="check">
+                  <input type="checkbox" disabled>
+                  <span>
+                    <b>Read-only immutability</b>Native count, walk, stored-field, and search-after operations leave bytes, mtimes, and directory entries unchanged
+                      while remaining safe beside an open writer.</span>
                     <span class="tag fixture">required</span>
                   </label>
                 <label class="check">

--- a/docs/design/archive/0.12.0/native-inverted-index/index.html
+++ b/docs/design/archive/0.12.0/native-inverted-index/index.html
@@ -38,7 +38,7 @@
       </div>
       <div class="rail-status">
         <b>REVIEW</b>
-        <span>BDB-NIDX-SPEC-001<br>Revision 0.1 · 2026-08-24</span>
+        <span>BDB-NIDX-SPEC-001<br>Revision 0.2 · 2026-08-25</span>
         <span class="page-label">CHAPTER 01/05 · OVERVIEW</span>
       </div>
       <nav aria-label="Specification sections">
@@ -215,11 +215,11 @@
             <div class="doc-meta">
               <div class="meta-cell">
                 <b>Revision</b>
-                <span>0.1</span>
+                <span>0.2</span>
               </div>
               <div class="meta-cell">
                 <b>Date</b>
-                <span>2026-08-24</span>
+                <span>2026-08-25</span>
               </div>
               <div class="meta-cell">
                 <b>Compatibility target</b>
@@ -266,7 +266,7 @@
                 <i id="review-meter-fill">
                 </i>
               </div>
-              <p id="review-meter-label">0 of 10 open decisions dispositioned</p>
+              <p id="review-meter-label">11 of 11 decisions dispositioned</p>
             </div>
           </aside>
         </section>
@@ -300,7 +300,7 @@
         <a class="chapter-card" href="delivery-review.html#rollout">
           <b>CHAPTER 05</b>
           <strong>Delivery and review</strong>
-          <span>Four live cutovers, operational signals, accepted decisions, release gates, and source traceability.</span>
+          <span>Five bounded cutovers, operational signals, accepted decisions, release gates, and source traceability.</span>
         </a>
         </div>
       </section>

--- a/docs/design/archive/0.12.0/native-inverted-index/query-lifecycle.html
+++ b/docs/design/archive/0.12.0/native-inverted-index/query-lifecycle.html
@@ -38,7 +38,7 @@
       </div>
       <div class="rail-status">
         <b>REVIEW</b>
-        <span>BDB-NIDX-SPEC-001<br>Revision 0.1 · 2026-08-24</span>
+        <span>BDB-NIDX-SPEC-001<br>Revision 0.2 · 2026-08-25</span>
         <span class="page-label">CHAPTER 03/05 · QUERY + LIFECYCLE</span>
       </div>
       <nav aria-label="Specification sections">
@@ -209,7 +209,7 @@
         <div class="chapter-kicker">BDB-NIDX-SPEC-001 · chapter 03 of 05</div>
         <h1>Query and lifecycle</h1>
         <p class="chapter-summary">Filter execution, projection, ordering, durability, merge, garbage collection, and external receive.</p>
-        <p class="chapter-range">SECTIONS 10–14 · REVISION 0.1 · REVIEW DRAFT</p>
+        <p class="chapter-range">SECTIONS 10–14 · REVISION 0.2 · AMENDED DESIGN</p>
         <nav class="chapter-tabs" aria-label="Specification chapters">
           <a href="index.html#status">01 Overview</a>
           <a href="write-format.html#fields">02 Write + format</a>

--- a/docs/design/archive/0.12.0/native-inverted-index/research-plan.md
+++ b/docs/design/archive/0.12.0/native-inverted-index/research-plan.md
@@ -141,7 +141,7 @@ The work is intentionally spec-first. A phase may change later implementation es
 previously measured compatibility result without updating the fixture and rationale.
 
 These R0–R7 work packages are research activities, not main-branch implementation tickets. Prototypes remain isolated
-research artifacts. The only production implementation merges are the four live cutovers defined by R7; no research
+research artifacts. The only production implementation merges are the five live cutovers defined by R7; no research
 package authorizes dormant production code on main.
 
 ### R0 — Freeze the oracle and define provenance
@@ -352,54 +352,68 @@ cancellation boundaries. Reopen after each failure and verify that either the ol
 
 **Exit gate.** The proposal includes agreed regression budgets and demonstrates bounded memory and valid recovery.
 
-### R7 — Produce the four-ticket implementation and rollout proposal
+### R7 — Produce the five-ticket implementation and rollout proposal
 
-**Purpose.** Convert research evidence into reviewable engineering work.
+**Purpose.** Convert research evidence into reviewable engineering work without placing the entire native engine in the first merge.
 
-The implementation proposal must contain exactly four production vertical tickets. A codec, query IR, test writer,
-shadow executor, fuzz harness, or benchmark may be work inside a ticket, but cannot be merged as a standalone ticket.
-Every ticket must route a named live BanyanDB constructor or administrative caller to native code in the same merge.
+The implementation proposal must contain exactly five production tickets. A codec, query IR, test writer, shadow executor,
+fuzz harness, or benchmark may be work inside a ticket, but cannot merge without a named live BanyanDB caller switching to
+native in the same merge. NIDX-01 is intentionally read-only and is valid only because it replaces the complete bounded
+read operation set of named production callers; it must not expose an unused general reader.
 
-#### NIDX-01 — Property shard index
+#### NIDX-01 — Bounded read-only index access
 
-- **Live replacement:** Property upsert, query, sort, delete/expiry, repair, and durable publication.
-- **Inside:** Only the ICE/snapshot, query, writer, merge, recovery, and administration pieces exercised by Property.
-- **Outside:** Series matching, Stream element postings, external receive, and general migration.
+- **Live replacement:** `inverted.ReadOnlyDocCount`, schema-property `WalkShard`/`WalkDocs`, Property repair scans,
+  migration verification counts, and the source-read sides of index-mode copy and series union.
+- **Inside:** Latest committed snapshot open, live count, match-all, exact term/OR, deletion masks, stored-field visit,
+  typed scalar decode, tuple sort/search-after, streaming bounds, file-immutability proof, and typed corruption errors.
+- **Outside:** Every write, callback, publication, merge, expiry, GC, external introduction, general query language, and
+  destination writer.
 
-#### NIDX-02 — Per-segment series `sidx`
+#### NIDX-02 — Property shard index
+
+- **Live replacement:** `property/db.newShard` Property upsert, query, sort, delete/expiry, repair integration, and durable
+  publication.
+- **Inside:** Only the ICE/snapshot writer, query extensions, merge, recovery, callback, and lifecycle pieces exercised by
+  Property, building on NIDX-01's reader.
+- **Outside:** Series matching, Stream element postings, external receive, and general migration writers.
+
+#### NIDX-03 — Per-segment series `sidx`
 
 - **Live replacement:** Measure, Stream, and Trace series insert, update, lookup, sort, snapshot, and raw segment
   replication.
 - **Inside:** Field-set-aware insert, identity dictionaries/matchers, projection/sort, index-mode Measure, and external
   receive.
-- **Outside:** The Stream element `idx` and general offline migration commands.
+- **Outside:** The Stream element `idx` and general offline destination writers.
 
-#### NIDX-03 — Stream element `idx`
+#### NIDX-04 — Stream element `idx`
 
 - **Live replacement:** Stream element batch, filter/posting execution, sort, snapshot, and raw segment replication.
 - **Inside:** Only the required analyzer, numeric/date term, MATCH/filter, and paired document/timestamp posting surface.
 - **Outside:** Scoring and every other unused search-product feature.
 
-#### NIDX-04 — Administration, migration, and removal
+#### NIDX-05 — Administration, migration, and removal
 
-- **Live replacement:** Schema reader, union/rebuild, index-mode copy, migration verification, dump, and read-only count.
-- **Inside:** Rewire every remaining production/CLI caller, then remove runtime Bluge, ICE, and segment-API dependencies.
+- **Live replacement:** Remaining union/rebuild, index-mode copy, migration output, dump, and maintenance/CLI callers.
+- **Inside:** Native destination writers, every remaining caller rewire, and runtime Bluge, ICE, and segment-API dependency
+  removal.
 - **Outside:** The pinned legacy oracle, which remains only as an isolated compatibility test input.
 
 Each ticket must be a reviewable main-branch merge unit with all of the following:
 
-1. a production activation point that selects native by default for the named role;
+1. production activation points that select native for every named operation in that ticket;
 2. an explicit in-scope and out-of-scope API/format boundary;
-3. a call-graph check proving every new production component is reachable from that activation point;
-4. backend-neutral role tests, relevant fuzz/crash/benchmark gates, and legacy-directory coverage;
-5. native-reader/legacy-writer and native-writer/named-rollback-binary interoperability; and
-6. a same-file rollback procedure until NIDX-04 passes the approved dependency-retirement gate.
+3. a call-graph check proving every new production component is reachable from an activation point;
+4. backend-neutral operation tests, relevant fuzz/crash/benchmark gates, and legacy-directory coverage;
+5. for NIDX-01, proof of read-only file immutability, concurrent-writer inspection, bounded iteration, and no output bytes;
+6. for writing tickets, native-reader/legacy-writer and native-writer/named-rollback-binary interoperability; and
+7. a same-file rollback procedure until NIDX-05 passes the approved dependency-retirement gate.
 
 Shadow comparisons and test-only writers remain pre-merge evidence, not deliverables. Because CRC32 processing is
 prohibited, each writing ticket is blocked unless the named rollback binary accepts the retained-but-uncomputed CRC32
-field. The implementation must not silently restore checksum calculation to make the gate pass.
+field. NIDX-01 instead proves that arbitrary CRC32 values are ignored without modifying the source directory.
 
-**Deliverable.** A ticketed implementation plan with dependencies, test gates, observability, upgrade/downgrade policy,
+**Deliverable.** A five-ticket implementation plan with dependencies, test gates, observability, upgrade/downgrade policy,
 and removal criteria.
 
 **Exit gate.** Maintainers approve the requirements, format specifications, architecture decision, performance budgets,

--- a/docs/design/archive/0.12.0/native-inverted-index/research-report.html
+++ b/docs/design/archive/0.12.0/native-inverted-index/research-report.html
@@ -738,7 +738,7 @@
 
     .roadmap {
       display: grid;
-      grid-template-columns: repeat(4, minmax(14rem, 1fr));
+      grid-template-columns: repeat(5, minmax(13rem, 1fr));
       gap: .65rem;
       overflow-x: auto;
       padding-bottom: 1rem;
@@ -1814,42 +1814,48 @@
 
       <section id="roadmap">
         <span class="section-no">09 / DELIVERY</span>
-        <h2 class="section-title reveal">Four live cutovers. Zero foundation-only tickets.</h2>
-        <p class="section-lede reveal">Each main-branch merge replaces one named Bluge production path. Parsers, writers, query IR, fuzzing, and shadow
-          comparison ship inside the first vertical that uses them; none is a standalone delivery.</p>
-        <div class="roadmap reveal" aria-label="Four-ticket implementation roadmap">
+        <h2 class="section-title reveal">Five live replacements. Read-only first, never dormant.</h2>
+        <p class="section-lede reveal">Each main-branch merge replaces named Bluge production callers. NIDX-01 writes no index bytes, but it switches the
+          bounded count, walk, repair, verification, and migration-source operations that establish the reader used by later writers.</p>
+        <div class="roadmap reveal" aria-label="Five-ticket implementation roadmap">
           <article class="roadmap-step">
 <b>NIDX-01</b>
-<h3>Property shard index</h3>
-<p><strong>Replaces</strong> Property upsert, query, sort, delete/expiry, repair scan, callback, merge, recovery, and backup.</p>
-<p><strong>Boundary</strong> No series wildcard/dictionary behavior, Stream element postings, external receive, or general migration.</p>
-<small>LIVE MERGE · property/db.newShard defaults native</small>
+<h3>Bounded read-only access</h3>
+<p><strong>Replaces</strong> Live count, schema walk, Property repair scan, verification counts, and migration source reads.</p>
+<p><strong>Boundary</strong> Match-all, exact/OR, stored values, deletion masks, tuple search-after; no output bytes or general query API.</p>
+<small>LIVE MERGE · named readers default native</small>
 </article>
           <article class="roadmap-step">
 <b>NIDX-02</b>
-<h3>Per-segment series <code>sidx</code></h3>
-<p><strong>Replaces</strong> Measure, Stream, and Trace series write, lookup, projection, sort, snapshot, and raw segment replication.</p>
-<p><strong>Boundary</strong> No Stream element <code>idx</code>, general offline migration commands, or dependency removal.</p>
-<small>LIVE MERGE · internal/storage.newSeriesIndex defaults native</small>
+<h3>Property shard index</h3>
+<p><strong>Replaces</strong> Property upsert, query, sort, delete/expiry, callback, merge, recovery, and backup.</p>
+<p><strong>Boundary</strong> No series wildcard/dictionary behavior, Stream element postings, external receive, or general migration writers.</p>
+<small>LIVE MERGE · property/db.newShard defaults native</small>
 </article>
           <article class="roadmap-step">
 <b>NIDX-03</b>
+<h3>Per-segment series <code>sidx</code></h3>
+<p><strong>Replaces</strong> Measure, Stream, and Trace series write, lookup, projection, sort, snapshot, and raw segment replication.</p>
+<p><strong>Boundary</strong> No Stream element <code>idx</code>, general offline destination writers, or dependency removal.</p>
+<small>LIVE MERGE · internal/storage.newSeriesIndex defaults native</small>
+</article>
+          <article class="roadmap-step">
+<b>NIDX-04</b>
 <h3>Stream element <code>idx</code></h3>
 <p><strong>Replaces</strong> Element batch, filters, paired postings, sort, snapshot, restart, and raw segment receive.</p>
 <p><strong>Boundary</strong> Only required analyzers and filters; no scoring, phrase, fuzzy, geo, highlight, facet, or plugin API.</p>
 <small>LIVE MERGE · stream.newElementIndex defaults native</small>
 </article>
           <article class="roadmap-step">
-<b>NIDX-04</b>
-<h3>Admin, migration, removal</h3>
-<p><strong>Replaces</strong> Schema load, union/rebuild, index-mode copy, migration verify, dump, and read-only count.</p>
-<p><strong>Boundary</strong> Rewire every last live caller before removing runtime Bluge, ICE, and segment-API dependencies.</p>
+<b>NIDX-05</b>
+<h3>Admin writers and removal</h3>
+<p><strong>Replaces</strong> Remaining union/rebuild, index-mode copy, migration output, dump, and maintenance/CLI paths.</p>
+<p><strong>Boundary</strong> Rewire every last caller before removing runtime Bluge, ICE, and segment-API dependencies.</p>
 <small>LIVE MERGE · zero production dependency edges</small>
 </article>
         </div>
-        <p class="caption reveal"><strong>Shared gate:</strong> every ticket must open legacy files, emit files accepted by the named rollback binary, pass its
-          complete role contract, and include a same-file rollback. With CRC32 processing prohibited, failure of the rollback binary to accept the reserved
-          field blocks the writing ticket.</p>
+        <p class="caption reveal"><strong>Shared gate:</strong> NIDX-01 must prove immutable files, bounded iteration, historical results, concurrent-writer
+          inspection, and CRC32 ignore behavior. Each writing ticket must emit files accepted by its named rollback binary and include a same-file rollback.</p>
       </section>
 
       <section id="risks">
@@ -2050,14 +2056,14 @@
 
       <section class="closing" id="close">
         <span class="section-no">RECOMMENDATION</span>
-        <h2 class="section-title reveal">Begin with one complete live vertical.</h2>
-        <p class="section-lede reveal">Develop the bounded reader, compatible writer, query path, fixtures, and fault evidence together on NIDX-01. Merge
-          only when Property shards select that native path by default; never accumulate a second unused engine on main.</p>
+        <h2 class="section-title reveal">Begin with bounded production reads.</h2>
+        <p class="section-lede reveal">Develop only the ICE/snapshot sections required by named read-only callers. Merge NIDX-01 when those callers are
+          native, historical results match, iteration is bounded, and every source directory remains unchanged; do not expose an unused general reader.</p>
         <div class="next-action reveal">
           <b>NIDX-01</b>
           <div>
-<h3>First production cutover</h3>
-<p>Replace the complete Property shard index and repair path, with legacy-directory input, compatible output, and same-file rollback proof.</p>
+<h3>First production replacement</h3>
+<p>Replace count, schema walk, Property repair, verification, and migration-source reads with a bounded native reader that emits no index bytes.</p>
 </div>
         </div>
         <div class="source-links reveal">

--- a/docs/design/archive/0.12.0/native-inverted-index/research-report.md
+++ b/docs/design/archive/0.12.0/native-inverted-index/research-report.md
@@ -566,57 +566,66 @@ Record throughput, p50/p95/p99 latency, allocations, resident/mapped/cache bytes
 write amplification, merge time, startup/recovery time, and callback durability latency. Establish budgets from measured
 current workloads rather than choosing arbitrary parity thresholds.
 
-## 11. Four-ticket implementation sequence and rollback
+## 11. Five-ticket implementation sequence and rollback
 
-Implementation is organized by live BanyanDB role, not by engine layer. A parser, writer, query IR, shadow executor,
-fuzzer, or benchmark may be built on a ticket branch, but it cannot merge as a standalone delivery. Each ticket must
-replace its named Bluge production path in the same main-branch merge.
+Implementation is organized by independently mergeable production behavior. A parser, writer, query IR, shadow executor,
+fuzzer, or benchmark cannot merge unless named live callers switch to it in the same delivery. The read-only-first slice
+is intentionally narrow: it replaces current production reads and emits no index bytes.
 
-### NIDX-01 — Property shard index
+### NIDX-01 — Bounded read-only index access
 
-- **Production cutover:** `property/db.newShard` selects native for existing and new Property shards; Property repair uses
-  the native reader.
-- **Complete boundary:** ICE/snapshot read and compatible write; Property replace/upsert/delete; stored fields;
-  exact/boolean/range query and sort; durable callback; recovery; merge-time expiry; GC; repair; and backup.
+- **Production cutover:** `inverted.ReadOnlyDocCount`, schema-property `WalkShard`/`WalkDocs`, Property repair scans,
+  verification counts, and source reads for index-mode copy/series union use the native reader.
+- **Complete boundary:** Latest committed generation, live count, match-all, exact term/OR, deletion masks, stored fields,
+  typed scalars, repair tuple sort/search-after, streaming limits, concurrent-writer inspection, and immutable files.
+- **Deferred:** Every write, publication, callback, merge, expiry, GC, external introduction, general query language, and
+  destination writer.
+
+### NIDX-02 — Property shard index
+
+- **Production cutover:** `property/db.newShard` selects native for existing and new Property shards.
+- **Complete boundary:** Compatible write; Property replace/upsert/delete; stored fields; exact/boolean/range query and
+  sort; durable callback; recovery; merge-time expiry; GC; repair integration; and backup.
 - **Deferred:** Series wildcard/dictionary behavior, Stream element postings/MATCH, external receive, and general
-  migration.
+  migration writers.
 
-### NIDX-02 — Per-segment series `sidx`
+### NIDX-03 — Per-segment series `sidx`
 
 - **Production cutover:** `internal/storage.newSeriesIndex` selects native for Measure, Stream, and Trace, including raw
   segment replication.
 - **Complete boundary:** Field-set-aware insert, update/version/timestamp, exact/prefix/wildcard identity, dictionary
   iteration, projection, index/time/series sort, index-mode Measure, snapshot/stats, and external receive/deduplication.
-- **Deferred:** Stream element `idx`, general schema/union/copy/verify/dump/rebuild, and dependency removal.
+- **Deferred:** Stream element `idx`, general union/copy/verify/dump/rebuild writers, and dependency removal.
 
-### NIDX-03 — Stream element `idx`
+### NIDX-04 — Stream element `idx`
 
 - **Production cutover:** `stream.newElementIndex` selects the native writer, filters, posting collector, sort, snapshot,
   and receiver.
 - **Complete boundary:** Element batch and visibility; keyword/simple/standard/URL analysis; numeric/date terms;
   exact/range/AND/OR/NOT/HAVING/IN/prefix/wildcard/MATCH; paired document/timestamp postings; explicit sort; and raw
   segment receive.
-- **Deferred:** Scoring, phrase/fuzzy/geo/highlight/facet/explanation APIs, generic plugins, offline migration, and
-  dependency deletion.
+- **Deferred:** Scoring, phrase/fuzzy/geo/highlight/facet/explanation APIs, generic plugins, offline destination writers,
+  and dependency deletion.
 
-### NIDX-04 — Administration, migration, and removal
+### NIDX-05 — Remaining administration, migration, and removal
 
-- **Production cutover:** Schema loading, union/rebuild, index-mode copy, migration verification, dump, and read-only
-  count use native administration APIs.
-- **Complete boundary:** Read-only open/count, latest generation, document walk, stored/doc-value visit, sorted
-  search-after, verify/rebuild, every remaining caller rewire, and runtime Bluge/ICE/segment-API removal.
+- **Production cutover:** Remaining union/rebuild, index-mode copy, migration output, dump, and maintenance/CLI callers
+  use native administration APIs.
+- **Complete boundary:** Native destination writers, every remaining caller rewire, full verification, and runtime
+  Bluge/ICE/segment-API removal. Read-only count/walk/search-after already became native in NIDX-01.
 - **Deferred:** New disk version, opening-time migration, unused search features, and a runtime legacy fallback after
   retirement.
 
-NIDX-01 → NIDX-02 → NIDX-03 → NIDX-04 is the merge order. Each ticket is mergeable only when its native constructor is
-the default for the named role, every new production component is reachable from that constructor, the full role
-contract passes, and the named rollback binary opens, queries, mutates, merges, restarts, recovers, and—where relevant—
-receives native files on the same directory. Pre-merge shadow comparison is evidence, not a ticket.
+NIDX-01 → NIDX-02 → NIDX-03 → NIDX-04 → NIDX-05 is the merge order. NIDX-01 merges only when all named read-only callers
+are native, no file changes, iteration is bounded, and no unused reader surface is exposed. NIDX-02 through NIDX-04 merge
+only when their native constructor is the default for the complete named role and the rollback binary accepts their files.
+Pre-merge shadow comparison remains evidence, not a ticket.
 
-Before NIDX-04 retires the fallback, rollback means draining the role's writer and selecting the retained legacy
-constructor against the same files; no document replay or conversion is allowed. NIDX-04 may remove the runtime fallback
-only after the declared compatibility window and two-binary matrix pass. Because CRC32 processing is prohibited, any
-writing ticket is blocked unless the named rollback binary accepts the retained-but-uncomputed CRC32 field.
+Before NIDX-05 retires the fallback, rollback of a writing role means draining its writer and selecting the retained legacy
+constructor against the same files; no document replay or conversion is allowed. NIDX-01 rolls back by restoring the
+legacy readers and requires no drain. NIDX-05 may remove the runtime fallback only after the declared compatibility window
+and two-binary matrix pass. Because CRC32 processing is prohibited, writing tickets remain blocked unless the named
+rollback binary accepts the retained-but-uncomputed CRC32 field.
 
 ## 12. Effort and ownership estimate
 
@@ -633,7 +642,7 @@ The preliminary estimate is 25–35 engineer-weeks, or approximately 4–6 calen
 | Benchmarks, failure injection, soak, rollout | 6–10 weeks, parallel/ongoing |
 
 The ranges are planning estimates, not commitments. The codec compatibility prototype should revise them before the
-first production cutover is scheduled. These are workstreams inside NIDX-01 through NIDX-04, not additional mergeable
+first production cutover is scheduled. These are workstreams inside NIDX-01 through NIDX-05, not additional mergeable
 tickets.
 
 ## 13. Decisions and unresolved experiments
@@ -660,10 +669,11 @@ Experiments that still gate production work:
 
 ## 14. Final recommendation
 
-Proceed through four production vertical tickets. Do not merge a backend-neutral boundary, parser, shadow reader, or test
-writer by itself. Build those foundations on the NIDX-01 branch and merge them only when Property shards use the complete
-native read/write/lifecycle path by default. Then extend the already-live engine to per-segment series indexes, the Stream
-element index, and finally the remaining administration/migration callers and dependency removal.
+Proceed through five production tickets. Merge the bounded reader first only when named read-only production callers switch
+to it, historical fixtures pass, and the source directories remain byte-for-byte unchanged. Then cut over the complete
+Property write/query/lifecycle role, per-segment series indexes, the Stream element index, and finally the remaining
+administration/migration destination writers and dependency removal. Do not merge an unused backend-neutral boundary,
+parser, shadow reader, or test writer.
 
 Keep legacy output compatibility until the declared rollback window ends. This order makes every merge useful to
 BanyanDB, prevents an unused second engine from accumulating on main, and still produces a small BanyanDB-owned engine

--- a/docs/design/archive/0.12.0/native-inverted-index/safety-verification.html
+++ b/docs/design/archive/0.12.0/native-inverted-index/safety-verification.html
@@ -38,7 +38,7 @@
       </div>
       <div class="rail-status">
         <b>REVIEW</b>
-        <span>BDB-NIDX-SPEC-001<br>Revision 0.1 · 2026-08-24</span>
+        <span>BDB-NIDX-SPEC-001<br>Revision 0.2 · 2026-08-25</span>
         <span class="page-label">CHAPTER 04/05 · SAFETY</span>
       </div>
       <nav aria-label="Specification sections">
@@ -209,7 +209,7 @@
         <div class="chapter-kicker">BDB-NIDX-SPEC-001 · chapter 04 of 05</div>
         <h1>Safety and verification</h1>
         <p class="chapter-summary">Bounds, malformed-input behavior, compatibility matrices, fixtures, fuzzing, and crash evidence.</p>
-        <p class="chapter-range">SECTIONS 15–17 · REVISION 0.1 · REVIEW DRAFT</p>
+        <p class="chapter-range">SECTIONS 15–17 · REVISION 0.2 · AMENDED DESIGN</p>
         <nav class="chapter-tabs" aria-label="Specification chapters">
           <a href="index.html#status">01 Overview</a>
           <a href="write-format.html#fields">02 Write + format</a>

--- a/docs/design/archive/0.12.0/native-inverted-index/spec.css
+++ b/docs/design/archive/0.12.0/native-inverted-index/spec.css
@@ -419,7 +419,8 @@
 
     .ticket-chain {
       display: grid;
-      grid-template-columns: minmax(8rem, 1fr) auto minmax(8rem, 1fr) auto minmax(8rem, 1fr) auto minmax(8rem, 1fr);
+      grid-template-columns:
+        minmax(8rem, 1fr) auto minmax(8rem, 1fr) auto minmax(8rem, 1fr) auto minmax(8rem, 1fr) auto minmax(8rem, 1fr);
       gap: .45rem;
       align-items: stretch;
       margin: 1.2rem 0 2rem;

--- a/docs/design/archive/0.12.0/native-inverted-index/spec.js
+++ b/docs/design/archive/0.12.0/native-inverted-index/spec.js
@@ -18,8 +18,21 @@
  */
 
 (() => {
-  const storageKey = 'banyandb-native-index-spec-review-v1';
+  const storageKey = 'banyandb-native-index-spec-review-v2';
   const themeKey = 'banyandb-native-index-spec-theme';
+  const documentedDisposition = {
+    'DEC-001': 'Accept recommendation',
+    'DEC-002': 'Accept recommendation',
+    'DEC-003': 'Accept recommendation',
+    'DEC-004': 'Accept recommendation',
+    'DEC-005': 'Accept recommendation',
+    'DEC-006': 'Accept recommendation',
+    'DEC-007': 'Block specification',
+    'DEC-008': 'Accept recommendation',
+    'DEC-009': 'Accept recommendation',
+    'DEC-010': 'Accept recommendation',
+    'DEC-011': 'Accept recommendation'
+  };
   const page = document.body.dataset.page;
   const movedSections = {
     fields: 'write-format.html#fields',
@@ -42,6 +55,7 @@
     'nidx-02': 'delivery-review.html#nidx-02',
     'nidx-03': 'delivery-review.html#nidx-03',
     'nidx-04': 'delivery-review.html#nidx-04',
+    'nidx-05': 'delivery-review.html#nidx-05',
     'dec-001': 'delivery-review.html#dec-001',
     'dec-002': 'delivery-review.html#dec-002',
     'dec-003': 'delivery-review.html#dec-003',
@@ -52,6 +66,7 @@
     'dec-008': 'delivery-review.html#dec-008',
     'dec-009': 'delivery-review.html#dec-009',
     'dec-010': 'delivery-review.html#dec-010',
+    'dec-011': 'delivery-review.html#dec-011',
     'review-notes': 'delivery-review.html#review-notes',
     acceptance: 'delivery-review.html#acceptance',
     traceability: 'delivery-review.html#traceability'
@@ -85,11 +100,11 @@
 
   const reviewState = () => {
     const stored = readStoredReview();
-    const disposition = { ...(stored.disposition || {}) };
+    const disposition = { ...documentedDisposition, ...(stored.disposition || {}) };
     decisions.forEach(select => { disposition[select.dataset.decision] = select.value; });
     return {
       specification: 'BDB-NIDX-SPEC-001',
-      revision: '0.1',
+      revision: '0.2',
       disposition,
       notes: reviewNotes ? reviewNotes.value : (stored.notes || '')
     };
@@ -97,11 +112,12 @@
 
   const updateReviewMeter = () => {
     const state = reviewState();
-    const reviewed = Object.values(state.disposition).filter(Boolean).length;
+    const decisionIDs = Object.keys(documentedDisposition);
+    const reviewed = decisionIDs.filter(id => state.disposition[id]).length;
     const fill = document.querySelector('#review-meter-fill');
     const label = document.querySelector('#review-meter-label');
-    if (fill) fill.style.width = `${Math.min(reviewed, 10) * 10}%`;
-    if (label) label.textContent = `${reviewed} of 10 open decisions dispositioned`;
+    if (fill) fill.style.width = `${Math.min(reviewed / decisionIDs.length, 1) * 100}%`;
+    if (label) label.textContent = `${reviewed} of ${decisionIDs.length} decisions dispositioned`;
   };
 
   const saveReview = () => {
@@ -187,7 +203,10 @@
 
   document.querySelector('#reset-review')?.addEventListener('click', () => {
     localStorage.removeItem(storageKey);
-    decisions.forEach(select => { select.value = ''; });
+    decisions.forEach(select => {
+      const defaultOption = [...select.options].find(option => option.defaultSelected);
+      select.value = defaultOption?.value || '';
+    });
     if (reviewNotes) reviewNotes.value = '';
     updateReviewMeter();
   });

--- a/docs/design/archive/0.12.0/native-inverted-index/write-format.html
+++ b/docs/design/archive/0.12.0/native-inverted-index/write-format.html
@@ -38,7 +38,7 @@
       </div>
       <div class="rail-status">
         <b>REVIEW</b>
-        <span>BDB-NIDX-SPEC-001<br>Revision 0.1 · 2026-08-24</span>
+        <span>BDB-NIDX-SPEC-001<br>Revision 0.2 · 2026-08-25</span>
         <span class="page-label">CHAPTER 02/05 · WRITE + FORMAT</span>
       </div>
       <nav aria-label="Specification sections">
@@ -209,7 +209,7 @@
         <div class="chapter-kicker">BDB-NIDX-SPEC-001 · chapter 02 of 05</div>
         <h1>Write path and disk grammar</h1>
         <p class="chapter-summary">Fields, analyzers, batch transformation, ICE v3 sections, and snapshot v3 publication.</p>
-        <p class="chapter-range">SECTIONS 05–09 · REVISION 0.1 · REVIEW DRAFT</p>
+        <p class="chapter-range">SECTIONS 05–09 · REVISION 0.2 · AMENDED DESIGN</p>
         <nav class="chapter-tabs" aria-label="Specification chapters">
           <a href="index.html#status">01 Overview</a>
           <a href="#fields" aria-current="page">02 Write + format</a>


### PR DESCRIPTION
### Refine the native inverted-index delivery design

This updates BDB-NIDX-SPEC-001 to revision 0.2 after reviewing the scope of the first implementation ticket.

- splits the former Property-first delivery into a bounded read-only production slice followed by the complete Property cutover
- defines the exact read-only callers, supported operations, exclusions, resource bounds, immutability requirements, and rollback behavior
- changes the implementation roadmap from four tickets to five mergeable tickets
- adds DEC-011 and records all maintainer decision dispositions
- aligns the research plan and the Markdown/HTML research reports
- preserves the revision 0.1 monolithic document unchanged

Related to apache/skywalking#13990.

Validation:

- JavaScript syntax check
- HTML IDs, local links, and fragments
- Markdown local links
- headless browser rendering
- `git diff --check`
- `make license-check`

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Fixes apache/skywalking#<issue number>.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking-banyandb/blob/main/CHANGES.md). Not required: this refines the design already listed for 0.12.0.
