### PR TITLE
docs(skills): size-audit GitHub issues

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,5 +7,6 @@ Release Notes.
 ### Document
 
 - Add the [native inverted-index replacement design package](docs/design/archive/0.12.0/native-inverted-index/README.md), including the implementation specification, ICE walkthrough, research plan, and visual report.
+- Add mandatory size and TDD-feasibility audits to the BanyanDB GitHub issue skill.
 
 ## 0.11.0

--- a/skills/README.md
+++ b/skills/README.md
@@ -28,17 +28,17 @@ Compile and build the SkyWalking BanyanDB project.
 
 ### gh-issue
 
-Write a BanyanDB issue someone can implement from, and break a design-ready
-issue into tickets.
+Size-audit and write a BanyanDB issue somebody or an automated TDD workflow can
+implement, and split tracking parents into executable leaves.
 
-**Triggers:** "file an issue", "write up this feature", "turn this design into tickets", "split this issue"
+**Triggers:** "file an issue", "is this issue too large", "make this TDD-ready", "turn this design into tickets", "split this issue"
 
 **What it does:**
-1. Checks the body carries a boundary, expected values, and criteria provable by a command
-2. Names the packages and the commands that test them
-3. Flags what a storage change owes: compatibility, durability, concurrency, bounds
-4. Splits a design-ready issue into dependency-ordered vertical slices
-5. Files them as sub-issues of the base
+1. Audits repository evidence and classifies the work as an executable leaf or tracking parent
+2. Rejects oversized, false-RED, foundation-only, and not-yet-merged dependency scopes
+3. Checks the body carries a boundary, independent expected values, production activation, and command-proven acceptance criteria
+4. Splits storage replacements by live caller and fixture complexity instead of unused format layers
+5. Decomposes downstream work just in time and queues only the oldest unblocked executable leaf
 
 ### gh-pull-request
 

--- a/skills/gh-issue/SKILL.md
+++ b/skills/gh-issue/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: gh-issue
-description: Write a BanyanDB issue that someone else can implement from, and break a design-ready issue into tickets. Use when the user asks to file an issue, write up a feature or bug, turn a design or proposal into tickets, or split an issue that is too large.
+description: >-
+  Size-audit, write, and split BanyanDB issues that somebody else or an
+  automated TDD workflow can implement. Use whenever the user asks to file or
+  revise an issue, decide whether an issue is too large, make an issue
+  TDD-ready, turn a design into tickets, or split an umbrella into executable
+  leaves. Do not draft or file an implementation issue before classifying it as
+  a mergeable leaf or a tracking parent.
 allowed-tools: Bash, Read, Grep, Glob
 ---
 
@@ -13,6 +19,110 @@ repository — `apache/skywalking-banyandb` has issues disabled. Label them
 A good issue is one somebody can implement from **without asking you a
 question**. That is a higher bar than "clear", and it is the bar that decides
 whether an issue sits untouched for a year.
+
+## Size the work before polishing the issue
+
+Issue length is not issue size. Inspect the design and the relevant production
+code before drafting. Count independently testable behaviour, integration seams,
+callers, format families, lifecycle domains, fixture work, and test suites. A
+short issue that says "replace the index" can be much larger than a long issue
+that fixes one query operation.
+
+Always produce a short size audit during review, even if it will not appear in
+the filed body:
+
+```markdown
+## Size audit
+Classification: executable leaf | tracking parent
+Boundary: <one seam, or the several seams that make this a parent>
+Production activation: <the caller switched by this merge>
+RED test: <the command and the observable failure on current main>
+End to end: <the real operation proved by the merge>
+Format/lifecycle scope: <sections or algorithms; read/write/publish/merge/GC/etc.>
+Fixtures and oracle: <who supplies expected values independently of the code under test>
+Focused suites: <commands>
+Dependencies present on main: yes | no — <evidence>
+Decision: <fits one run, or the exact split required>
+```
+
+Do not infer the answers only from the proposal. Use repository evidence such as
+interfaces, call sites, packages, fixtures, and existing tests. Treat line count
+as supporting evidence, never as the sole sizing rule.
+
+### Executable leaf versus tracking parent
+
+An **executable leaf** must satisfy all of these:
+
+- It exposes one agreed boundary and delivers one behaviour end to end.
+- The same merge switches at least one named production or CLI caller to it.
+- Every requirement has a RED test that fails on current `main` for a stated
+  reason and passes after the change.
+- One focused end-to-end scenario proves the real caller, not just an isolated
+  codec or helper.
+- Expected values and persisted bytes come from an independent oracle.
+- Its prerequisites and the seam it builds on are already merged to `main`.
+- A contract author can create the boundary and RED tests in one workflow turn,
+  and an implementer can reasonably complete the production change in the next.
+
+A **tracking parent** describes a milestone, replacement, or multi-PR outcome.
+It owns completion criteria, the dependency graph, and links to children, but it
+is not itself an implementation contract. Mark it clearly as a tracking parent
+and do not put it in an automated implementation queue.
+
+### Mandatory split triggers
+
+Classify the issue as a parent or split it before filing when any of these is
+true:
+
+- It mixes lifecycle domains such as read, write, publish/recovery, merge/GC, or
+  replication.
+- It introduces several independent public seams or several unrelated caller
+  cutovers.
+- It replaces a whole third-party subsystem rather than one observable operation.
+- No test can be named that fails on current `main` without asserting private
+  implementation details.
+- It needs the production implementation to generate its own expected fixture
+  bytes; that is a circular oracle, not a test contract.
+- A required boundary exists only in an open or planned PR. Keep the issue as a
+  parent and decompose it after the blocker merges.
+- It is foundation-only: the merge adds format readers, helpers, or abstractions
+  that no production/CLI path uses.
+
+Use this score as a second check when none of the hard triggers is decisive:
+
+| add | signal |
+|---:|---|
+| +2 | each additional public boundary after the first |
+| +2 | each additional lifecycle domain after the first |
+| +1 | each additional production caller family |
+| +1 | each additional persisted format or algorithm family |
+| +1 | each additional independent fixture family |
+| +1 | each additional focused package test suite |
+| +2 | a prerequisite or seam is not yet on `main` |
+
+Score `0–2`: normally a leaf. Score `3–4`: split unless repository evidence
+shows it is still one small behaviour. Score `5+`: a tracking parent. A hard
+trigger overrides the score.
+
+For a TDD workflow, also cap a leaf at roughly four observable requirements,
+one fixture family, one activation point, and one focused end-to-end scenario.
+These are review budgets, not excuses to hide work by combining requirements.
+
+### RED-test feasibility catches false slices
+
+A compatibility-preserving cutover often returns the same result before and
+after the change, so a new output assertion may pass against the legacy path and
+is not RED. State why the test fails before implementation. Absence of a new
+boundary can be a compile-time RED test, but acceptance must also prove that a
+real caller uses the boundary; do not use brittle source-text assertions as the
+only proof.
+
+If a fixture is required, include its cost in the size audit. Persisted expected
+bytes should be generated by an independent legacy/reference writer and checked
+in with provenance before the native code consumes them. Do not create a
+fixture-only or codec-only ticket when the project requires every merge to
+activate production behaviour; put the smallest fixture and decoder beside the
+first real caller that uses them.
 
 ## The body is the specification
 
@@ -107,6 +217,18 @@ A slice is the right size when it delivers one behaviour end to end and its
 acceptance criteria can be checked by running something. A slice that only makes
 sense alongside the next one is not a slice; it is half of one.
 
+Do not slice a storage replacement horizontally by format section (`container`,
+`postings`, `stored fields`) if those tickets would be unused foundations. Slice
+by **fixture complexity against one real caller** instead. A first read slice may
+activate document count on a deliberately small fixture; a later slice can widen
+that same caller to multiple segments and deletion masks; another caller can
+then activate stored-field decoding. Each merge stays TDD-sized and live.
+
+Decompose just in time. Keep downstream design workstreams as tracking parents
+until their blocker lands. Then inspect the boundary that actually merged and
+create their executable leaves. Pre-filing speculative leaves commits to stale
+seams and recreates horizontal slicing at the issue layer.
+
 **Order them by dependency and say so.** Put `Blocked by: #NNNN` in the body of
 anything that needs an earlier ticket, and create them in that order so the
 numbers ascend with the graph. **Do not start a blocked ticket before its blocker
@@ -147,13 +269,24 @@ gh api repos/apache/skywalking/issues/<base> -q .sub_issues_summary
 The base issue stays open as the umbrella, and `sub_issues_summary` is the
 progress bar. Close it when the last ticket merges.
 
+If automation selects the oldest issue with a queue label such as `Backlog`,
+apply that label only to the oldest unblocked executable leaf. Never queue a
+tracking parent or all sibling leaves at once. Create children in dependency
+order so issue numbers reinforce rather than fight the execution order.
+
 ## Before you file
 
+- Did you show the size audit and explicitly classify the issue as a leaf or a
+  tracking parent?
 - Could someone write a failing test from this body alone, without asking you
   anything?
+- Does the test actually fail on current `main`, or would the legacy path already
+  satisfy it?
 - Does every expected value come from the issue rather than from what the code
   would compute?
 - Is every acceptance criterion provable by running something?
-- Is it one boundary, or is it a plan with phases?
+- Is it one boundary and one production activation, or a plan with phases?
+- Does this merge activate a real caller rather than land dead foundation code?
+- Are all prerequisite seams already merged to `main`?
 - If it touches stored or wire data, does it say what happens to existing data
   and to a mixed-version cluster?

--- a/skills/gh-issue/evals/evals.json
+++ b/skills/gh-issue/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill_name": "gh-issue",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Make one Backlog issue replace the ICE reader across six callers, including all codecs, generation selection, sorting, and a new fixture corpus.",
+      "expected_output": "Classifies it as a parent after a size audit, proposes live-caller slices instead of format tickets, and does not queue the parent.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "Write an issue to switch property ReadOnlyDocCount to a merged seam. A legacy-generated, no-deletion fixture has expected count 7.",
+      "expected_output": "Classifies it as a leaf, states the expected count, RED and end-to-end tests, and excludes multi-segment and deletion behavior.",
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "The reader is not merged. Pre-file writer, GC, replication, query, and cutover leaves, then apply Backlog to every child.",
+      "expected_output": "Keeps downstream work as parents until blockers merge, decomposes just in time, and queues only the oldest unblocked leaf.",
+      "files": []
+    },
+    {
+      "id": 4,
+      "prompt": "Make a reader cutover TDD-ready. Its output test already passes on legacy, and its new decoders have no caller until a later PR.",
+      "expected_output": "Flags the false RED and dead foundation, then requires a failing boundary test and caller activation in the same merge or redesigns the slice.",
+      "files": []
+    }
+  ]
+}


### PR DESCRIPTION
### Size-audit BanyanDB implementation issues

- require a repository-backed size audit before drafting or filing an implementation issue
- distinguish executable leaves from tracking parents with mandatory split triggers and a review score
- require RED-test feasibility, an independent fixture oracle, and production caller activation
- guide storage replacements toward live-caller slices and just-in-time downstream decomposition
- add four regression prompts for oversized, correctly sized, prematurely decomposed, and false-RED scopes
- update the skill catalog and `CHANGES.md`

- [x] This pull request does not close an existing issue.
- [x] Update the [`CHANGES` log](https://github.com/apache/skywalking-banyandb/blob/main/CHANGES.md).

### Tests

- `python3 -m json.tool skills/gh-issue/evals/evals.json`
- frontmatter, line-length, and `git diff --check` validation
- `make license-check`
