### PR TITLE
feat(liaison): scope schema authorization to exact BanyanDB groups

### DIFF
--- a/banyand/liaison/grpc/methodpolicy.go
+++ b/banyand/liaison/grpc/methodpolicy.go
@@ -72,6 +72,11 @@ const (
 	// for the method's permission. It is the fail-closed outcome and, like DecisionDeny,
 	// is reported to the caller as codes.PermissionDenied.
 	DecisionUnavailable
+	// DecisionInvalidRequest rejects the request because the group scope its method's policy
+	// needs cannot be read from it. It is reported to the caller as codes.InvalidArgument, so
+	// an authenticated caller sending a malformed request learns that it was malformed and
+	// learns nothing about what it would have been allowed to do.
+	DecisionInvalidRequest
 )
 
 // DecisionReason is a bounded explanation for an authorization decision.
@@ -84,7 +89,21 @@ const (
 	DecisionReasonPermissionMissing   DecisionReason = "permission_missing"
 	DecisionReasonExecutorUnavailable DecisionReason = "executor_unavailable"
 	DecisionReasonHealthExempt        DecisionReason = "health_exempt"
+	DecisionReasonInvalidRequest      DecisionReason = "invalid_request"
 )
+
+// DecisionReasons returns every bounded reason an authorization decision can carry, in a
+// fixed order. It is the closed label set observability is allowed to report.
+func DecisionReasons() []DecisionReason {
+	return []DecisionReason{
+		DecisionReasonGranted,
+		DecisionReasonUnauthenticated,
+		DecisionReasonPermissionMissing,
+		DecisionReasonExecutorUnavailable,
+		DecisionReasonHealthExempt,
+		DecisionReasonInvalidRequest,
+	}
+}
 
 // DecisionLabel returns the bounded observability label for the decision. Internal deny
 // variants collapse to "deny" and are distinguished by a bounded reason label.
@@ -109,6 +128,10 @@ type MethodPolicy struct {
 	Permission auth.Permission
 	// Access identifies authentication-only, health-policy, or RBAC permission checks.
 	Access MethodAccess
+	// Scope names the typed extractor that resolves the method's group scopes from its
+	// request. It pairs the method with exactly one scope family, so a decision for the
+	// method reads the groups out of the request shape that method actually has.
+	Scope ScopeFamily
 	// Activated reports whether this release has an executor that can decide Permission.
 	// A registered method whose permission has no activated executor fails closed for
 	// every principal, admin included.
@@ -210,47 +233,48 @@ func fullMethod(descriptor grpclib.ServiceDesc, method string) string {
 }
 
 // GlobalMethodPolicies returns the method policy table for this release: every method the
-// liaison can serve, the permission it requires, and whether this release can decide that
-// permission. Cluster permissions are activated; schema and data permissions are not, and
-// the methods carrying them fail closed until a later release activates their executor.
+// liaison can serve, the permission it requires, the scope family a decision for it reads out
+// of its request, and whether this release can decide that permission. Cluster permissions
+// are activated; the methods whose permission has no activated executor fail closed for every
+// principal until a later release activates it.
 func GlobalMethodPolicies() MethodPolicyTable {
 	policies := MethodPolicyTable{
 		authenticatedPolicy("/banyandb.common.v1.Service/GetAPIVersion"),
 		healthPolicy("/grpc.health.v1.Health/Check"),
 		authenticatedPolicy("/grpc.health.v1.Health/List"),
 		authenticatedPolicy("/grpc.health.v1.Health/Watch"),
-		permissionPolicy("/banyandb.database.v1.ClusterStateService/GetClusterState", auth.PermissionClusterRead, true),
-		permissionPolicy("/banyandb.database.v1.NodeQueryService/GetCurrentNode", auth.PermissionClusterRead, true),
-		permissionPolicy("/banyandb.database.v1.GroupRegistryService/Inspect", auth.PermissionClusterRead, true),
-		permissionPolicy("/banyandb.database.v1.GroupRegistryService/Query", auth.PermissionClusterRead, true),
-		permissionPolicy("/banyandb.database.v1.SnapshotService/Snapshot", auth.PermissionClusterAdmin, true),
-		permissionPolicy("/banyandb.stream.v1.StreamService/DeleteExpiredSegments", auth.PermissionClusterAdmin, true),
-		permissionPolicy("/banyandb.measure.v1.MeasureService/DeleteExpiredSegments", auth.PermissionClusterAdmin, true),
-		permissionPolicy("/banyandb.trace.v1.TraceService/DeleteExpiredSegments", auth.PermissionClusterAdmin, true),
-		permissionPolicy("/banyandb.measure.v1.MeasureService/InternalQuery", auth.PermissionClusterAdmin, true),
-		permissionPolicy("/banyandb.cluster.v1.NodeSchemaStatusService/GetMaxRevision", auth.PermissionClusterAdmin, true),
-		permissionPolicy("/banyandb.cluster.v1.NodeSchemaStatusService/GetKeyRevisions", auth.PermissionClusterAdmin, true),
-		permissionPolicy("/banyandb.cluster.v1.NodeSchemaStatusService/GetAbsentKeys", auth.PermissionClusterAdmin, true),
-		permissionPolicy("/banyandb.schema.v1.SchemaBarrierService/AwaitRevisionApplied", auth.PermissionSchemaRead, false),
-		permissionPolicy("/banyandb.schema.v1.SchemaBarrierService/AwaitSchemaApplied", auth.PermissionSchemaRead, false),
-		permissionPolicy("/banyandb.schema.v1.SchemaBarrierService/AwaitSchemaDeleted", auth.PermissionSchemaRead, false),
-		permissionPolicy("/banyandb.database.v1.GroupRegistryService/Get", auth.PermissionSchemaRead, false),
-		permissionPolicy("/banyandb.database.v1.GroupRegistryService/List", auth.PermissionSchemaRead, false),
-		permissionPolicy("/banyandb.database.v1.GroupRegistryService/Exist", auth.PermissionSchemaRead, false),
-		permissionPolicy("/banyandb.database.v1.GroupRegistryService/Create", auth.PermissionSchemaWrite, false),
-		permissionPolicy("/banyandb.database.v1.GroupRegistryService/Update", auth.PermissionSchemaWrite, false),
-		permissionPolicy("/banyandb.database.v1.GroupRegistryService/Delete", auth.PermissionSchemaWrite, false),
-		permissionPolicy("/banyandb.stream.v1.StreamService/Query", auth.PermissionDataRead, false),
-		permissionPolicy("/banyandb.stream.v1.StreamService/Write", auth.PermissionDataWrite, false),
-		permissionPolicy("/banyandb.measure.v1.MeasureService/Query", auth.PermissionDataRead, false),
-		permissionPolicy("/banyandb.measure.v1.MeasureService/TopN", auth.PermissionDataRead, false),
-		permissionPolicy("/banyandb.measure.v1.MeasureService/Write", auth.PermissionDataWrite, false),
-		permissionPolicy("/banyandb.trace.v1.TraceService/Query", auth.PermissionDataRead, false),
-		permissionPolicy("/banyandb.trace.v1.TraceService/Write", auth.PermissionDataWrite, false),
-		permissionPolicy("/banyandb.property.v1.PropertyService/Query", auth.PermissionDataRead, false),
-		permissionPolicy("/banyandb.property.v1.PropertyService/Apply", auth.PermissionDataWrite, false),
-		permissionPolicy("/banyandb.property.v1.PropertyService/Delete", auth.PermissionDataWrite, false),
-		permissionPolicy("/banyandb.bydbql.v1.BydbQLService/Query", auth.PermissionDataRead, false),
+		permissionPolicy("/banyandb.database.v1.ClusterStateService/GetClusterState", auth.PermissionClusterRead, ScopeGlobal, true),
+		permissionPolicy("/banyandb.database.v1.NodeQueryService/GetCurrentNode", auth.PermissionClusterRead, ScopeGlobal, true),
+		permissionPolicy("/banyandb.database.v1.GroupRegistryService/Inspect", auth.PermissionClusterRead, ScopeGlobal, true),
+		permissionPolicy("/banyandb.database.v1.GroupRegistryService/Query", auth.PermissionClusterRead, ScopeGlobal, true),
+		permissionPolicy("/banyandb.database.v1.SnapshotService/Snapshot", auth.PermissionClusterAdmin, ScopeGlobal, true),
+		permissionPolicy("/banyandb.stream.v1.StreamService/DeleteExpiredSegments", auth.PermissionClusterAdmin, ScopeGlobal, true),
+		permissionPolicy("/banyandb.measure.v1.MeasureService/DeleteExpiredSegments", auth.PermissionClusterAdmin, ScopeGlobal, true),
+		permissionPolicy("/banyandb.trace.v1.TraceService/DeleteExpiredSegments", auth.PermissionClusterAdmin, ScopeGlobal, true),
+		permissionPolicy("/banyandb.measure.v1.MeasureService/InternalQuery", auth.PermissionClusterAdmin, ScopeGlobal, true),
+		permissionPolicy("/banyandb.cluster.v1.NodeSchemaStatusService/GetMaxRevision", auth.PermissionClusterAdmin, ScopeGlobal, true),
+		permissionPolicy("/banyandb.cluster.v1.NodeSchemaStatusService/GetKeyRevisions", auth.PermissionClusterAdmin, ScopeGlobal, true),
+		permissionPolicy("/banyandb.cluster.v1.NodeSchemaStatusService/GetAbsentKeys", auth.PermissionClusterAdmin, ScopeGlobal, true),
+		permissionPolicy("/banyandb.schema.v1.SchemaBarrierService/AwaitRevisionApplied", auth.PermissionSchemaRead, ScopeUnspecified, false),
+		permissionPolicy("/banyandb.schema.v1.SchemaBarrierService/AwaitSchemaApplied", auth.PermissionSchemaRead, ScopeUnspecified, false),
+		permissionPolicy("/banyandb.schema.v1.SchemaBarrierService/AwaitSchemaDeleted", auth.PermissionSchemaRead, ScopeUnspecified, false),
+		permissionPolicy("/banyandb.database.v1.GroupRegistryService/Get", auth.PermissionSchemaRead, ScopeUnspecified, false),
+		permissionPolicy("/banyandb.database.v1.GroupRegistryService/List", auth.PermissionSchemaRead, ScopeUnspecified, false),
+		permissionPolicy("/banyandb.database.v1.GroupRegistryService/Exist", auth.PermissionSchemaRead, ScopeUnspecified, false),
+		permissionPolicy("/banyandb.database.v1.GroupRegistryService/Create", auth.PermissionSchemaWrite, ScopeUnspecified, false),
+		permissionPolicy("/banyandb.database.v1.GroupRegistryService/Update", auth.PermissionSchemaWrite, ScopeUnspecified, false),
+		permissionPolicy("/banyandb.database.v1.GroupRegistryService/Delete", auth.PermissionSchemaWrite, ScopeUnspecified, false),
+		permissionPolicy("/banyandb.stream.v1.StreamService/Query", auth.PermissionDataRead, ScopeUnspecified, false),
+		permissionPolicy("/banyandb.stream.v1.StreamService/Write", auth.PermissionDataWrite, ScopeUnspecified, false),
+		permissionPolicy("/banyandb.measure.v1.MeasureService/Query", auth.PermissionDataRead, ScopeUnspecified, false),
+		permissionPolicy("/banyandb.measure.v1.MeasureService/TopN", auth.PermissionDataRead, ScopeUnspecified, false),
+		permissionPolicy("/banyandb.measure.v1.MeasureService/Write", auth.PermissionDataWrite, ScopeUnspecified, false),
+		permissionPolicy("/banyandb.trace.v1.TraceService/Query", auth.PermissionDataRead, ScopeUnspecified, false),
+		permissionPolicy("/banyandb.trace.v1.TraceService/Write", auth.PermissionDataWrite, ScopeUnspecified, false),
+		permissionPolicy("/banyandb.property.v1.PropertyService/Query", auth.PermissionDataRead, ScopeUnspecified, false),
+		permissionPolicy("/banyandb.property.v1.PropertyService/Apply", auth.PermissionDataWrite, ScopeUnspecified, false),
+		permissionPolicy("/banyandb.property.v1.PropertyService/Delete", auth.PermissionDataWrite, ScopeUnspecified, false),
+		permissionPolicy("/banyandb.bydbql.v1.BydbQLService/Query", auth.PermissionDataRead, ScopeUnspecified, false),
 	}
 	for _, service := range []string{
 		"StreamRegistryService", "MeasureRegistryService", "TraceRegistryService", "IndexRuleRegistryService",
@@ -258,19 +282,19 @@ func GlobalMethodPolicies() MethodPolicyTable {
 	} {
 		servicePrefix := "/banyandb.database.v1." + service + "/"
 		policies = append(policies,
-			permissionPolicy(servicePrefix+"Get", auth.PermissionSchemaRead, false),
-			permissionPolicy(servicePrefix+"List", auth.PermissionSchemaRead, false),
-			permissionPolicy(servicePrefix+"Exist", auth.PermissionSchemaRead, false),
-			permissionPolicy(servicePrefix+"Create", auth.PermissionSchemaWrite, false),
-			permissionPolicy(servicePrefix+"Update", auth.PermissionSchemaWrite, false),
-			permissionPolicy(servicePrefix+"Delete", auth.PermissionSchemaWrite, false),
+			permissionPolicy(servicePrefix+"Get", auth.PermissionSchemaRead, ScopeUnspecified, false),
+			permissionPolicy(servicePrefix+"List", auth.PermissionSchemaRead, ScopeUnspecified, false),
+			permissionPolicy(servicePrefix+"Exist", auth.PermissionSchemaRead, ScopeUnspecified, false),
+			permissionPolicy(servicePrefix+"Create", auth.PermissionSchemaWrite, ScopeUnspecified, false),
+			permissionPolicy(servicePrefix+"Update", auth.PermissionSchemaWrite, ScopeUnspecified, false),
+			permissionPolicy(servicePrefix+"Delete", auth.PermissionSchemaWrite, ScopeUnspecified, false),
 		)
 	}
 	return policies
 }
 
-func permissionPolicy(method string, permission auth.Permission, activated bool) MethodPolicy {
-	return MethodPolicy{FullMethod: method, Permission: permission, Access: MethodAccessPermission, Activated: activated}
+func permissionPolicy(method string, permission auth.Permission, scope ScopeFamily, activated bool) MethodPolicy {
+	return MethodPolicy{FullMethod: method, Permission: permission, Access: MethodAccessPermission, Scope: scope, Activated: activated}
 }
 
 func authenticatedPolicy(method string) MethodPolicy {
@@ -307,25 +331,41 @@ func (table MethodPolicyTable) Policy(fullMethod string) (MethodPolicy, bool) {
 	return MethodPolicy{}, false
 }
 
-// Authorize decides the given gRPC method for the given principal against the grants in
-// the given snapshot. It returns DecisionUnavailable when the method's permission has no
-// activated executor, DecisionDeny when the principal does not hold the permission or when
-// the method is unclassified, and DecisionAllow only when an activated permission is held.
-func (table MethodPolicyTable) Authorize(snapshot auth.Snapshot, principal auth.Principal, fullMethod string) Decision {
+// Authorize is the liaison's single authorization decision. It decides fullMethod for
+// principal against the grants in snapshot, resolving the group scopes the method's policy
+// needs from request, and returns the outcome together with the bounded reason the liaison
+// reports for it. Both interceptors take their decision here; there is no second authorizer
+// and no per-transport policy, so a direct gRPC call and the grpc-gateway call bound to the
+// same method are decided identically.
+//
+// The order is fixed and each step is decidable without the one after it: an unclassified
+// method is DecisionDeny; an authentication-only or health method is DecisionAllow; a method
+// whose permission has no activated executor is DecisionUnavailable for every principal,
+// admin included; a request the policy's scope family cannot be read from is
+// DecisionInvalidRequest; and the permission must then be held for every resolved scope,
+// which makes a multi-group request all-or-nothing. Requests addressing no group pass a nil
+// request and are satisfied only by a wildcard grant.
+func (table MethodPolicyTable) Authorize(
+	snapshot auth.Snapshot, principal auth.Principal, fullMethod string, request any,
+) (Decision, DecisionReason) {
 	policy, exists := table.Policy(fullMethod)
 	if !exists {
-		return DecisionDeny
+		return DecisionDeny, DecisionReasonPermissionMissing
 	}
 	if policy.Access == MethodAccessAuthenticated || policy.Access == MethodAccessHealth {
-		return DecisionAllow
+		return DecisionAllow, DecisionReasonGranted
 	}
 	if !policy.Activated {
-		return DecisionUnavailable
+		return DecisionUnavailable, DecisionReasonExecutorUnavailable
 	}
-	if snapshot == nil || !snapshot.Allows(principal, policy.Permission) {
-		return DecisionDeny
+	scopes, scopeErr := RequestScopes(policy.Scope, request)
+	if scopeErr != nil {
+		return DecisionInvalidRequest, DecisionReasonInvalidRequest
 	}
-	return DecisionAllow
+	if snapshot == nil || !snapshot.Allows(principal, policy.Permission, scopes...) {
+		return DecisionDeny, DecisionReasonPermissionMissing
+	}
+	return DecisionAllow, DecisionReasonGranted
 }
 
 // ValidateMethodPolicies reports whether the given table classifies exactly the given
@@ -425,9 +465,9 @@ func NewAuthorizationInterceptor(reloader *auth.Reloader, table MethodPolicyTabl
 			return handler(handlerContext, request)
 		}
 
-		decision := table.Authorize(snapshot, principal, info.FullMethod)
+		decision, reason := table.Authorize(snapshot, principal, info.FullMethod, request)
 		if classified {
-			observeDecision(observer, snapshot, policy, decision, reasonForDecision(decision))
+			observeDecision(observer, snapshot, policy, decision, reason)
 		}
 		if decision != DecisionAllow {
 			return nil, status.Error(codes.PermissionDenied, "permission denied")
@@ -477,9 +517,9 @@ func NewAuthorizationStreamInterceptor(
 			return handler(server, trustedStream)
 		}
 
-		decision := table.Authorize(snapshot, principal, info.FullMethod)
+		decision, reason := table.Authorize(snapshot, principal, info.FullMethod, nil)
 		if classified {
-			observeDecision(observer, snapshot, policy, decision, reasonForDecision(decision))
+			observeDecision(observer, snapshot, policy, decision, reason)
 		}
 		if decision != DecisionAllow {
 			return status.Error(codes.PermissionDenied, "permission denied")
@@ -503,17 +543,6 @@ func permissionLabel(policy MethodPolicy) string {
 		return "health"
 	default:
 		return string(policy.Permission)
-	}
-}
-
-func reasonForDecision(decision Decision) DecisionReason {
-	switch decision {
-	case DecisionAllow:
-		return DecisionReasonGranted
-	case DecisionUnavailable:
-		return DecisionReasonExecutorUnavailable
-	default:
-		return DecisionReasonPermissionMissing
 	}
 }
 

--- a/banyand/liaison/grpc/methodpolicy.go
+++ b/banyand/liaison/grpc/methodpolicy.go
@@ -255,15 +255,15 @@ func GlobalMethodPolicies() MethodPolicyTable {
 		permissionPolicy("/banyandb.cluster.v1.NodeSchemaStatusService/GetMaxRevision", auth.PermissionClusterAdmin, ScopeGlobal, true),
 		permissionPolicy("/banyandb.cluster.v1.NodeSchemaStatusService/GetKeyRevisions", auth.PermissionClusterAdmin, ScopeGlobal, true),
 		permissionPolicy("/banyandb.cluster.v1.NodeSchemaStatusService/GetAbsentKeys", auth.PermissionClusterAdmin, ScopeGlobal, true),
-		permissionPolicy("/banyandb.schema.v1.SchemaBarrierService/AwaitRevisionApplied", auth.PermissionSchemaRead, ScopeUnspecified, false),
-		permissionPolicy("/banyandb.schema.v1.SchemaBarrierService/AwaitSchemaApplied", auth.PermissionSchemaRead, ScopeUnspecified, false),
-		permissionPolicy("/banyandb.schema.v1.SchemaBarrierService/AwaitSchemaDeleted", auth.PermissionSchemaRead, ScopeUnspecified, false),
-		permissionPolicy("/banyandb.database.v1.GroupRegistryService/Get", auth.PermissionSchemaRead, ScopeUnspecified, false),
-		permissionPolicy("/banyandb.database.v1.GroupRegistryService/List", auth.PermissionSchemaRead, ScopeUnspecified, false),
-		permissionPolicy("/banyandb.database.v1.GroupRegistryService/Exist", auth.PermissionSchemaRead, ScopeUnspecified, false),
-		permissionPolicy("/banyandb.database.v1.GroupRegistryService/Create", auth.PermissionSchemaWrite, ScopeUnspecified, false),
-		permissionPolicy("/banyandb.database.v1.GroupRegistryService/Update", auth.PermissionSchemaWrite, ScopeUnspecified, false),
-		permissionPolicy("/banyandb.database.v1.GroupRegistryService/Delete", auth.PermissionSchemaWrite, ScopeUnspecified, false),
+		permissionPolicy("/banyandb.schema.v1.SchemaBarrierService/AwaitRevisionApplied", auth.PermissionSchemaRead, ScopeGlobal, true),
+		permissionPolicy("/banyandb.schema.v1.SchemaBarrierService/AwaitSchemaApplied", auth.PermissionSchemaRead, ScopeSchemaKeys, true),
+		permissionPolicy("/banyandb.schema.v1.SchemaBarrierService/AwaitSchemaDeleted", auth.PermissionSchemaRead, ScopeSchemaKeys, true),
+		permissionPolicy("/banyandb.database.v1.GroupRegistryService/Get", auth.PermissionSchemaRead, ScopeDirectGroup, true),
+		permissionPolicy("/banyandb.database.v1.GroupRegistryService/List", auth.PermissionSchemaRead, ScopeVisibleGroups, true),
+		permissionPolicy("/banyandb.database.v1.GroupRegistryService/Exist", auth.PermissionSchemaRead, ScopeDirectGroup, true),
+		permissionPolicy("/banyandb.database.v1.GroupRegistryService/Create", auth.PermissionSchemaWrite, ScopeGroupBodyName, true),
+		permissionPolicy("/banyandb.database.v1.GroupRegistryService/Update", auth.PermissionSchemaWrite, ScopeGroupBodyName, true),
+		permissionPolicy("/banyandb.database.v1.GroupRegistryService/Delete", auth.PermissionSchemaWrite, ScopeDirectGroup, true),
 		permissionPolicy("/banyandb.stream.v1.StreamService/Query", auth.PermissionDataRead, ScopeUnspecified, false),
 		permissionPolicy("/banyandb.stream.v1.StreamService/Write", auth.PermissionDataWrite, ScopeUnspecified, false),
 		permissionPolicy("/banyandb.measure.v1.MeasureService/Query", auth.PermissionDataRead, ScopeUnspecified, false),
@@ -282,12 +282,12 @@ func GlobalMethodPolicies() MethodPolicyTable {
 	} {
 		servicePrefix := "/banyandb.database.v1." + service + "/"
 		policies = append(policies,
-			permissionPolicy(servicePrefix+"Get", auth.PermissionSchemaRead, ScopeUnspecified, false),
-			permissionPolicy(servicePrefix+"List", auth.PermissionSchemaRead, ScopeUnspecified, false),
-			permissionPolicy(servicePrefix+"Exist", auth.PermissionSchemaRead, ScopeUnspecified, false),
-			permissionPolicy(servicePrefix+"Create", auth.PermissionSchemaWrite, ScopeUnspecified, false),
-			permissionPolicy(servicePrefix+"Update", auth.PermissionSchemaWrite, ScopeUnspecified, false),
-			permissionPolicy(servicePrefix+"Delete", auth.PermissionSchemaWrite, ScopeUnspecified, false),
+			permissionPolicy(servicePrefix+"Get", auth.PermissionSchemaRead, ScopeMetadataGroup, true),
+			permissionPolicy(servicePrefix+"List", auth.PermissionSchemaRead, ScopeDirectGroup, true),
+			permissionPolicy(servicePrefix+"Exist", auth.PermissionSchemaRead, ScopeMetadataGroup, true),
+			permissionPolicy(servicePrefix+"Create", auth.PermissionSchemaWrite, ScopeResourceMetadataGroup, true),
+			permissionPolicy(servicePrefix+"Update", auth.PermissionSchemaWrite, ScopeResourceMetadataGroup, true),
+			permissionPolicy(servicePrefix+"Delete", auth.PermissionSchemaWrite, ScopeMetadataGroup, true),
 		)
 	}
 	return policies
@@ -362,7 +362,16 @@ func (table MethodPolicyTable) Authorize(
 	if scopeErr != nil {
 		return DecisionInvalidRequest, DecisionReasonInvalidRequest
 	}
-	if snapshot == nil || !snapshot.Allows(principal, policy.Permission, scopes...) {
+	if snapshot == nil {
+		return DecisionDeny, DecisionReasonPermissionMissing
+	}
+	if policy.Scope == ScopeVisibleGroups {
+		if !snapshot.AllowsAny(principal, policy.Permission) {
+			return DecisionDeny, DecisionReasonPermissionMissing
+		}
+		return DecisionAllow, DecisionReasonGranted
+	}
+	if !snapshot.Allows(principal, policy.Permission, scopes...) {
 		return DecisionDeny, DecisionReasonPermissionMissing
 	}
 	return DecisionAllow, DecisionReasonGranted
@@ -470,9 +479,13 @@ func NewAuthorizationInterceptor(reloader *auth.Reloader, table MethodPolicyTabl
 			observeDecision(observer, snapshot, policy, decision, reason)
 		}
 		if decision != DecisionAllow {
-			return nil, status.Error(codes.PermissionDenied, "permission denied")
+			return nil, decisionError(decision)
 		}
-		return handler(handlerContext, request)
+		reply, handlerErr := handler(handlerContext, request)
+		if handlerErr != nil {
+			return reply, handlerErr
+		}
+		return FilterResponse(snapshot, principal, policy, reply), nil
 	}
 }
 
@@ -544,6 +557,13 @@ func permissionLabel(policy MethodPolicy) string {
 	default:
 		return string(policy.Permission)
 	}
+}
+
+func decisionError(decision Decision) error {
+	if decision == DecisionInvalidRequest {
+		return status.Error(codes.InvalidArgument, "invalid request")
+	}
+	return status.Error(codes.PermissionDenied, "permission denied")
 }
 
 func authenticatePrincipal(ctx context.Context, snapshot auth.Snapshot) (auth.Principal, bool) {

--- a/banyand/liaison/grpc/methodpolicy_contract_test.go
+++ b/banyand/liaison/grpc/methodpolicy_contract_test.go
@@ -282,10 +282,15 @@ func TestR1_ClassificationDefectsStopStartup(t *testing.T) {
 	})
 }
 
-// TestR6_GlobalMethodsAreActivatedAndTheRestFailClosed proves R6: exactly the global
-// method set of issue #14014 carries a cluster permission and is activated, and every
-// other method the liaison serves is classified with a schema or data permission and is
-// *not* activated, so it fails closed until W-PR2/W-PR3 activates its executor.
+// TestR6_GlobalMethodsAreActivatedAndTheRestFailClosed proves that the classification's
+// activation column matches what the release can decide. The global method set of issue
+// #14014 carries a cluster permission and is activated; the schema methods issue #14015
+// activates carry a schema permission and are activated; and every data method is classified
+// but *not* activated, so it fails closed until W-PR3 activates its executor.
+//
+// It gates R6 of issue #14015 alongside R6 of #14014: the activation column is the single
+// place a data method could be switched on by accident, and the per-permission counts below
+// are the fixed table size neither milestone may change.
 func TestR6_GlobalMethodsAreActivatedAndTheRestFailClosed(t *testing.T) {
 	table := policyTable(t)
 	seen := make(map[string]bool, len(globalMethods))
@@ -309,11 +314,15 @@ func TestR6_GlobalMethodsAreActivatedAndTheRestFailClosed(t *testing.T) {
 			}
 			continue
 		}
-		if p.Activated {
-			t.Errorf("policy for %s is activated, want only the fixed global method set activated in this release", p.FullMethod)
-		}
 		switch p.Permission {
-		case auth.PermissionSchemaRead, auth.PermissionSchemaWrite, auth.PermissionDataRead, auth.PermissionDataWrite:
+		case auth.PermissionSchemaRead, auth.PermissionSchemaWrite:
+			if !p.Activated {
+				t.Errorf("schema policy for %s is not activated, want issue #14015 to decide it", p.FullMethod)
+			}
+		case auth.PermissionDataRead, auth.PermissionDataWrite:
+			if p.Activated {
+				t.Errorf("data policy for %s is activated, want it to stay fail-closed for W-PR3", p.FullMethod)
+			}
 		default:
 			t.Errorf("policy for %s requires %q, want a schema or data permission for a non-global method", p.FullMethod, p.Permission)
 		}
@@ -378,14 +387,12 @@ func TestR3_GlobalDecisionMatrix(t *testing.T) {
 		{mMeasureDeleteSeg, allow, deny, deny, deny, deny},
 		{mTraceDeleteSeg, allow, deny, deny, deny, deny},
 		{mMeasureInternalQ, allow, deny, deny, deny, deny},
-		// data / schema — no activated executor, so every actor fails closed.
-		{mAwaitRevision, shut, shut, shut, shut, shut},
+		// data — no activated executor, so every actor fails closed. The schema methods
+		// this milestone activates are oracled in rbac_schema_contract_test.go instead.
 		{mMeasureQuery, shut, shut, shut, shut, shut},
 		{mStreamWrite, shut, shut, shut, shut, shut},
 		{mBydbQLQuery, shut, shut, shut, shut, shut},
 		{mPropertyApply, shut, shut, shut, shut, shut},
-		{mGroupCreate, shut, shut, shut, shut, shut},
-		{mGroupList, shut, shut, shut, shut, shut},
 	} {
 		for _, who := range []struct {
 			name string
@@ -398,7 +405,7 @@ func TestR3_GlobalDecisionMatrix(t *testing.T) {
 			{"bydb-writer", writer, tc.writer},
 			{"bydb-unbound", unbound, tc.unbound},
 		} {
-			if got := table.Authorize(snap, who.p, tc.method); got != who.want {
+			if got, _ := table.Authorize(snap, who.p, tc.method, nil); got != who.want {
 				t.Errorf("Authorize(%s, %s) = %v, want %v", who.name, tc.method, got, who.want)
 			}
 		}
@@ -410,7 +417,7 @@ func TestR3_GlobalDecisionMatrix(t *testing.T) {
 func TestR3_UnclassifiedMethodIsDenied(t *testing.T) {
 	snap := enabledSnapshot(t)
 	admin := actor(t, snap, "bydb-admin", "admin-secret")
-	if got := policyTable(t).Authorize(snap, admin, "/banyandb.future.v1.Whatever/Method"); got != liaisongrpc.DecisionDeny {
+	if got, _ := policyTable(t).Authorize(snap, admin, "/banyandb.future.v1.Whatever/Method", nil); got != liaisongrpc.DecisionDeny {
 		t.Errorf("Authorize(admin, an unclassified method) = %v, want DecisionDeny", got)
 	}
 }

--- a/banyand/liaison/grpc/methodpolicy_rbac_disabled_test.go
+++ b/banyand/liaison/grpc/methodpolicy_rbac_disabled_test.go
@@ -28,6 +28,8 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
+	commonv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/common/v1"
+	databasev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
 	liaisongrpc "github.com/apache/skywalking-banyandb/banyand/liaison/grpc"
 	"github.com/apache/skywalking-banyandb/banyand/liaison/pkg/auth"
 	"github.com/apache/skywalking-banyandb/pkg/logger"
@@ -85,6 +87,116 @@ func TestR2_RBACDisabledUnaryInterceptorAuthenticatesWithoutAuthorizing(t *testi
 		}
 		if handlerCalled {
 			t.Fatal("interceptor(missing credentials) invoked the handler, want authentication to reject first")
+		}
+	})
+}
+
+// TestSchemaR5_SchemaMethodsAreUnchangedWithoutRBAC proves R5, the compatibility requirement this
+// milestone carries whether or not the issue states one: a deployment that ships no `rbac`
+// block sees the schema API exactly as it did before. Group scope is never consulted, a
+// malformed group is left to the request validator rather than answered InvalidArgument by
+// authorization, and Group.List returns every group the handler produced — an existing
+// bydbctl or OAP client must not silently start receiving a shorter list.
+func TestSchemaR5_SchemaMethodsAreUnchangedWithoutRBAC(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "security.yaml")
+	if writeErr := os.WriteFile(path, []byte(usersOnlyInterceptorPolicyYAML), 0o600); writeErr != nil {
+		t.Fatalf("writing %s: %v", path, writeErr)
+	}
+	reloader := auth.InitAuthReloader()
+	if configErr := reloader.ConfigAuthReloader(path, false, logger.GetLogger("rbac-disabled-schema-test")); configErr != nil {
+		t.Fatalf("ConfigAuthReloader(%s) = %v, want a users-only policy to load", path, configErr)
+	}
+	table := liaisongrpc.GlobalMethodPolicies()
+	interceptor := liaisongrpc.NewAuthorizationInterceptor(reloader, table, nil)
+
+	unfiltered := &databasev1.GroupRegistryServiceListResponse{
+		Group: []*commonv1.Group{
+			{Metadata: &commonv1.Metadata{Name: "sw_metric"}},
+			{Metadata: &commonv1.Metadata{Name: "sw_record"}},
+		},
+	}
+	for _, tc := range []struct {
+		request any
+		reply   any
+		method  string
+		name    string
+	}{
+		{
+			name:   "a scoped read reaches its handler",
+			method: "/banyandb.database.v1.GroupRegistryService/Get",
+			// A group this users-only deployment never granted anybody access to.
+			request: &databasev1.GroupRegistryServiceGetRequest{Group: "sw_metric"},
+			reply:   &databasev1.GroupRegistryServiceGetResponse{},
+		},
+		{
+			name:    "a scoped write reaches its handler",
+			method:  "/banyandb.database.v1.MeasureRegistryService/Create",
+			request: &databasev1.MeasureRegistryServiceCreateRequest{},
+			reply:   &databasev1.MeasureRegistryServiceCreateResponse{},
+		},
+		{
+			name:    "a malformed group is not turned into an authorization answer",
+			method:  "/banyandb.database.v1.GroupRegistryService/Get",
+			request: &databasev1.GroupRegistryServiceGetRequest{},
+			reply:   &databasev1.GroupRegistryServiceGetResponse{},
+		},
+		{
+			name:    "a barrier wait reaches its handler",
+			method:  "/banyandb.schema.v1.SchemaBarrierService/AwaitRevisionApplied",
+			request: struct{}{},
+			reply:   struct{}{},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("username", "alice", "password", "secret"))
+			handlerCalled := false
+			got, callErr := interceptor(ctx, tc.request, &grpclib.UnaryServerInfo{FullMethod: tc.method},
+				func(context.Context, any) (any, error) {
+					handlerCalled = true
+					return tc.reply, nil
+				})
+			if callErr != nil {
+				t.Fatalf("%s with a users-only policy = %v, want the handler's result", tc.method, callErr)
+			}
+			if !handlerCalled {
+				t.Fatalf("%s with a users-only policy did not reach its handler", tc.method)
+			}
+			if got != tc.reply {
+				t.Errorf("%s returned a different value than the handler produced, want the reply passed through", tc.method)
+			}
+		})
+	}
+
+	t.Run("Group.List is not filtered", func(t *testing.T) {
+		ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs("username", "alice", "password", "secret"))
+		got, callErr := interceptor(ctx, &databasev1.GroupRegistryServiceListRequest{},
+			&grpclib.UnaryServerInfo{FullMethod: "/banyandb.database.v1.GroupRegistryService/List"},
+			func(context.Context, any) (any, error) { return unfiltered, nil })
+		if callErr != nil {
+			t.Fatalf("Group.List with a users-only policy = %v, want the handler's result", callErr)
+		}
+		listed, ok := got.(*databasev1.GroupRegistryServiceListResponse)
+		if !ok {
+			t.Fatalf("Group.List returned %T, want the handler's Group List response", got)
+		}
+		if len(listed.GetGroup()) != 2 {
+			t.Errorf("Group.List returned %d groups with RBAC off, want the handler's 2 untouched", len(listed.GetGroup()))
+		}
+	})
+
+	t.Run("no auth file at all authorizes nothing", func(t *testing.T) {
+		bare := liaisongrpc.NewAuthorizationInterceptor(nil, table, nil)
+		handlerCalled := false
+		if _, callErr := bare(context.Background(), &databasev1.GroupRegistryServiceGetRequest{},
+			&grpclib.UnaryServerInfo{FullMethod: "/banyandb.database.v1.GroupRegistryService/Get"},
+			func(context.Context, any) (any, error) {
+				handlerCalled = true
+				return nil, nil
+			}); callErr != nil {
+			t.Fatalf("a deployment with no auth file returned %v on a schema method, want the handler's result", callErr)
+		}
+		if !handlerCalled {
+			t.Fatal("a deployment with no auth file did not reach its schema handler")
 		}
 	})
 }

--- a/banyand/liaison/grpc/rbac_extractors.go
+++ b/banyand/liaison/grpc/rbac_extractors.go
@@ -20,6 +20,12 @@ package grpc
 import (
 	"errors"
 	"fmt"
+	"sort"
+	"strings"
+
+	commonv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/common/v1"
+	databasev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
+	schemav1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/schema/v1"
 )
 
 // ErrScopeUnresolvable reports a request from which the group scopes its method's policy
@@ -80,7 +86,248 @@ func RequestScopes(family ScopeFamily, request any) ([]string, error) {
 	switch family {
 	case ScopeGlobal, ScopeVisibleGroups:
 		return nil, nil
+	case ScopeDirectGroup:
+		return directGroupScopes(family, request)
+	case ScopeGroupBodyName:
+		return groupBodyNameScopes(family, request)
+	case ScopeMetadataGroup:
+		return metadataGroupScopes(family, request)
+	case ScopeResourceMetadataGroup:
+		return resourceMetadataGroupScopes(family, request)
+	case ScopeSchemaKeys:
+		return schemaKeyScopes(family, request)
 	default:
-		return nil, fmt.Errorf("%w: family %d carries no extractor for %T", ErrScopeUnresolvable, family, request)
+		return nil, unresolvableScope(family, request)
 	}
+}
+
+func directGroupScopes(family ScopeFamily, request any) ([]string, error) {
+	switch typedRequest := request.(type) {
+	case *databasev1.GroupRegistryServiceGetRequest:
+		if typedRequest != nil {
+			return oneScope(family, request, typedRequest.GetGroup())
+		}
+	case *databasev1.GroupRegistryServiceExistRequest:
+		if typedRequest != nil {
+			return oneScope(family, request, typedRequest.GetGroup())
+		}
+	case *databasev1.GroupRegistryServiceDeleteRequest:
+		if typedRequest != nil {
+			return oneScope(family, request, typedRequest.GetGroup())
+		}
+	case *databasev1.StreamRegistryServiceListRequest:
+		if typedRequest != nil {
+			return oneScope(family, request, typedRequest.GetGroup())
+		}
+	case *databasev1.MeasureRegistryServiceListRequest:
+		if typedRequest != nil {
+			return oneScope(family, request, typedRequest.GetGroup())
+		}
+	case *databasev1.TraceRegistryServiceListRequest:
+		if typedRequest != nil {
+			return oneScope(family, request, typedRequest.GetGroup())
+		}
+	case *databasev1.IndexRuleRegistryServiceListRequest:
+		if typedRequest != nil {
+			return oneScope(family, request, typedRequest.GetGroup())
+		}
+	case *databasev1.IndexRuleBindingRegistryServiceListRequest:
+		if typedRequest != nil {
+			return oneScope(family, request, typedRequest.GetGroup())
+		}
+	case *databasev1.TopNAggregationRegistryServiceListRequest:
+		if typedRequest != nil {
+			return oneScope(family, request, typedRequest.GetGroup())
+		}
+	case *databasev1.PropertyRegistryServiceListRequest:
+		if typedRequest != nil {
+			return oneScope(family, request, typedRequest.GetGroup())
+		}
+	}
+	return nil, unresolvableScope(family, request)
+}
+
+func groupBodyNameScopes(family ScopeFamily, request any) ([]string, error) {
+	switch typedRequest := request.(type) {
+	case *databasev1.GroupRegistryServiceCreateRequest:
+		if typedRequest != nil {
+			return groupNameScope(family, request, typedRequest.GetGroup())
+		}
+	case *databasev1.GroupRegistryServiceUpdateRequest:
+		if typedRequest != nil {
+			return groupNameScope(family, request, typedRequest.GetGroup())
+		}
+	}
+	return nil, unresolvableScope(family, request)
+}
+
+func groupNameScope(family ScopeFamily, request any, group *commonv1.Group) ([]string, error) {
+	if group == nil || group.GetMetadata() == nil {
+		return nil, unresolvableScope(family, request)
+	}
+	return oneScope(family, request, group.GetMetadata().GetName())
+}
+
+func metadataGroupScopes(family ScopeFamily, request any) ([]string, error) {
+	switch typedRequest := request.(type) {
+	case *databasev1.StreamRegistryServiceGetRequest:
+		return metadataScope(family, request, typedRequest)
+	case *databasev1.StreamRegistryServiceExistRequest:
+		return metadataScope(family, request, typedRequest)
+	case *databasev1.StreamRegistryServiceDeleteRequest:
+		return metadataScope(family, request, typedRequest)
+	case *databasev1.MeasureRegistryServiceGetRequest:
+		return metadataScope(family, request, typedRequest)
+	case *databasev1.MeasureRegistryServiceExistRequest:
+		return metadataScope(family, request, typedRequest)
+	case *databasev1.MeasureRegistryServiceDeleteRequest:
+		return metadataScope(family, request, typedRequest)
+	case *databasev1.TraceRegistryServiceGetRequest:
+		return metadataScope(family, request, typedRequest)
+	case *databasev1.TraceRegistryServiceExistRequest:
+		return metadataScope(family, request, typedRequest)
+	case *databasev1.TraceRegistryServiceDeleteRequest:
+		return metadataScope(family, request, typedRequest)
+	case *databasev1.IndexRuleRegistryServiceGetRequest:
+		return metadataScope(family, request, typedRequest)
+	case *databasev1.IndexRuleRegistryServiceExistRequest:
+		return metadataScope(family, request, typedRequest)
+	case *databasev1.IndexRuleRegistryServiceDeleteRequest:
+		return metadataScope(family, request, typedRequest)
+	case *databasev1.IndexRuleBindingRegistryServiceGetRequest:
+		return metadataScope(family, request, typedRequest)
+	case *databasev1.IndexRuleBindingRegistryServiceExistRequest:
+		return metadataScope(family, request, typedRequest)
+	case *databasev1.IndexRuleBindingRegistryServiceDeleteRequest:
+		return metadataScope(family, request, typedRequest)
+	case *databasev1.TopNAggregationRegistryServiceGetRequest:
+		return metadataScope(family, request, typedRequest)
+	case *databasev1.TopNAggregationRegistryServiceExistRequest:
+		return metadataScope(family, request, typedRequest)
+	case *databasev1.TopNAggregationRegistryServiceDeleteRequest:
+		return metadataScope(family, request, typedRequest)
+	case *databasev1.PropertyRegistryServiceGetRequest:
+		return metadataScope(family, request, typedRequest)
+	case *databasev1.PropertyRegistryServiceExistRequest:
+		return metadataScope(family, request, typedRequest)
+	case *databasev1.PropertyRegistryServiceDeleteRequest:
+		return metadataScope(family, request, typedRequest)
+	default:
+		return nil, unresolvableScope(family, request)
+	}
+}
+
+type metadataRequest interface {
+	GetMetadata() *commonv1.Metadata
+}
+
+func metadataScope(family ScopeFamily, request any, metadataCarrier metadataRequest) ([]string, error) {
+	if metadataCarrier == nil || metadataCarrier.GetMetadata() == nil {
+		return nil, unresolvableScope(family, request)
+	}
+	return oneScope(family, request, metadataCarrier.GetMetadata().GetGroup())
+}
+
+func resourceMetadataGroupScopes(family ScopeFamily, request any) ([]string, error) {
+	switch typedRequest := request.(type) {
+	case *databasev1.StreamRegistryServiceCreateRequest:
+		return resourceMetadataScope(family, request, typedRequest.GetStream())
+	case *databasev1.StreamRegistryServiceUpdateRequest:
+		return resourceMetadataScope(family, request, typedRequest.GetStream())
+	case *databasev1.MeasureRegistryServiceCreateRequest:
+		return resourceMetadataScope(family, request, typedRequest.GetMeasure())
+	case *databasev1.MeasureRegistryServiceUpdateRequest:
+		return resourceMetadataScope(family, request, typedRequest.GetMeasure())
+	case *databasev1.TraceRegistryServiceCreateRequest:
+		return resourceMetadataScope(family, request, typedRequest.GetTrace())
+	case *databasev1.TraceRegistryServiceUpdateRequest:
+		return resourceMetadataScope(family, request, typedRequest.GetTrace())
+	case *databasev1.IndexRuleRegistryServiceCreateRequest:
+		return resourceMetadataScope(family, request, typedRequest.GetIndexRule())
+	case *databasev1.IndexRuleRegistryServiceUpdateRequest:
+		return resourceMetadataScope(family, request, typedRequest.GetIndexRule())
+	case *databasev1.IndexRuleBindingRegistryServiceCreateRequest:
+		return resourceMetadataScope(family, request, typedRequest.GetIndexRuleBinding())
+	case *databasev1.IndexRuleBindingRegistryServiceUpdateRequest:
+		return resourceMetadataScope(family, request, typedRequest.GetIndexRuleBinding())
+	case *databasev1.TopNAggregationRegistryServiceCreateRequest:
+		return resourceMetadataScope(family, request, typedRequest.GetTopNAggregation())
+	case *databasev1.TopNAggregationRegistryServiceUpdateRequest:
+		return resourceMetadataScope(family, request, typedRequest.GetTopNAggregation())
+	case *databasev1.PropertyRegistryServiceCreateRequest:
+		return resourceMetadataScope(family, request, typedRequest.GetProperty())
+	case *databasev1.PropertyRegistryServiceUpdateRequest:
+		return resourceMetadataScope(family, request, typedRequest.GetProperty())
+	default:
+		return nil, unresolvableScope(family, request)
+	}
+}
+
+type resourceWithMetadata interface {
+	GetMetadata() *commonv1.Metadata
+}
+
+func resourceMetadataScope(family ScopeFamily, request any, resource resourceWithMetadata) ([]string, error) {
+	if resource == nil || resource.GetMetadata() == nil {
+		return nil, unresolvableScope(family, request)
+	}
+	return oneScope(family, request, resource.GetMetadata().GetGroup())
+}
+
+func schemaKeyScopes(family ScopeFamily, request any) ([]string, error) {
+	var keys []*schemav1.SchemaKey
+	switch typedRequest := request.(type) {
+	case *schemav1.AwaitSchemaAppliedRequest:
+		if typedRequest == nil {
+			return nil, unresolvableScope(family, request)
+		}
+		keys = typedRequest.GetKeys()
+	case *schemav1.AwaitSchemaDeletedRequest:
+		if typedRequest == nil {
+			return nil, unresolvableScope(family, request)
+		}
+		keys = typedRequest.GetKeys()
+	default:
+		return nil, unresolvableScope(family, request)
+	}
+	if len(keys) == 0 {
+		return nil, nil
+	}
+	groups := make([]string, 0, len(keys))
+	for _, key := range keys {
+		if key == nil {
+			return nil, unresolvableScope(family, request)
+		}
+		group := key.GetGroup()
+		if key.GetKind() == "group" {
+			group = key.GetName()
+		}
+		groups = append(groups, group)
+	}
+	return normalizedScopes(family, request, groups)
+}
+
+func oneScope(family ScopeFamily, request any, group string) ([]string, error) {
+	return normalizedScopes(family, request, []string{group})
+}
+
+func normalizedScopes(family ScopeFamily, request any, groups []string) ([]string, error) {
+	resolved := make(map[string]struct{}, len(groups))
+	for _, group := range groups {
+		scope := strings.TrimSpace(group)
+		if scope == "" {
+			return nil, unresolvableScope(family, request)
+		}
+		resolved[scope] = struct{}{}
+	}
+	scopes := make([]string, 0, len(resolved))
+	for scope := range resolved {
+		scopes = append(scopes, scope)
+	}
+	sort.Strings(scopes)
+	return scopes, nil
+}
+
+func unresolvableScope(family ScopeFamily, request any) error {
+	return fmt.Errorf("%w: family %d carries no resolvable scope for %T", ErrScopeUnresolvable, family, request)
 }

--- a/banyand/liaison/grpc/rbac_extractors.go
+++ b/banyand/liaison/grpc/rbac_extractors.go
@@ -1,0 +1,86 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package grpc
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrScopeUnresolvable reports a request from which the group scopes its method's policy
+// needs cannot be read: an absent resource body, absent metadata, an empty or whitespace-only
+// group name, or a request whose type does not belong to the policy's scope family. The
+// liaison reports it to the caller as codes.InvalidArgument, so a malformed request from an
+// authenticated caller is answered as malformed rather than as an authorization outcome.
+var ErrScopeUnresolvable = errors.New("method scope: request carries no resolvable group")
+
+// ScopeFamily names the typed extractor that resolves one method's group scopes from its
+// request message. Every classified method points at exactly one family. There is no generic
+// "find a field named group" rule: BanyanDB request shapes differ too much for one, and a
+// newly added RPC must be classified explicitly rather than inherit a scope by accident.
+type ScopeFamily int
+
+const (
+	// ScopeUnspecified is the zero value and names no extractor. A method whose permission
+	// this release cannot decide carries it, and resolving it is an error, so a policy row
+	// that is activated without being given a family fails closed instead of falling back to
+	// a global decision.
+	ScopeUnspecified ScopeFamily = iota
+	// ScopeGlobal names the deployment-wide scope: the method addresses no group, and only a
+	// wildcard grant satisfies it. Cluster state, node query, internal maintenance and the
+	// cluster-wide schema revision wait use it.
+	ScopeGlobal
+	// ScopeDirectGroup reads the request's own group field, the single non-empty string of
+	// Group Get/Exist/Delete and of the seven registry List methods.
+	ScopeDirectGroup
+	// ScopeGroupBodyName reads the group name out of the Group body a request carries, which
+	// for a group is Group.Metadata.Name and never Group.Metadata.Group. Group Create and
+	// Update use it.
+	ScopeGroupBodyName
+	// ScopeMetadataGroup reads Metadata.Group off a request that identifies one existing
+	// resource by name. The seven registry Get, Exist and Delete methods use it.
+	ScopeMetadataGroup
+	// ScopeResourceMetadataGroup reads Metadata.Group out of the resource body a request
+	// carries. The seven registry Create and Update methods use it.
+	ScopeResourceMetadataGroup
+	// ScopeSchemaKeys reads every schema key a barrier wait names. A key of kind "group"
+	// scopes to its Name, because that is where a group key carries the group; every other
+	// kind scopes to its Group.
+	ScopeSchemaKeys
+	// ScopeVisibleGroups names the whole-deployment resource set of Group List: the method
+	// addresses no group, any grant admits the caller, and the response is reduced afterwards
+	// to the groups the caller's scopes cover.
+	ScopeVisibleGroups
+)
+
+// RequestScopes resolves the group scopes family requires from request. The result is
+// deduplicated and sorted, so a request naming one group twice, or two groups in either
+// order, yields one canonical scope set that an all-or-nothing decision can be taken over.
+//
+// ScopeGlobal and ScopeVisibleGroups resolve to no scopes: the first is satisfied only by a
+// wildcard grant, the second is admitted by any grant and filtered after its handler. Every
+// other family reads its groups from the request, and a request the family cannot be read
+// from returns an error wrapping ErrScopeUnresolvable.
+func RequestScopes(family ScopeFamily, request any) ([]string, error) {
+	switch family {
+	case ScopeGlobal, ScopeVisibleGroups:
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("%w: family %d carries no extractor for %T", ErrScopeUnresolvable, family, request)
+	}
+}

--- a/banyand/liaison/grpc/rbac_schema_contract_test.go
+++ b/banyand/liaison/grpc/rbac_schema_contract_test.go
@@ -1,0 +1,1001 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package grpc_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	grpclib "google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	commonv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/common/v1"
+	databasev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
+	schemav1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/schema/v1"
+	liaisongrpc "github.com/apache/skywalking-banyandb/banyand/liaison/grpc"
+	"github.com/apache/skywalking-banyandb/banyand/liaison/pkg/auth"
+	"github.com/apache/skywalking-banyandb/pkg/logger"
+)
+
+// The canonical fixture of the #13994 design: an operator administrator, a group-scoped
+// tenant reader and writer, a wildcard reader that also proves future-group semantics, and an
+// authenticated principal with no binding at all.
+const schemaPolicyYAML = `
+users:
+  - username: "sch-admin"
+    password: "admin-secret"
+  - username: "sch-writer-alpha"
+    password: "writer-alpha-secret"
+  - username: "sch-reader-alpha"
+    password: "reader-alpha-secret"
+  - username: "sch-reader-all"
+    password: "reader-all-secret"
+  - username: "sch-unbound"
+    password: "unbound-secret"
+rbac:
+  enabled: true
+  bindings:
+    - principal: "sch-admin"
+      role: "admin"
+      groups: ["*"]
+    - principal: "sch-writer-alpha"
+      role: "writer"
+      groups: ["rbac-alpha"]
+    - principal: "sch-reader-alpha"
+      role: "reader"
+      groups: ["rbac-alpha"]
+    - principal: "sch-reader-all"
+      role: "reader"
+      groups: ["*"]
+`
+
+// widenedSchemaPolicyYAML is the same fixture with the alpha reader promoted to the wildcard
+// scope. Compiling it as a second revision is how a test observes a policy change without
+// touching the first revision, which callers holding it must keep seeing.
+const widenedSchemaPolicyYAML = `
+users:
+  - username: "sch-admin"
+    password: "admin-secret"
+  - username: "sch-reader-alpha"
+    password: "reader-alpha-secret"
+rbac:
+  enabled: true
+  bindings:
+    - principal: "sch-admin"
+      role: "admin"
+      groups: ["*"]
+    - principal: "sch-reader-alpha"
+      role: "reader"
+      groups: ["*"]
+`
+
+// The two fixture groups. Data and schema names are duplicated across them so a scope leak
+// is observable as a name that resolves in the wrong group rather than as a missing resource.
+const (
+	groupAlpha = "rbac-alpha"
+	groupBeta  = "rbac-beta"
+	groupGamma = "rbac-gamma"
+	// fixtureMeasure is the child-schema name both fixture groups carry.
+	fixtureMeasure = "service_cpm"
+)
+
+// Schema method names, transcribed from the generated service descriptors' _FullMethodName
+// constants. They are produced by protoc from the .proto files, so they are an independent
+// source from anything this milestone adds.
+const (
+	mGroupGet           = "/banyandb.database.v1.GroupRegistryService/Get"
+	mGroupExist         = "/banyandb.database.v1.GroupRegistryService/Exist"
+	mGroupUpdate        = "/banyandb.database.v1.GroupRegistryService/Update"
+	mGroupDelete        = "/banyandb.database.v1.GroupRegistryService/Delete"
+	mAwaitSchemaApplied = "/banyandb.schema.v1.SchemaBarrierService/AwaitSchemaApplied"
+	mAwaitSchemaDeleted = "/banyandb.schema.v1.SchemaBarrierService/AwaitSchemaDeleted"
+	mMeasureSchemaGet   = "/banyandb.database.v1.MeasureRegistryService/Get"
+	mMeasureSchemaList  = "/banyandb.database.v1.MeasureRegistryService/List"
+	mMeasureSchemaExist = "/banyandb.database.v1.MeasureRegistryService/Exist"
+	mMeasureSchemaNew   = "/banyandb.database.v1.MeasureRegistryService/Create"
+	mMeasureSchemaSet   = "/banyandb.database.v1.MeasureRegistryService/Update"
+	mMeasureSchemaDrop  = "/banyandb.database.v1.MeasureRegistryService/Delete"
+)
+
+// registryServices is the fixed seven-family oracle of the issue: the registry services whose
+// six-method rule family this milestone activates.
+var registryServices = []string{
+	"StreamRegistryService", "MeasureRegistryService", "TraceRegistryService", "IndexRuleRegistryService",
+	"IndexRuleBindingRegistryService", "TopNAggregationRegistryService", "PropertyRegistryService",
+}
+
+func registryMethod(service, method string) string {
+	return "/banyandb.database.v1." + service + "/" + method
+}
+
+func schemaSnapshot(t *testing.T) auth.Snapshot {
+	t.Helper()
+	snap, err := auth.CompileSnapshot(1, []byte(schemaPolicyYAML))
+	if err != nil {
+		t.Fatalf("CompileSnapshot(1, schema fixture) returned error %v, want a compiled snapshot", err)
+	}
+	return snap
+}
+
+func newSchemaReloader(t *testing.T) *auth.Reloader {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "security.yaml")
+	if err := os.WriteFile(path, []byte(schemaPolicyYAML), 0o600); err != nil {
+		t.Fatalf("writing %s: %v", path, err)
+	}
+	reloader := auth.InitAuthReloader()
+	if err := reloader.ConfigAuthReloader(path, false, logger.GetLogger("rbac-schema-contract-test")); err != nil {
+		t.Fatalf("ConfigAuthReloader(%s) = %v, want it to accept the schema policy", path, err)
+	}
+	return reloader
+}
+
+// schemaActors resolves the five fixture principals against snap, keyed by the name each is
+// referred to by in the expectation tables below.
+func schemaActors(t *testing.T, snap auth.Snapshot) map[string]auth.Principal {
+	t.Helper()
+	return map[string]auth.Principal{
+		"admin":        actor(t, snap, "sch-admin", "admin-secret"),
+		"writer-alpha": actor(t, snap, "sch-writer-alpha", "writer-alpha-secret"),
+		"reader-alpha": actor(t, snap, "sch-reader-alpha", "reader-alpha-secret"),
+		"reader-all":   actor(t, snap, "sch-reader-all", "reader-all-secret"),
+		"unbound":      actor(t, snap, "sch-unbound", "unbound-secret"),
+	}
+}
+
+// measureIn is the fixture measure body. The same name is used in both groups so a scope
+// leak shows up as the wrong group answering rather than as a different resource.
+func measureIn(group string) *databasev1.Measure {
+	return &databasev1.Measure{Metadata: &commonv1.Metadata{Group: group, Name: fixtureMeasure}}
+}
+
+// The three request factories below cover all seven registry families for the three
+// structural request shapes the issue's R2 agrees on. Each returns the generated request type
+// protoc produced for that service, so the oracle is a literal list of shapes rather than a
+// structural assertion that would pass for a type the liaison never serves.
+func registryListRequest(service, group string) any {
+	switch service {
+	case "StreamRegistryService":
+		return &databasev1.StreamRegistryServiceListRequest{Group: group}
+	case "MeasureRegistryService":
+		return &databasev1.MeasureRegistryServiceListRequest{Group: group}
+	case "TraceRegistryService":
+		return &databasev1.TraceRegistryServiceListRequest{Group: group}
+	case "IndexRuleRegistryService":
+		return &databasev1.IndexRuleRegistryServiceListRequest{Group: group}
+	case "IndexRuleBindingRegistryService":
+		return &databasev1.IndexRuleBindingRegistryServiceListRequest{Group: group}
+	case "TopNAggregationRegistryService":
+		return &databasev1.TopNAggregationRegistryServiceListRequest{Group: group}
+	default:
+		return &databasev1.PropertyRegistryServiceListRequest{Group: group}
+	}
+}
+
+func registryGetRequest(service, group string) any {
+	resourceMeta := &commonv1.Metadata{Group: group, Name: "fixture"}
+	switch service {
+	case "StreamRegistryService":
+		return &databasev1.StreamRegistryServiceGetRequest{Metadata: resourceMeta}
+	case "MeasureRegistryService":
+		return &databasev1.MeasureRegistryServiceGetRequest{Metadata: resourceMeta}
+	case "TraceRegistryService":
+		return &databasev1.TraceRegistryServiceGetRequest{Metadata: resourceMeta}
+	case "IndexRuleRegistryService":
+		return &databasev1.IndexRuleRegistryServiceGetRequest{Metadata: resourceMeta}
+	case "IndexRuleBindingRegistryService":
+		return &databasev1.IndexRuleBindingRegistryServiceGetRequest{Metadata: resourceMeta}
+	case "TopNAggregationRegistryService":
+		return &databasev1.TopNAggregationRegistryServiceGetRequest{Metadata: resourceMeta}
+	default:
+		return &databasev1.PropertyRegistryServiceGetRequest{Metadata: resourceMeta}
+	}
+}
+
+func registryCreateRequest(service, group string) any {
+	resourceMeta := &commonv1.Metadata{Group: group, Name: "fixture"}
+	switch service {
+	case "StreamRegistryService":
+		return &databasev1.StreamRegistryServiceCreateRequest{Stream: &databasev1.Stream{Metadata: resourceMeta}}
+	case "MeasureRegistryService":
+		return &databasev1.MeasureRegistryServiceCreateRequest{Measure: &databasev1.Measure{Metadata: resourceMeta}}
+	case "TraceRegistryService":
+		return &databasev1.TraceRegistryServiceCreateRequest{Trace: &databasev1.Trace{Metadata: resourceMeta}}
+	case "IndexRuleRegistryService":
+		return &databasev1.IndexRuleRegistryServiceCreateRequest{IndexRule: &databasev1.IndexRule{Metadata: resourceMeta}}
+	case "IndexRuleBindingRegistryService":
+		return &databasev1.IndexRuleBindingRegistryServiceCreateRequest{
+			IndexRuleBinding: &databasev1.IndexRuleBinding{Metadata: resourceMeta},
+		}
+	case "TopNAggregationRegistryService":
+		return &databasev1.TopNAggregationRegistryServiceCreateRequest{
+			TopNAggregation: &databasev1.TopNAggregation{Metadata: resourceMeta},
+		}
+	default:
+		return &databasev1.PropertyRegistryServiceCreateRequest{Property: &databasev1.Property{Metadata: resourceMeta}}
+	}
+}
+
+// TestSchemaR1_ExactAndWildcardScopeDecisions proves R1: an exact grant admits its own group
+// and nothing else, a wildcard grant admits every group including one created after the
+// policy was loaded, a wrong scope is denied, and an unauthorized existence check is denied
+// rather than answered. Every cell below is read off issue #14015's R1 and the built-in role
+// definitions of the #13994 design; none is recomputed the way the decision will compute it.
+func TestSchemaR1_ExactAndWildcardScopeDecisions(t *testing.T) {
+	snap := schemaSnapshot(t)
+	table := policyTable(t)
+	actors := schemaActors(t, snap)
+
+	const (
+		allow   = liaisongrpc.DecisionAllow
+		deny    = liaisongrpc.DecisionDeny
+		invalid = liaisongrpc.DecisionInvalidRequest
+	)
+	for _, tc := range []struct {
+		request                                             any
+		method                                              string
+		note                                                string
+		admin, writerAlpha, readerAlpha, readerAll, unbound liaisongrpc.Decision
+	}{
+		// Group point reads take their scope from the request's own group field (B1).
+		{
+			method: mGroupGet, note: "alpha", request: &databasev1.GroupRegistryServiceGetRequest{Group: groupAlpha},
+			admin: allow, writerAlpha: allow, readerAlpha: allow, readerAll: allow, unbound: deny,
+		},
+		{
+			method: mGroupGet, note: "beta", request: &databasev1.GroupRegistryServiceGetRequest{Group: groupBeta},
+			admin: allow, writerAlpha: deny, readerAlpha: deny, readerAll: allow, unbound: deny,
+		},
+		{
+			method: mGroupExist, note: "beta is denied, never answered false",
+			request: &databasev1.GroupRegistryServiceExistRequest{Group: groupBeta},
+			admin:   allow, writerAlpha: deny, readerAlpha: deny, readerAll: allow, unbound: deny,
+		},
+		// A wildcard grant covers a group nobody named when the policy was compiled.
+		{
+			method: mGroupGet, note: "gamma, created after policy load",
+			request: &databasev1.GroupRegistryServiceGetRequest{Group: groupGamma},
+			admin:   allow, writerAlpha: deny, readerAlpha: deny, readerAll: allow, unbound: deny,
+		},
+		// Exact match only: no prefix, substring or case-folded match may admit a caller.
+		{
+			method: mGroupGet, note: "case-folded alpha",
+			request: &databasev1.GroupRegistryServiceGetRequest{Group: "RBAC-ALPHA"},
+			admin:   allow, writerAlpha: deny, readerAlpha: deny, readerAll: allow, unbound: deny,
+		},
+		{
+			method: mGroupGet, note: "alpha with a suffix",
+			request: &databasev1.GroupRegistryServiceGetRequest{Group: groupAlpha + "-extra"},
+			admin:   allow, writerAlpha: deny, readerAlpha: deny, readerAll: allow, unbound: deny,
+		},
+		// Group upserts take their scope from Group.Metadata.Name, never Metadata.Group (B2).
+		{
+			method: mGroupCreate, note: "alpha", request: &databasev1.GroupRegistryServiceCreateRequest{
+				Group: &commonv1.Group{Metadata: &commonv1.Metadata{Name: groupAlpha}},
+			},
+			admin: allow, writerAlpha: allow, readerAlpha: deny, readerAll: deny, unbound: deny,
+		},
+		{
+			method: mGroupUpdate, note: "beta", request: &databasev1.GroupRegistryServiceUpdateRequest{
+				Group: &commonv1.Group{Metadata: &commonv1.Metadata{Name: groupBeta}},
+			},
+			admin: allow, writerAlpha: deny, readerAlpha: deny, readerAll: deny, unbound: deny,
+		},
+		// A Group body whose Metadata.Group names an allowed group must not smuggle a write
+		// into a group the caller has no grant on: only Metadata.Name is the resource.
+		{
+			method: mGroupCreate, note: "beta named, alpha in Metadata.Group",
+			request: &databasev1.GroupRegistryServiceCreateRequest{
+				Group: &commonv1.Group{Metadata: &commonv1.Metadata{Name: groupBeta, Group: groupAlpha}},
+			},
+			admin: allow, writerAlpha: deny, readerAlpha: deny, readerAll: deny, unbound: deny,
+		},
+		// Group deletion is decided before any dry-run, force or deletion-task logic (B3).
+		{
+			method: mGroupDelete, note: "alpha, force",
+			request: &databasev1.GroupRegistryServiceDeleteRequest{Group: groupAlpha, Force: true},
+			admin:   allow, writerAlpha: allow, readerAlpha: deny, readerAll: deny, unbound: deny,
+		},
+		{
+			method: mGroupDelete, note: "beta, dry run",
+			request: &databasev1.GroupRegistryServiceDeleteRequest{Group: groupBeta, DryRun: true},
+			admin:   allow, writerAlpha: deny, readerAlpha: deny, readerAll: deny, unbound: deny,
+		},
+		// Registry List takes its scope from the request's own group field (B4).
+		{
+			method: mMeasureSchemaList, note: "alpha", request: &databasev1.MeasureRegistryServiceListRequest{Group: groupAlpha},
+			admin: allow, writerAlpha: allow, readerAlpha: allow, readerAll: allow, unbound: deny,
+		},
+		{
+			method: mMeasureSchemaList, note: "beta", request: &databasev1.MeasureRegistryServiceListRequest{Group: groupBeta},
+			admin: allow, writerAlpha: deny, readerAlpha: deny, readerAll: allow, unbound: deny,
+		},
+		// Registry point reads take their scope from Metadata.Group (B5).
+		{
+			method: mMeasureSchemaGet, note: "alpha", request: &databasev1.MeasureRegistryServiceGetRequest{
+				Metadata: &commonv1.Metadata{Group: groupAlpha, Name: fixtureMeasure},
+			},
+			admin: allow, writerAlpha: allow, readerAlpha: allow, readerAll: allow, unbound: deny,
+		},
+		{
+			method: mMeasureSchemaExist, note: "beta is denied, never answered false",
+			request: &databasev1.MeasureRegistryServiceExistRequest{
+				Metadata: &commonv1.Metadata{Group: groupBeta, Name: fixtureMeasure},
+			},
+			admin: allow, writerAlpha: deny, readerAlpha: deny, readerAll: allow, unbound: deny,
+		},
+		// Registry upserts take their scope from the resource body's Metadata.Group (B6).
+		{
+			method: mMeasureSchemaNew, note: "alpha", request: &databasev1.MeasureRegistryServiceCreateRequest{
+				Measure: measureIn(groupAlpha),
+			},
+			admin: allow, writerAlpha: allow, readerAlpha: deny, readerAll: deny, unbound: deny,
+		},
+		{
+			method: mMeasureSchemaSet, note: "beta", request: &databasev1.MeasureRegistryServiceUpdateRequest{
+				Measure: measureIn(groupBeta),
+			},
+			admin: allow, writerAlpha: deny, readerAlpha: deny, readerAll: deny, unbound: deny,
+		},
+		// Registry deletion takes its scope from Metadata.Group (B7).
+		{
+			method: mMeasureSchemaDrop, note: "alpha", request: &databasev1.MeasureRegistryServiceDeleteRequest{
+				Metadata: &commonv1.Metadata{Group: groupAlpha, Name: fixtureMeasure},
+			},
+			admin: allow, writerAlpha: allow, readerAlpha: deny, readerAll: deny, unbound: deny,
+		},
+		// A malformed request from an authenticated caller is malformed, not unauthorized,
+		// and that answer does not depend on what the caller would have been allowed.
+		{
+			method: mGroupGet, note: "empty group", request: &databasev1.GroupRegistryServiceGetRequest{},
+			admin: invalid, writerAlpha: invalid, readerAlpha: invalid, readerAll: invalid, unbound: invalid,
+		},
+		{
+			method: mMeasureSchemaNew, note: "nil resource body", request: &databasev1.MeasureRegistryServiceCreateRequest{},
+			admin: invalid, writerAlpha: invalid, readerAlpha: invalid, readerAll: invalid, unbound: invalid,
+		},
+	} {
+		for _, who := range []struct {
+			name string
+			want liaisongrpc.Decision
+		}{
+			{"admin", tc.admin},
+			{"writer-alpha", tc.writerAlpha},
+			{"reader-alpha", tc.readerAlpha},
+			{"reader-all", tc.readerAll},
+			{"unbound", tc.unbound},
+		} {
+			got, reason := table.Authorize(snap, actors[who.name], tc.method, tc.request)
+			if got != who.want {
+				t.Errorf("Authorize(%s, %s, %s) = %v (%s), want %v", who.name, tc.method, tc.note, got, reason, who.want)
+			}
+		}
+	}
+}
+
+// TestSchemaR2_ScopeFamilyClassification proves R2's classification half: every method the
+// liaison serves is paired with exactly one scope family, and the pairing is the one the
+// #13994 API policy map and the B1-B10 round catalog specify. The per-family counts below are
+// hand-counted from that map — 7 registry families times the methods each round names — so a
+// method that silently changes family, or a new RPC that inherits one, fails here.
+func TestSchemaR2_ScopeFamilyClassification(t *testing.T) {
+	table := policyTable(t)
+
+	wantFamily := map[string]liaisongrpc.ScopeFamily{}
+	for _, method := range []string{mGroupGet, mGroupExist, mGroupDelete} {
+		wantFamily[method] = liaisongrpc.ScopeDirectGroup
+	}
+	for _, method := range []string{mGroupCreate, mGroupUpdate} {
+		wantFamily[method] = liaisongrpc.ScopeGroupBodyName
+	}
+	wantFamily[mGroupList] = liaisongrpc.ScopeVisibleGroups
+	for _, service := range registryServices {
+		wantFamily[registryMethod(service, "List")] = liaisongrpc.ScopeDirectGroup
+		for _, method := range []string{"Get", "Exist", "Delete"} {
+			wantFamily[registryMethod(service, method)] = liaisongrpc.ScopeMetadataGroup
+		}
+		for _, method := range []string{"Create", "Update"} {
+			wantFamily[registryMethod(service, method)] = liaisongrpc.ScopeResourceMetadataGroup
+		}
+	}
+	wantFamily[mAwaitSchemaApplied] = liaisongrpc.ScopeSchemaKeys
+	wantFamily[mAwaitSchemaDeleted] = liaisongrpc.ScopeSchemaKeys
+	wantFamily[mAwaitRevision] = liaisongrpc.ScopeGlobal
+
+	familyCounts := make(map[liaisongrpc.ScopeFamily]int)
+	for _, policy := range table {
+		familyCounts[policy.Scope]++
+		want, classified := wantFamily[policy.FullMethod]
+		if !classified {
+			continue
+		}
+		if policy.Scope != want {
+			t.Errorf("policy for %s has scope family %d, want %d", policy.FullMethod, policy.Scope, want)
+		}
+	}
+	for family, want := range map[liaisongrpc.ScopeFamily]int{
+		liaisongrpc.ScopeGlobal:                13,
+		liaisongrpc.ScopeDirectGroup:           10,
+		liaisongrpc.ScopeGroupBodyName:         2,
+		liaisongrpc.ScopeMetadataGroup:         21,
+		liaisongrpc.ScopeResourceMetadataGroup: 14,
+		liaisongrpc.ScopeSchemaKeys:            2,
+		liaisongrpc.ScopeVisibleGroups:         1,
+		liaisongrpc.ScopeUnspecified:           15,
+	} {
+		if familyCounts[family] != want {
+			t.Errorf("scope family %d classifies %d methods, want %d", family, familyCounts[family], want)
+		}
+	}
+	for _, policy := range table {
+		if policy.Access != liaisongrpc.MethodAccessPermission || !policy.Activated {
+			continue
+		}
+		if policy.Scope == liaisongrpc.ScopeUnspecified {
+			t.Errorf("policy for %s is activated with no scope family, which would decide it globally", policy.FullMethod)
+		}
+	}
+}
+
+// TestSchemaR2_RequestScopesReadsTheAgreedRequestShapes proves R2's extraction half: each
+// family reads its groups out of the request shape the round catalog names for it and out of
+// no other, and a request it cannot be read from is reported as unresolvable rather than as
+// an empty scope set that would collapse to a global decision. Every want below is written
+// out by hand from the request literal beside it.
+func TestSchemaR2_RequestScopesReadsTheAgreedRequestShapes(t *testing.T) {
+	for _, tc := range []struct {
+		request any
+		name    string
+		want    []string
+		family  liaisongrpc.ScopeFamily
+	}{
+		{
+			name: "direct group on a Group point read", family: liaisongrpc.ScopeDirectGroup,
+			request: &databasev1.GroupRegistryServiceGetRequest{Group: groupBeta}, want: []string{groupBeta},
+		},
+		{
+			name: "direct group on a Group delete", family: liaisongrpc.ScopeDirectGroup,
+			request: &databasev1.GroupRegistryServiceDeleteRequest{Group: groupAlpha, Force: true}, want: []string{groupAlpha},
+		},
+		{
+			name: "group body name, not the body's Metadata.Group", family: liaisongrpc.ScopeGroupBodyName,
+			request: &databasev1.GroupRegistryServiceCreateRequest{
+				Group: &commonv1.Group{Metadata: &commonv1.Metadata{Name: groupAlpha, Group: groupBeta}},
+			},
+			want: []string{groupAlpha},
+		},
+		{
+			name: "metadata group", family: liaisongrpc.ScopeMetadataGroup,
+			request: &databasev1.MeasureRegistryServiceGetRequest{
+				Metadata: &commonv1.Metadata{Group: groupBeta, Name: fixtureMeasure},
+			},
+			want: []string{groupBeta},
+		},
+		{
+			name: "resource metadata group", family: liaisongrpc.ScopeResourceMetadataGroup,
+			request: &databasev1.MeasureRegistryServiceCreateRequest{Measure: measureIn(groupAlpha)},
+			want:    []string{groupAlpha},
+		},
+		{
+			name: "a global method addresses no group", family: liaisongrpc.ScopeGlobal,
+			request: &schemav1.AwaitRevisionAppliedRequest{MinRevision: 7}, want: nil,
+		},
+		{
+			name: "Group.List addresses no group and is filtered afterwards", family: liaisongrpc.ScopeVisibleGroups,
+			request: &databasev1.GroupRegistryServiceListRequest{}, want: nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := liaisongrpc.RequestScopes(tc.family, tc.request)
+			if err != nil {
+				t.Fatalf("RequestScopes(%d, %T) returned %v, want %v", tc.family, tc.request, err, tc.want)
+			}
+			if len(got) == 0 && len(tc.want) == 0 {
+				return
+			}
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("RequestScopes(%d, %T) = %v, want %v", tc.family, tc.request, got, tc.want)
+			}
+		})
+	}
+
+	t.Run("every registry family covers all seven services", func(t *testing.T) {
+		for _, service := range registryServices {
+			for _, shape := range []struct {
+				request any
+				family  liaisongrpc.ScopeFamily
+			}{
+				{family: liaisongrpc.ScopeDirectGroup, request: registryListRequest(service, groupAlpha)},
+				{family: liaisongrpc.ScopeMetadataGroup, request: registryGetRequest(service, groupAlpha)},
+				{family: liaisongrpc.ScopeResourceMetadataGroup, request: registryCreateRequest(service, groupAlpha)},
+			} {
+				got, err := liaisongrpc.RequestScopes(shape.family, shape.request)
+				if err != nil {
+					t.Errorf("RequestScopes(%d, %T) returned %v, want [%s]", shape.family, shape.request, err, groupAlpha)
+					continue
+				}
+				if !reflect.DeepEqual(got, []string{groupAlpha}) {
+					t.Errorf("RequestScopes(%d, %T) = %v, want [%s]", shape.family, shape.request, got, groupAlpha)
+				}
+			}
+		}
+	})
+
+	t.Run("unresolvable requests", func(t *testing.T) {
+		namedMetadata := &commonv1.Metadata{Name: fixtureMeasure}
+		for _, tc := range []struct {
+			request any
+			name    string
+			family  liaisongrpc.ScopeFamily
+		}{
+			{name: "nil request", family: liaisongrpc.ScopeDirectGroup, request: nil},
+			{
+				name: "empty direct group", family: liaisongrpc.ScopeDirectGroup,
+				request: &databasev1.GroupRegistryServiceGetRequest{},
+			},
+			{
+				name: "whitespace direct group", family: liaisongrpc.ScopeDirectGroup,
+				request: &databasev1.GroupRegistryServiceGetRequest{Group: "  "},
+			},
+			{
+				name: "nil group body", family: liaisongrpc.ScopeGroupBodyName,
+				request: &databasev1.GroupRegistryServiceCreateRequest{},
+			},
+			{
+				name: "group body with no name", family: liaisongrpc.ScopeGroupBodyName,
+				request: &databasev1.GroupRegistryServiceCreateRequest{Group: &commonv1.Group{}},
+			},
+			{
+				name: "nil metadata", family: liaisongrpc.ScopeMetadataGroup,
+				request: &databasev1.MeasureRegistryServiceGetRequest{},
+			},
+			{
+				name: "metadata with no group", family: liaisongrpc.ScopeMetadataGroup,
+				request: &databasev1.MeasureRegistryServiceGetRequest{Metadata: namedMetadata},
+			},
+			{
+				name: "nil resource body", family: liaisongrpc.ScopeResourceMetadataGroup,
+				request: &databasev1.MeasureRegistryServiceCreateRequest{},
+			},
+			{
+				name: "resource with nil metadata", family: liaisongrpc.ScopeResourceMetadataGroup,
+				request: &databasev1.MeasureRegistryServiceCreateRequest{Measure: &databasev1.Measure{}},
+			},
+			{
+				name: "request of the wrong family", family: liaisongrpc.ScopeMetadataGroup,
+				request: &databasev1.GroupRegistryServiceGetRequest{Group: groupAlpha},
+			},
+			{
+				name: "a family with no extractor", family: liaisongrpc.ScopeUnspecified,
+				request: &databasev1.GroupRegistryServiceGetRequest{Group: groupAlpha},
+			},
+			{
+				name: "schema key with no group", family: liaisongrpc.ScopeSchemaKeys,
+				request: &schemav1.AwaitSchemaAppliedRequest{Keys: []*schemav1.SchemaKey{{Kind: "measure", Name: "m"}}},
+			},
+			{
+				name: "group-kind key with no name", family: liaisongrpc.ScopeSchemaKeys,
+				request: &schemav1.AwaitSchemaAppliedRequest{Keys: []*schemav1.SchemaKey{{Kind: "group"}}},
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				got, err := liaisongrpc.RequestScopes(tc.family, tc.request)
+				if !errors.Is(err, liaisongrpc.ErrScopeUnresolvable) {
+					t.Fatalf("RequestScopes(%d, %T) = %v, %v; want an error wrapping ErrScopeUnresolvable",
+						tc.family, tc.request, got, err)
+				}
+				if len(got) != 0 {
+					t.Errorf("RequestScopes(%d, %T) returned scopes %v alongside its error, want none", tc.family, tc.request, got)
+				}
+			})
+		}
+	})
+}
+
+// TestSchemaR3_DeniedMutationsNeverReachTheHandler proves R3's side-effect half at the
+// interceptor seam: the decision precedes the handler, so a denied create, update or delete
+// cannot have written metadata, opened a deletion task or left a tombstone — there was no
+// handler invocation in which to do so. The status codes are what a client observes, so they
+// are part of the contract: a wrong scope is PermissionDenied and a request carrying no
+// resolvable group is InvalidArgument.
+func TestSchemaR3_DeniedMutationsNeverReachTheHandler(t *testing.T) {
+	interceptor := liaisongrpc.NewAuthorizationInterceptor(newSchemaReloader(t), policyTable(t), &recordingObserver{})
+
+	for _, tc := range []struct {
+		request  any
+		method   string
+		name     string
+		user     string
+		password string
+		wantCode codes.Code
+	}{
+		{
+			name: "reader cannot create a group", method: mGroupCreate,
+			user: "sch-reader-alpha", password: "reader-alpha-secret",
+			request: &databasev1.GroupRegistryServiceCreateRequest{
+				Group: &commonv1.Group{Metadata: &commonv1.Metadata{Name: groupAlpha}},
+			},
+			wantCode: codes.PermissionDenied,
+		},
+		{
+			name: "alpha writer cannot delete the beta group", method: mGroupDelete,
+			user: "sch-writer-alpha", password: "writer-alpha-secret",
+			request:  &databasev1.GroupRegistryServiceDeleteRequest{Group: groupBeta, Force: true},
+			wantCode: codes.PermissionDenied,
+		},
+		{
+			name: "alpha writer cannot create a beta measure", method: mMeasureSchemaNew,
+			user: "sch-writer-alpha", password: "writer-alpha-secret",
+			request:  &databasev1.MeasureRegistryServiceCreateRequest{Measure: measureIn(groupBeta)},
+			wantCode: codes.PermissionDenied,
+		},
+		{
+			name: "reader cannot delete an alpha measure", method: mMeasureSchemaDrop,
+			user: "sch-reader-alpha", password: "reader-alpha-secret",
+			request: &databasev1.MeasureRegistryServiceDeleteRequest{
+				Metadata: &commonv1.Metadata{Group: groupAlpha, Name: fixtureMeasure},
+			},
+			wantCode: codes.PermissionDenied,
+		},
+		{
+			name: "an unresolvable group is malformed, not unauthorized", method: mMeasureSchemaNew,
+			user: "sch-admin", password: "admin-secret",
+			request:  &databasev1.MeasureRegistryServiceCreateRequest{},
+			wantCode: codes.InvalidArgument,
+		},
+		{
+			name: "an empty group on a point read is malformed", method: mGroupGet,
+			user: "sch-admin", password: "admin-secret",
+			request:  &databasev1.GroupRegistryServiceGetRequest{},
+			wantCode: codes.InvalidArgument,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := metadata.NewIncomingContext(context.Background(),
+				metadata.Pairs("username", tc.user, "password", tc.password))
+			handlerRan := false
+			_, err := interceptor(ctx, tc.request, &grpclib.UnaryServerInfo{FullMethod: tc.method},
+				func(context.Context, any) (any, error) {
+					handlerRan = true
+					return struct{}{}, nil
+				})
+			if got := status.Code(err); got != tc.wantCode {
+				t.Errorf("%s on %s = %v, want %v", tc.user, tc.method, got, tc.wantCode)
+			}
+			if handlerRan {
+				t.Errorf("the handler ran for a rejected %s call, want no side effect", tc.method)
+			}
+		})
+	}
+
+	t.Run("an allowed mutation reaches its handler", func(t *testing.T) {
+		ctx := metadata.NewIncomingContext(context.Background(),
+			metadata.Pairs("username", "sch-writer-alpha", "password", "writer-alpha-secret"))
+		handlerRan := false
+		_, err := interceptor(ctx, &databasev1.MeasureRegistryServiceCreateRequest{Measure: measureIn(groupAlpha)},
+			&grpclib.UnaryServerInfo{FullMethod: mMeasureSchemaNew},
+			func(context.Context, any) (any, error) {
+				handlerRan = true
+				return struct{}{}, nil
+			})
+		if err != nil {
+			t.Fatalf("the alpha writer creating an alpha measure returned %v, want the handler's result", err)
+		}
+		if !handlerRan {
+			t.Error("the handler did not run for an allowed create")
+		}
+	})
+}
+
+// TestSchemaR3_GroupListIsFilteredToVisibleScopes proves R3's visibility half: Group List
+// admits any principal holding schema:read somewhere and rejects one holding it nowhere, and
+// the response it returns names only the groups that principal's scopes cover. The expected
+// lists are written out by hand from the fixture bindings, and a group created after the
+// policy was compiled is included so wildcard visibility is not confused with a fixed list.
+func TestSchemaR3_GroupListIsFilteredToVisibleScopes(t *testing.T) {
+	snap := schemaSnapshot(t)
+	table := policyTable(t)
+	actors := schemaActors(t, snap)
+	policy, exists := table.Policy(mGroupList)
+	if !exists {
+		t.Fatalf("the table does not classify %s", mGroupList)
+	}
+
+	unfiltered := &databasev1.GroupRegistryServiceListResponse{
+		Group: []*commonv1.Group{
+			{Metadata: &commonv1.Metadata{Name: groupAlpha}},
+			{Metadata: &commonv1.Metadata{Name: groupBeta}},
+			{Metadata: &commonv1.Metadata{Name: groupGamma}},
+		},
+	}
+	for _, tc := range []struct {
+		who         string
+		wantVisible []string
+		wantAdmit   liaisongrpc.Decision
+	}{
+		{who: "admin", wantAdmit: liaisongrpc.DecisionAllow, wantVisible: []string{groupAlpha, groupBeta, groupGamma}},
+		{who: "reader-all", wantAdmit: liaisongrpc.DecisionAllow, wantVisible: []string{groupAlpha, groupBeta, groupGamma}},
+		{who: "reader-alpha", wantAdmit: liaisongrpc.DecisionAllow, wantVisible: []string{groupAlpha}},
+		{who: "writer-alpha", wantAdmit: liaisongrpc.DecisionAllow, wantVisible: []string{groupAlpha}},
+		{who: "unbound", wantAdmit: liaisongrpc.DecisionDeny, wantVisible: nil},
+	} {
+		t.Run(tc.who, func(t *testing.T) {
+			principal := actors[tc.who]
+			admit, reason := table.Authorize(snap, principal, mGroupList, &databasev1.GroupRegistryServiceListRequest{})
+			if admit != tc.wantAdmit {
+				t.Fatalf("Authorize(%s, %s) = %v (%s), want %v", tc.who, mGroupList, admit, reason, tc.wantAdmit)
+			}
+			if tc.wantAdmit != liaisongrpc.DecisionAllow {
+				return
+			}
+			filtered, ok := liaisongrpc.FilterResponse(snap, principal, policy, unfiltered).(*databasev1.GroupRegistryServiceListResponse)
+			if !ok {
+				t.Fatalf("FilterResponse(%s) did not return a Group List response", tc.who)
+			}
+			names := make([]string, 0, len(filtered.GetGroup()))
+			for _, group := range filtered.GetGroup() {
+				names = append(names, group.GetMetadata().GetName())
+			}
+			if !reflect.DeepEqual(names, tc.wantVisible) {
+				t.Errorf("FilterResponse(%s) listed %v, want %v", tc.who, names, tc.wantVisible)
+			}
+		})
+	}
+
+	t.Run("the unfiltered response is not mutated", func(t *testing.T) {
+		if len(unfiltered.GetGroup()) != 3 {
+			t.Fatalf("filtering reduced the handler's own response to %d groups, want the original 3 untouched",
+				len(unfiltered.GetGroup()))
+		}
+	})
+
+	// A policy reload that lands while the handler is running must not widen or narrow what
+	// this request sees: the filter answers from the snapshot the decision was taken against,
+	// which is why it is passed one rather than reading the reloader itself.
+	t.Run("filtering answers from the request's own snapshot", func(t *testing.T) {
+		widened, compileErr := auth.CompileSnapshot(2, []byte(widenedSchemaPolicyYAML))
+		if compileErr != nil {
+			t.Fatalf("CompileSnapshot(2, widened fixture) returned %v, want a compiled snapshot", compileErr)
+		}
+		reader := actor(t, widened, "sch-reader-alpha", "reader-alpha-secret")
+		newFiltered, ok := liaisongrpc.FilterResponse(widened, reader, policy, unfiltered).(*databasev1.GroupRegistryServiceListResponse)
+		if !ok {
+			t.Fatalf("FilterResponse against revision 2 did not return a Group List response")
+		}
+		if len(newFiltered.GetGroup()) != 3 {
+			t.Fatalf("revision 2 widened the alpha reader to a wildcard, so it should list 3 groups, got %d",
+				len(newFiltered.GetGroup()))
+		}
+		// The same principal filtered against revision 1 must still see only alpha.
+		oldFiltered, ok := liaisongrpc.FilterResponse(snap, actors["reader-alpha"], policy, unfiltered).(*databasev1.GroupRegistryServiceListResponse)
+		if !ok {
+			t.Fatalf("FilterResponse against revision 1 did not return a Group List response")
+		}
+		if len(oldFiltered.GetGroup()) != 1 {
+			t.Errorf("the revision-1 snapshot listed %d groups, want only %s; a filter must not read a newer revision",
+				len(oldFiltered.GetGroup()), groupAlpha)
+		}
+	})
+
+	t.Run("no other policy has its reply filtered", func(t *testing.T) {
+		getPolicy, _ := table.Policy(mGroupGet)
+		reply := &databasev1.GroupRegistryServiceGetResponse{Group: &commonv1.Group{Metadata: &commonv1.Metadata{Name: groupBeta}}}
+		if got := liaisongrpc.FilterResponse(snap, actors["reader-alpha"], getPolicy, reply); got != any(reply) {
+			t.Errorf("FilterResponse on a %s reply returned %v, want the reply unchanged", mGroupGet, got)
+		}
+	})
+}
+
+// TestSchemaR4_SchemaBarrierScopes proves R4: a key wait resolves one scope per key, taking a
+// group-kind key's scope from SchemaKey.Name and every other kind's from SchemaKey.Group,
+// deduplicates them, and requires the permission for all of them, while a revision wait names
+// no group and is satisfied only by a wildcard schema read. A key list that names no group at
+// all resolves to no scope, which makes it a wildcard question rather than a free pass.
+func TestSchemaR4_SchemaBarrierScopes(t *testing.T) {
+	t.Run("keys resolve to their groups", func(t *testing.T) {
+		for _, tc := range []struct {
+			request *schemav1.AwaitSchemaAppliedRequest
+			name    string
+			want    []string
+		}{
+			{
+				name: "a group-kind key scopes to its name",
+				request: &schemav1.AwaitSchemaAppliedRequest{Keys: []*schemav1.SchemaKey{
+					{Kind: "group", Name: groupAlpha},
+				}},
+				want: []string{groupAlpha},
+			},
+			{
+				name: "every other kind scopes to its group",
+				request: &schemav1.AwaitSchemaAppliedRequest{Keys: []*schemav1.SchemaKey{
+					{Kind: "measure", Group: groupAlpha, Name: fixtureMeasure},
+				}},
+				want: []string{groupAlpha},
+			},
+			{
+				name: "duplicate and unordered keys collapse to one sorted set",
+				request: &schemav1.AwaitSchemaAppliedRequest{Keys: []*schemav1.SchemaKey{
+					{Kind: "measure", Group: groupBeta, Name: fixtureMeasure},
+					{Kind: "stream", Group: groupAlpha, Name: "segment"},
+					{Kind: "measure", Group: groupBeta, Name: "service_resp_time"},
+					{Kind: "group", Name: groupAlpha},
+				}},
+				want: []string{groupAlpha, groupBeta},
+			},
+			{
+				name:    "no keys name no group",
+				request: &schemav1.AwaitSchemaAppliedRequest{},
+				want:    nil,
+			},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				got, err := liaisongrpc.RequestScopes(liaisongrpc.ScopeSchemaKeys, tc.request)
+				if err != nil {
+					t.Fatalf("RequestScopes(ScopeSchemaKeys, %v) returned %v, want %v", tc.request.GetKeys(), err, tc.want)
+				}
+				if len(got) == 0 && len(tc.want) == 0 {
+					return
+				}
+				if !reflect.DeepEqual(got, tc.want) {
+					t.Errorf("RequestScopes(ScopeSchemaKeys, %v) = %v, want %v", tc.request.GetKeys(), got, tc.want)
+				}
+			})
+		}
+	})
+
+	snap := schemaSnapshot(t)
+	table := policyTable(t)
+	actors := schemaActors(t, snap)
+	const (
+		allow = liaisongrpc.DecisionAllow
+		deny  = liaisongrpc.DecisionDeny
+	)
+	alphaKeys := &schemav1.AwaitSchemaAppliedRequest{Keys: []*schemav1.SchemaKey{{Kind: "group", Name: groupAlpha}}}
+	bothKeys := &schemav1.AwaitSchemaAppliedRequest{Keys: []*schemav1.SchemaKey{
+		{Kind: "group", Name: groupAlpha},
+		{Kind: "group", Name: groupBeta},
+	}}
+	deleteBeta := &schemav1.AwaitSchemaDeletedRequest{Keys: []*schemav1.SchemaKey{
+		{Kind: "measure", Group: groupBeta, Name: fixtureMeasure},
+	}}
+	for _, tc := range []struct {
+		request                                             any
+		method                                              string
+		note                                                string
+		admin, writerAlpha, readerAlpha, readerAll, unbound liaisongrpc.Decision
+	}{
+		{
+			method: mAwaitSchemaApplied, note: "alpha only", request: alphaKeys,
+			admin: allow, writerAlpha: allow, readerAlpha: allow, readerAll: allow, unbound: deny,
+		},
+		{
+			method: mAwaitSchemaApplied, note: "alpha and beta is all-or-nothing", request: bothKeys,
+			admin: allow, writerAlpha: deny, readerAlpha: deny, readerAll: allow, unbound: deny,
+		},
+		{
+			method: mAwaitSchemaDeleted, note: "beta", request: deleteBeta,
+			admin: allow, writerAlpha: deny, readerAlpha: deny, readerAll: allow, unbound: deny,
+		},
+		{
+			method: mAwaitRevision, note: "a cluster-wide wait needs a wildcard read",
+			request: &schemav1.AwaitRevisionAppliedRequest{MinRevision: 0},
+			admin:   allow, writerAlpha: deny, readerAlpha: deny, readerAll: allow, unbound: deny,
+		},
+	} {
+		for _, who := range []struct {
+			name string
+			want liaisongrpc.Decision
+		}{
+			{"admin", tc.admin},
+			{"writer-alpha", tc.writerAlpha},
+			{"reader-alpha", tc.readerAlpha},
+			{"reader-all", tc.readerAll},
+			{"unbound", tc.unbound},
+		} {
+			got, reason := table.Authorize(snap, actors[who.name], tc.method, tc.request)
+			if got != who.want {
+				t.Errorf("Authorize(%s, %s, %s) = %v (%s), want %v", who.name, tc.method, tc.note, got, reason, who.want)
+			}
+		}
+	}
+}
+
+// TestSchemaR6_DataMethodsStayFailClosed proves R6, the issue's "all data permission methods
+// remain fail-closed" criterion: no method carrying a data permission may be decided by this
+// milestone, for any principal including the global administrator, and the reason it reports
+// must stay the bounded executor_unavailable rather than becoming a scope or grant outcome.
+func TestSchemaR6_DataMethodsStayFailClosed(t *testing.T) {
+	snap := schemaSnapshot(t)
+	table := policyTable(t)
+	actors := schemaActors(t, snap)
+
+	dataMethods := 0
+	for _, policy := range table {
+		switch policy.Permission {
+		case auth.PermissionDataRead, auth.PermissionDataWrite:
+		default:
+			continue
+		}
+		dataMethods++
+		for _, who := range []string{"admin", "writer-alpha", "reader-alpha", "reader-all", "unbound"} {
+			decision, reason := table.Authorize(snap, actors[who], policy.FullMethod, nil)
+			if decision != liaisongrpc.DecisionUnavailable {
+				t.Errorf("Authorize(%s, %s) = %v, want DecisionUnavailable", who, policy.FullMethod, decision)
+			}
+			if reason != liaisongrpc.DecisionReasonExecutorUnavailable {
+				t.Errorf("Authorize(%s, %s) reported %q, want %q", who, policy.FullMethod, reason,
+					liaisongrpc.DecisionReasonExecutorUnavailable)
+			}
+		}
+	}
+	if dataMethods != 11 {
+		t.Errorf("the table classifies %d data methods, want the fixed 11 that W-PR3 owns", dataMethods)
+	}
+}
+
+// TestSchemaR6_DecisionReasonsStayBounded proves that the reason this milestone adds joins a
+// closed set rather than opening one: every reason the decision function can return is listed
+// by DecisionReasons(), and the outcome label of the new invalid-request decision collapses
+// into the same two-valued decision label the metric already uses.
+func TestSchemaR6_DecisionReasonsStayBounded(t *testing.T) {
+	bounded := make(map[liaisongrpc.DecisionReason]bool)
+	for _, reason := range liaisongrpc.DecisionReasons() {
+		if bounded[reason] {
+			t.Errorf("DecisionReasons() lists %q twice", reason)
+		}
+		bounded[reason] = true
+	}
+	if !bounded[liaisongrpc.DecisionReasonInvalidRequest] {
+		t.Errorf("DecisionReasons() omits %q", liaisongrpc.DecisionReasonInvalidRequest)
+	}
+
+	labels := make(map[string]bool)
+	for _, label := range liaisongrpc.DecisionLabels() {
+		labels[label] = true
+	}
+	if got := liaisongrpc.DecisionLabel(liaisongrpc.DecisionInvalidRequest); !labels[got] {
+		t.Errorf("DecisionLabel(DecisionInvalidRequest) = %q, which is outside DecisionLabels() %v", got, liaisongrpc.DecisionLabels())
+	}
+
+	snap := schemaSnapshot(t)
+	table := policyTable(t)
+	actors := schemaActors(t, snap)
+	for _, tc := range []struct {
+		request any
+		method  string
+	}{
+		{method: mGroupGet, request: &databasev1.GroupRegistryServiceGetRequest{Group: groupAlpha}},
+		{method: mGroupGet, request: &databasev1.GroupRegistryServiceGetRequest{Group: groupBeta}},
+		{method: mGroupGet, request: &databasev1.GroupRegistryServiceGetRequest{}},
+		{method: mGroupList, request: &databasev1.GroupRegistryServiceListRequest{}},
+		{method: mMeasureQuery, request: nil},
+		{method: mGetClusterState, request: nil},
+	} {
+		for _, who := range []string{"admin", "reader-alpha", "unbound"} {
+			if _, reason := table.Authorize(snap, actors[who], tc.method, tc.request); !bounded[reason] {
+				t.Errorf("Authorize(%s, %s) reported %q, which is outside DecisionReasons()", who, tc.method, reason)
+			}
+		}
+	}
+}

--- a/banyand/liaison/grpc/rbac_schema_contract_test.go
+++ b/banyand/liaison/grpc/rbac_schema_contract_test.go
@@ -98,6 +98,14 @@ const (
 	groupGamma = "rbac-gamma"
 	// fixtureMeasure is the child-schema name both fixture groups carry.
 	fixtureMeasure = "service_cpm"
+
+	streamRegistryService           = "StreamRegistryService"
+	measureRegistryService          = "MeasureRegistryService"
+	traceRegistryService            = "TraceRegistryService"
+	indexRuleRegistryService        = "IndexRuleRegistryService"
+	indexRuleBindingRegistryService = "IndexRuleBindingRegistryService"
+	topNAggregationRegistryService  = "TopNAggregationRegistryService"
+	propertyRegistryService         = "PropertyRegistryService"
 )
 
 // Schema method names, transcribed from the generated service descriptors' _FullMethodName
@@ -121,8 +129,8 @@ const (
 // registryServices is the fixed seven-family oracle of the issue: the registry services whose
 // six-method rule family this milestone activates.
 var registryServices = []string{
-	"StreamRegistryService", "MeasureRegistryService", "TraceRegistryService", "IndexRuleRegistryService",
-	"IndexRuleBindingRegistryService", "TopNAggregationRegistryService", "PropertyRegistryService",
+	streamRegistryService, measureRegistryService, traceRegistryService, indexRuleRegistryService,
+	indexRuleBindingRegistryService, topNAggregationRegistryService, propertyRegistryService,
 }
 
 func registryMethod(service, method string) string {
@@ -176,17 +184,17 @@ func measureIn(group string) *databasev1.Measure {
 // structural assertion that would pass for a type the liaison never serves.
 func registryListRequest(service, group string) any {
 	switch service {
-	case "StreamRegistryService":
+	case streamRegistryService:
 		return &databasev1.StreamRegistryServiceListRequest{Group: group}
-	case "MeasureRegistryService":
+	case measureRegistryService:
 		return &databasev1.MeasureRegistryServiceListRequest{Group: group}
-	case "TraceRegistryService":
+	case traceRegistryService:
 		return &databasev1.TraceRegistryServiceListRequest{Group: group}
-	case "IndexRuleRegistryService":
+	case indexRuleRegistryService:
 		return &databasev1.IndexRuleRegistryServiceListRequest{Group: group}
-	case "IndexRuleBindingRegistryService":
+	case indexRuleBindingRegistryService:
 		return &databasev1.IndexRuleBindingRegistryServiceListRequest{Group: group}
-	case "TopNAggregationRegistryService":
+	case topNAggregationRegistryService:
 		return &databasev1.TopNAggregationRegistryServiceListRequest{Group: group}
 	default:
 		return &databasev1.PropertyRegistryServiceListRequest{Group: group}
@@ -196,17 +204,17 @@ func registryListRequest(service, group string) any {
 func registryGetRequest(service, group string) any {
 	resourceMeta := &commonv1.Metadata{Group: group, Name: "fixture"}
 	switch service {
-	case "StreamRegistryService":
+	case streamRegistryService:
 		return &databasev1.StreamRegistryServiceGetRequest{Metadata: resourceMeta}
-	case "MeasureRegistryService":
+	case measureRegistryService:
 		return &databasev1.MeasureRegistryServiceGetRequest{Metadata: resourceMeta}
-	case "TraceRegistryService":
+	case traceRegistryService:
 		return &databasev1.TraceRegistryServiceGetRequest{Metadata: resourceMeta}
-	case "IndexRuleRegistryService":
+	case indexRuleRegistryService:
 		return &databasev1.IndexRuleRegistryServiceGetRequest{Metadata: resourceMeta}
-	case "IndexRuleBindingRegistryService":
+	case indexRuleBindingRegistryService:
 		return &databasev1.IndexRuleBindingRegistryServiceGetRequest{Metadata: resourceMeta}
-	case "TopNAggregationRegistryService":
+	case topNAggregationRegistryService:
 		return &databasev1.TopNAggregationRegistryServiceGetRequest{Metadata: resourceMeta}
 	default:
 		return &databasev1.PropertyRegistryServiceGetRequest{Metadata: resourceMeta}
@@ -223,17 +231,17 @@ func registryGetRequest(service, group string) any {
 func registryExistRequest(service, group string) any {
 	resourceMeta := &commonv1.Metadata{Group: group, Name: "fixture"}
 	switch service {
-	case "StreamRegistryService":
+	case streamRegistryService:
 		return &databasev1.StreamRegistryServiceExistRequest{Metadata: resourceMeta}
-	case "MeasureRegistryService":
+	case measureRegistryService:
 		return &databasev1.MeasureRegistryServiceExistRequest{Metadata: resourceMeta}
-	case "TraceRegistryService":
+	case traceRegistryService:
 		return &databasev1.TraceRegistryServiceExistRequest{Metadata: resourceMeta}
-	case "IndexRuleRegistryService":
+	case indexRuleRegistryService:
 		return &databasev1.IndexRuleRegistryServiceExistRequest{Metadata: resourceMeta}
-	case "IndexRuleBindingRegistryService":
+	case indexRuleBindingRegistryService:
 		return &databasev1.IndexRuleBindingRegistryServiceExistRequest{Metadata: resourceMeta}
-	case "TopNAggregationRegistryService":
+	case topNAggregationRegistryService:
 		return &databasev1.TopNAggregationRegistryServiceExistRequest{Metadata: resourceMeta}
 	default:
 		return &databasev1.PropertyRegistryServiceExistRequest{Metadata: resourceMeta}
@@ -243,17 +251,17 @@ func registryExistRequest(service, group string) any {
 func registryDeleteRequest(service, group string) any {
 	resourceMeta := &commonv1.Metadata{Group: group, Name: "fixture"}
 	switch service {
-	case "StreamRegistryService":
+	case streamRegistryService:
 		return &databasev1.StreamRegistryServiceDeleteRequest{Metadata: resourceMeta}
-	case "MeasureRegistryService":
+	case measureRegistryService:
 		return &databasev1.MeasureRegistryServiceDeleteRequest{Metadata: resourceMeta}
-	case "TraceRegistryService":
+	case traceRegistryService:
 		return &databasev1.TraceRegistryServiceDeleteRequest{Metadata: resourceMeta}
-	case "IndexRuleRegistryService":
+	case indexRuleRegistryService:
 		return &databasev1.IndexRuleRegistryServiceDeleteRequest{Metadata: resourceMeta}
-	case "IndexRuleBindingRegistryService":
+	case indexRuleBindingRegistryService:
 		return &databasev1.IndexRuleBindingRegistryServiceDeleteRequest{Metadata: resourceMeta}
-	case "TopNAggregationRegistryService":
+	case topNAggregationRegistryService:
 		return &databasev1.TopNAggregationRegistryServiceDeleteRequest{Metadata: resourceMeta}
 	default:
 		return &databasev1.PropertyRegistryServiceDeleteRequest{Metadata: resourceMeta}
@@ -263,19 +271,19 @@ func registryDeleteRequest(service, group string) any {
 func registryUpdateRequest(service, group string) any {
 	resourceMeta := &commonv1.Metadata{Group: group, Name: "fixture"}
 	switch service {
-	case "StreamRegistryService":
+	case streamRegistryService:
 		return &databasev1.StreamRegistryServiceUpdateRequest{Stream: &databasev1.Stream{Metadata: resourceMeta}}
-	case "MeasureRegistryService":
+	case measureRegistryService:
 		return &databasev1.MeasureRegistryServiceUpdateRequest{Measure: &databasev1.Measure{Metadata: resourceMeta}}
-	case "TraceRegistryService":
+	case traceRegistryService:
 		return &databasev1.TraceRegistryServiceUpdateRequest{Trace: &databasev1.Trace{Metadata: resourceMeta}}
-	case "IndexRuleRegistryService":
+	case indexRuleRegistryService:
 		return &databasev1.IndexRuleRegistryServiceUpdateRequest{IndexRule: &databasev1.IndexRule{Metadata: resourceMeta}}
-	case "IndexRuleBindingRegistryService":
+	case indexRuleBindingRegistryService:
 		return &databasev1.IndexRuleBindingRegistryServiceUpdateRequest{
 			IndexRuleBinding: &databasev1.IndexRuleBinding{Metadata: resourceMeta},
 		}
-	case "TopNAggregationRegistryService":
+	case topNAggregationRegistryService:
 		return &databasev1.TopNAggregationRegistryServiceUpdateRequest{
 			TopNAggregation: &databasev1.TopNAggregation{Metadata: resourceMeta},
 		}
@@ -287,19 +295,19 @@ func registryUpdateRequest(service, group string) any {
 func registryCreateRequest(service, group string) any {
 	resourceMeta := &commonv1.Metadata{Group: group, Name: "fixture"}
 	switch service {
-	case "StreamRegistryService":
+	case streamRegistryService:
 		return &databasev1.StreamRegistryServiceCreateRequest{Stream: &databasev1.Stream{Metadata: resourceMeta}}
-	case "MeasureRegistryService":
+	case measureRegistryService:
 		return &databasev1.MeasureRegistryServiceCreateRequest{Measure: &databasev1.Measure{Metadata: resourceMeta}}
-	case "TraceRegistryService":
+	case traceRegistryService:
 		return &databasev1.TraceRegistryServiceCreateRequest{Trace: &databasev1.Trace{Metadata: resourceMeta}}
-	case "IndexRuleRegistryService":
+	case indexRuleRegistryService:
 		return &databasev1.IndexRuleRegistryServiceCreateRequest{IndexRule: &databasev1.IndexRule{Metadata: resourceMeta}}
-	case "IndexRuleBindingRegistryService":
+	case indexRuleBindingRegistryService:
 		return &databasev1.IndexRuleBindingRegistryServiceCreateRequest{
 			IndexRuleBinding: &databasev1.IndexRuleBinding{Metadata: resourceMeta},
 		}
-	case "TopNAggregationRegistryService":
+	case topNAggregationRegistryService:
 		return &databasev1.TopNAggregationRegistryServiceCreateRequest{
 			TopNAggregation: &databasev1.TopNAggregation{Metadata: resourceMeta},
 		}

--- a/banyand/liaison/grpc/rbac_schema_contract_test.go
+++ b/banyand/liaison/grpc/rbac_schema_contract_test.go
@@ -213,6 +213,77 @@ func registryGetRequest(service, group string) any {
 	}
 }
 
+// registryExistRequest and registryDeleteRequest build the other two members of
+// the Metadata.Group family, and registryUpdateRequest the second member of the
+// resource-body family. R2 names three structural families, and the design's
+// § 06 asks the coverage test to prove "the method and extractor remain
+// paired" — driving one shape per family satisfies the first reading, every
+// method the second. These make both true at once, which is cheaper than
+// deciding which R2 meant.
+func registryExistRequest(service, group string) any {
+	resourceMeta := &commonv1.Metadata{Group: group, Name: "fixture"}
+	switch service {
+	case "StreamRegistryService":
+		return &databasev1.StreamRegistryServiceExistRequest{Metadata: resourceMeta}
+	case "MeasureRegistryService":
+		return &databasev1.MeasureRegistryServiceExistRequest{Metadata: resourceMeta}
+	case "TraceRegistryService":
+		return &databasev1.TraceRegistryServiceExistRequest{Metadata: resourceMeta}
+	case "IndexRuleRegistryService":
+		return &databasev1.IndexRuleRegistryServiceExistRequest{Metadata: resourceMeta}
+	case "IndexRuleBindingRegistryService":
+		return &databasev1.IndexRuleBindingRegistryServiceExistRequest{Metadata: resourceMeta}
+	case "TopNAggregationRegistryService":
+		return &databasev1.TopNAggregationRegistryServiceExistRequest{Metadata: resourceMeta}
+	default:
+		return &databasev1.PropertyRegistryServiceExistRequest{Metadata: resourceMeta}
+	}
+}
+
+func registryDeleteRequest(service, group string) any {
+	resourceMeta := &commonv1.Metadata{Group: group, Name: "fixture"}
+	switch service {
+	case "StreamRegistryService":
+		return &databasev1.StreamRegistryServiceDeleteRequest{Metadata: resourceMeta}
+	case "MeasureRegistryService":
+		return &databasev1.MeasureRegistryServiceDeleteRequest{Metadata: resourceMeta}
+	case "TraceRegistryService":
+		return &databasev1.TraceRegistryServiceDeleteRequest{Metadata: resourceMeta}
+	case "IndexRuleRegistryService":
+		return &databasev1.IndexRuleRegistryServiceDeleteRequest{Metadata: resourceMeta}
+	case "IndexRuleBindingRegistryService":
+		return &databasev1.IndexRuleBindingRegistryServiceDeleteRequest{Metadata: resourceMeta}
+	case "TopNAggregationRegistryService":
+		return &databasev1.TopNAggregationRegistryServiceDeleteRequest{Metadata: resourceMeta}
+	default:
+		return &databasev1.PropertyRegistryServiceDeleteRequest{Metadata: resourceMeta}
+	}
+}
+
+func registryUpdateRequest(service, group string) any {
+	resourceMeta := &commonv1.Metadata{Group: group, Name: "fixture"}
+	switch service {
+	case "StreamRegistryService":
+		return &databasev1.StreamRegistryServiceUpdateRequest{Stream: &databasev1.Stream{Metadata: resourceMeta}}
+	case "MeasureRegistryService":
+		return &databasev1.MeasureRegistryServiceUpdateRequest{Measure: &databasev1.Measure{Metadata: resourceMeta}}
+	case "TraceRegistryService":
+		return &databasev1.TraceRegistryServiceUpdateRequest{Trace: &databasev1.Trace{Metadata: resourceMeta}}
+	case "IndexRuleRegistryService":
+		return &databasev1.IndexRuleRegistryServiceUpdateRequest{IndexRule: &databasev1.IndexRule{Metadata: resourceMeta}}
+	case "IndexRuleBindingRegistryService":
+		return &databasev1.IndexRuleBindingRegistryServiceUpdateRequest{
+			IndexRuleBinding: &databasev1.IndexRuleBinding{Metadata: resourceMeta},
+		}
+	case "TopNAggregationRegistryService":
+		return &databasev1.TopNAggregationRegistryServiceUpdateRequest{
+			TopNAggregation: &databasev1.TopNAggregation{Metadata: resourceMeta},
+		}
+	default:
+		return &databasev1.PropertyRegistryServiceUpdateRequest{Property: &databasev1.Property{Metadata: resourceMeta}}
+	}
+}
+
 func registryCreateRequest(service, group string) any {
 	resourceMeta := &commonv1.Metadata{Group: group, Name: "fixture"}
 	switch service {
@@ -528,7 +599,10 @@ func TestSchemaR2_RequestScopesReadsTheAgreedRequestShapes(t *testing.T) {
 			}{
 				{family: liaisongrpc.ScopeDirectGroup, request: registryListRequest(service, groupAlpha)},
 				{family: liaisongrpc.ScopeMetadataGroup, request: registryGetRequest(service, groupAlpha)},
+				{family: liaisongrpc.ScopeMetadataGroup, request: registryExistRequest(service, groupAlpha)},
+				{family: liaisongrpc.ScopeMetadataGroup, request: registryDeleteRequest(service, groupAlpha)},
 				{family: liaisongrpc.ScopeResourceMetadataGroup, request: registryCreateRequest(service, groupAlpha)},
+				{family: liaisongrpc.ScopeResourceMetadataGroup, request: registryUpdateRequest(service, groupAlpha)},
 			} {
 				got, err := liaisongrpc.RequestScopes(shape.family, shape.request)
 				if err != nil {

--- a/banyand/liaison/grpc/rbac_schema_impl_test.go
+++ b/banyand/liaison/grpc/rbac_schema_impl_test.go
@@ -1,0 +1,222 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership. The ASF licenses this
+// file to you under the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License. You may obtain a
+// copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package grpc
+
+import (
+	"reflect"
+	"testing"
+
+	commonv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/common/v1"
+	databasev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
+	schemav1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/schema/v1"
+	"github.com/apache/skywalking-banyandb/banyand/liaison/pkg/auth"
+)
+
+// TestSchemaB1GroupPointReadPolicy activates Group point reads with the direct-group family.
+func TestSchemaB1GroupPointReadPolicy(t *testing.T) {
+	table := GlobalMethodPolicies()
+	for _, method := range []string{
+		"/banyandb.database.v1.GroupRegistryService/Get",
+		"/banyandb.database.v1.GroupRegistryService/Exist",
+	} {
+		policy, exists := table.Policy(method)
+		if !exists {
+			t.Fatalf("policy for %s is missing", method)
+		}
+		if !policy.Activated {
+			t.Errorf("policy for %s is not activated", method)
+		}
+		if policy.Scope != ScopeDirectGroup {
+			t.Errorf("policy for %s has scope %d, want %d", method, policy.Scope, ScopeDirectGroup)
+		}
+	}
+}
+
+// TestSchemaB2GroupWritesUseBodyName keeps Group upserts bound to Metadata.Name.
+func TestSchemaB2GroupWritesUseBodyName(t *testing.T) {
+	request := &databasev1.GroupRegistryServiceCreateRequest{
+		Group: &commonv1.Group{Metadata: &commonv1.Metadata{Group: "beta", Name: "alpha"}},
+	}
+	scopes, scopeErr := RequestScopes(ScopeGroupBodyName, request)
+	if scopeErr != nil {
+		t.Fatalf("RequestScopes(ScopeGroupBodyName, Group Create) = %v", scopeErr)
+	}
+	if !reflect.DeepEqual(scopes, []string{"alpha"}) {
+		t.Errorf("Group Create scopes = %v, want [alpha]", scopes)
+	}
+	for _, method := range []string{
+		"/banyandb.database.v1.GroupRegistryService/Create",
+		"/banyandb.database.v1.GroupRegistryService/Update",
+	} {
+		assertSchemaPolicy(t, method, ScopeGroupBodyName)
+	}
+}
+
+// TestSchemaB3GroupDeleteUsesDirectGroup keeps deletion independent of its operational flags.
+func TestSchemaB3GroupDeleteUsesDirectGroup(t *testing.T) {
+	request := &databasev1.GroupRegistryServiceDeleteRequest{Group: "alpha", DryRun: true, Force: true}
+	scopes, scopeErr := RequestScopes(ScopeDirectGroup, request)
+	if scopeErr != nil {
+		t.Fatalf("RequestScopes(ScopeDirectGroup, Group Delete) = %v", scopeErr)
+	}
+	if !reflect.DeepEqual(scopes, []string{"alpha"}) {
+		t.Errorf("Group Delete scopes = %v, want [alpha]", scopes)
+	}
+	assertSchemaPolicy(t, "/banyandb.database.v1.GroupRegistryService/Delete", ScopeDirectGroup)
+}
+
+// TestSchemaB4RegistryListsUseDirectGroup activates all seven registry List methods.
+func TestSchemaB4RegistryListsUseDirectGroup(t *testing.T) {
+	for _, service := range schemaRegistryServices {
+		assertSchemaPolicy(t, registryPolicyMethod(service, "List"), ScopeDirectGroup)
+	}
+}
+
+// TestSchemaB5RegistryPointReadsUseMetadataGroup activates all seven Get and Exist methods.
+func TestSchemaB5RegistryPointReadsUseMetadataGroup(t *testing.T) {
+	request := &databasev1.MeasureRegistryServiceGetRequest{Metadata: &commonv1.Metadata{Group: "alpha", Name: "service"}}
+	scopes, scopeErr := RequestScopes(ScopeMetadataGroup, request)
+	if scopeErr != nil {
+		t.Fatalf("RequestScopes(ScopeMetadataGroup, Measure Get) = %v", scopeErr)
+	}
+	if !reflect.DeepEqual(scopes, []string{"alpha"}) {
+		t.Errorf("Measure Get scopes = %v, want [alpha]", scopes)
+	}
+	for _, service := range schemaRegistryServices {
+		for _, method := range []string{"Get", "Exist"} {
+			assertSchemaPolicy(t, registryPolicyMethod(service, method), ScopeMetadataGroup)
+		}
+	}
+}
+
+// TestSchemaB6RegistryWritesUseResourceMetadataGroup activates all seven Create and Update methods.
+func TestSchemaB6RegistryWritesUseResourceMetadataGroup(t *testing.T) {
+	request := &databasev1.MeasureRegistryServiceCreateRequest{
+		Measure: &databasev1.Measure{Metadata: &commonv1.Metadata{Group: "alpha", Name: "service"}},
+	}
+	scopes, scopeErr := RequestScopes(ScopeResourceMetadataGroup, request)
+	if scopeErr != nil {
+		t.Fatalf("RequestScopes(ScopeResourceMetadataGroup, Measure Create) = %v", scopeErr)
+	}
+	if !reflect.DeepEqual(scopes, []string{"alpha"}) {
+		t.Errorf("Measure Create scopes = %v, want [alpha]", scopes)
+	}
+	for _, service := range schemaRegistryServices {
+		for _, method := range []string{"Create", "Update"} {
+			assertSchemaPolicy(t, registryPolicyMethod(service, method), ScopeResourceMetadataGroup)
+		}
+	}
+}
+
+// TestSchemaB7RegistryDeletesUseMetadataGroup activates all seven Delete methods.
+func TestSchemaB7RegistryDeletesUseMetadataGroup(t *testing.T) {
+	for _, service := range schemaRegistryServices {
+		assertSchemaPolicy(t, registryPolicyMethod(service, "Delete"), ScopeMetadataGroup)
+	}
+}
+
+// TestSchemaB8GroupListFiltersWithItsDecisionSnapshot preserves the handler's reply.
+func TestSchemaB8GroupListFiltersWithItsDecisionSnapshot(t *testing.T) {
+	snapshot := implementationSnapshot(t)
+	principal, authenticated := snapshot.Authenticate("reader-alpha", "reader-secret")
+	if !authenticated {
+		t.Fatal("reader-alpha fixture did not authenticate")
+	}
+	policy, exists := GlobalMethodPolicies().Policy("/banyandb.database.v1.GroupRegistryService/List")
+	if !exists {
+		t.Fatal("Group List policy is missing")
+	}
+	reply := &databasev1.GroupRegistryServiceListResponse{Group: []*commonv1.Group{
+		{Metadata: &commonv1.Metadata{Name: "alpha"}},
+		{Metadata: &commonv1.Metadata{Name: "beta"}},
+	}}
+	filtered, ok := FilterResponse(snapshot, principal, policy, reply).(*databasev1.GroupRegistryServiceListResponse)
+	if !ok {
+		t.Fatal("FilterResponse returned a non-Group List reply")
+	}
+	if len(filtered.GetGroup()) != 1 || filtered.GetGroup()[0].GetMetadata().GetName() != "alpha" {
+		t.Errorf("filtered Group List = %v, want only alpha", filtered.GetGroup())
+	}
+	if len(reply.GetGroup()) != 2 {
+		t.Errorf("FilterResponse mutated the handler reply to %d groups, want 2", len(reply.GetGroup()))
+	}
+}
+
+// TestSchemaB9SchemaBarrierKeysUseEveryResolvedGroup uses the group key name and canonicalizes scopes.
+func TestSchemaB9SchemaBarrierKeysUseEveryResolvedGroup(t *testing.T) {
+	request := &schemav1.AwaitSchemaAppliedRequest{Keys: []*schemav1.SchemaKey{
+		{Kind: "measure", Group: "beta", Name: "service"},
+		{Kind: "group", Name: "alpha"},
+		{Kind: "measure", Group: "beta", Name: "latency"},
+	}}
+	scopes, scopeErr := RequestScopes(ScopeSchemaKeys, request)
+	if scopeErr != nil {
+		t.Fatalf("RequestScopes(ScopeSchemaKeys, AwaitSchemaApplied) = %v", scopeErr)
+	}
+	if !reflect.DeepEqual(scopes, []string{"alpha", "beta"}) {
+		t.Errorf("SchemaBarrier scopes = %v, want [alpha beta]", scopes)
+	}
+	assertSchemaPolicy(t, "/banyandb.schema.v1.SchemaBarrierService/AwaitSchemaApplied", ScopeSchemaKeys)
+	assertSchemaPolicy(t, "/banyandb.schema.v1.SchemaBarrierService/AwaitSchemaDeleted", ScopeSchemaKeys)
+}
+
+// TestSchemaB10RevisionWaitUsesGlobalScope requires the wildcard/global form of schema read.
+func TestSchemaB10RevisionWaitUsesGlobalScope(t *testing.T) {
+	assertSchemaPolicy(t, "/banyandb.schema.v1.SchemaBarrierService/AwaitRevisionApplied", ScopeGlobal)
+}
+
+var schemaRegistryServices = []string{
+	"StreamRegistryService", "MeasureRegistryService", "TraceRegistryService", "IndexRuleRegistryService",
+	"IndexRuleBindingRegistryService", "TopNAggregationRegistryService", "PropertyRegistryService",
+}
+
+func registryPolicyMethod(service, method string) string {
+	return "/banyandb.database.v1." + service + "/" + method
+}
+
+func assertSchemaPolicy(t *testing.T, method string, scope ScopeFamily) {
+	t.Helper()
+	policy, exists := GlobalMethodPolicies().Policy(method)
+	if !exists {
+		t.Fatalf("policy for %s is missing", method)
+	}
+	if !policy.Activated {
+		t.Errorf("policy for %s is not activated", method)
+	}
+	if policy.Scope != scope {
+		t.Errorf("policy for %s has scope %d, want %d", method, policy.Scope, scope)
+	}
+}
+
+func implementationSnapshot(t *testing.T) auth.Snapshot {
+	t.Helper()
+	const policy = `
+users:
+  - username: "reader-alpha"
+    password: "reader-secret"
+rbac:
+  enabled: true
+  bindings:
+    - principal: "reader-alpha"
+      role: "reader"
+      groups: ["alpha"]
+`
+	snapshot, compileErr := auth.CompileSnapshot(1, []byte(policy))
+	if compileErr != nil {
+		t.Fatalf("CompileSnapshot() = %v", compileErr)
+	}
+	return snapshot
+}

--- a/banyand/liaison/grpc/rbac_special.go
+++ b/banyand/liaison/grpc/rbac_special.go
@@ -18,6 +18,8 @@
 package grpc
 
 import (
+	commonv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/common/v1"
+	databasev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
 	"github.com/apache/skywalking-banyandb/banyand/liaison/pkg/auth"
 )
 
@@ -33,6 +35,19 @@ import (
 // A principal that holds the permission in no scope at all is rejected before its handler
 // runs and never reaches this function, so an empty result here means the caller's scopes
 // simply cover none of the listed groups.
-func FilterResponse(_ auth.Snapshot, _ auth.Principal, _ MethodPolicy, reply any) any {
-	return reply
+func FilterResponse(snapshot auth.Snapshot, principal auth.Principal, policy MethodPolicy, reply any) any {
+	if policy.Scope != ScopeVisibleGroups || snapshot == nil {
+		return reply
+	}
+	groupList, ok := reply.(*databasev1.GroupRegistryServiceListResponse)
+	if !ok || groupList == nil {
+		return reply
+	}
+	filtered := make([]*commonv1.Group, 0, len(groupList.GetGroup()))
+	for _, group := range groupList.GetGroup() {
+		if group != nil && snapshot.Allows(principal, policy.Permission, group.GetMetadata().GetName()) {
+			filtered = append(filtered, group)
+		}
+	}
+	return &databasev1.GroupRegistryServiceListResponse{Group: filtered}
 }

--- a/banyand/liaison/grpc/rbac_special.go
+++ b/banyand/liaison/grpc/rbac_special.go
@@ -1,0 +1,38 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package grpc
+
+import (
+	"github.com/apache/skywalking-banyandb/banyand/liaison/pkg/auth"
+)
+
+// FilterResponse reduces a handler's reply to the part of it the principal may see.
+//
+// It is selected by the policy's scope family rather than by the reply's type: a policy whose
+// Scope is ScopeVisibleGroups has its listed groups reduced to those principal holds the
+// policy's permission for, keeping every group when the grant is the wildcard one, and every
+// other policy has its reply returned unchanged. The snapshot passed in is the one the
+// request's authorization decision was taken from, so a policy reload that lands while the
+// handler runs cannot mix one revision's decision with another revision's visibility.
+//
+// A principal that holds the permission in no scope at all is rejected before its handler
+// runs and never reaches this function, so an empty result here means the caller's scopes
+// simply cover none of the listed groups.
+func FilterResponse(_ auth.Snapshot, _ auth.Principal, _ MethodPolicy, reply any) any {
+	return reply
+}

--- a/banyand/liaison/pkg/auth/rbac.go
+++ b/banyand/liaison/pkg/auth/rbac.go
@@ -114,6 +114,13 @@ type Snapshot interface {
 	// Allows reports whether principal holds perm for every requested group. Omitting groups
 	// asks for the wildcard/global grant. It reports false for a zero or unbound principal.
 	Allows(principal Principal, perm Permission, groups ...string) bool
+	// AllowsAny reports whether principal holds perm in at least one scope, exact or
+	// wildcard. It answers the visibility question a method whose resource set is the whole
+	// deployment asks before its handler runs: a principal holding perm in no scope at all is
+	// rejected outright, while one holding it in any scope proceeds and has its response
+	// reduced to the groups its scopes cover. It reports false for a zero or unbound
+	// principal, and false whenever the configuration left RBAC off.
+	AllowsAny(principal Principal, perm Permission) bool
 }
 
 type credential struct {
@@ -387,6 +394,10 @@ func (s *compiledSnapshot) Allows(principal Principal, permission Permission, gr
 		}
 	}
 	return true
+}
+
+func (s *compiledSnapshot) AllowsAny(_ Principal, _ Permission) bool {
+	return false
 }
 
 // CurrentSnapshot returns the security snapshot in force. It never returns nil: before any

--- a/banyand/liaison/pkg/auth/rbac.go
+++ b/banyand/liaison/pkg/auth/rbac.go
@@ -396,8 +396,16 @@ func (s *compiledSnapshot) Allows(principal Principal, permission Permission, gr
 	return true
 }
 
-func (s *compiledSnapshot) AllowsAny(_ Principal, _ Permission) bool {
-	return false
+func (s *compiledSnapshot) AllowsAny(principal Principal, permission Permission) bool {
+	if !s.rbacEnabled || principal.IsZero() {
+		return false
+	}
+	permissions, exists := s.grants[principal.username]
+	if !exists {
+		return false
+	}
+	scopes, allowed := permissions[permission]
+	return allowed && len(scopes) > 0
 }
 
 // CurrentSnapshot returns the security snapshot in force. It never returns nil: before any

--- a/banyand/liaison/pkg/auth/rbac_visibility_contract_test.go
+++ b/banyand/liaison/pkg/auth/rbac_visibility_contract_test.go
@@ -1,0 +1,124 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package auth_test
+
+import (
+	"testing"
+
+	"github.com/apache/skywalking-banyandb/banyand/liaison/pkg/auth"
+)
+
+// visibilityPolicyYAML binds one exact-scope reader, one wildcard reader, one exact-scope
+// writer and one principal with no binding, which is the smallest family that separates
+// "holds the permission somewhere" from "holds the permission for this group" and from
+// "holds the permission for every group".
+const visibilityPolicyYAML = `
+users:
+  - username: "vis-reader-alpha"
+    password: "reader-alpha-secret"
+  - username: "vis-reader-all"
+    password: "reader-all-secret"
+  - username: "vis-writer-alpha"
+    password: "writer-alpha-secret"
+  - username: "vis-unbound"
+    password: "unbound-secret"
+rbac:
+  enabled: true
+  bindings:
+    - principal: "vis-reader-alpha"
+      role: "reader"
+      groups: ["rbac-alpha"]
+    - principal: "vis-reader-all"
+      role: "reader"
+      groups: ["*"]
+    - principal: "vis-writer-alpha"
+      role: "writer"
+      groups: ["rbac-alpha"]
+`
+
+const visibilityUsersOnlyYAML = `
+users:
+  - username: "vis-reader-alpha"
+    password: "reader-alpha-secret"
+`
+
+// TestSchemaR3_AllowsAnyReportsHoldingAPermissionSomewhere proves the visibility half of R3 at the
+// snapshot seam. A method whose resource set is the whole deployment cannot ask "does this
+// principal hold the permission for group X" before its handler has produced the groups, so
+// the snapshot must answer the weaker question first: does the principal hold it anywhere.
+// Every want below is read off the bindings in the fixture above.
+func TestSchemaR3_AllowsAnyReportsHoldingAPermissionSomewhere(t *testing.T) {
+	snapshot := compile(t, 1, visibilityPolicyYAML)
+
+	for _, tc := range []struct {
+		username string
+		password string
+		perm     auth.Permission
+		want     bool
+	}{
+		// An exact-scope grant is a grant: the reader holds schema:read, on one group.
+		{username: "vis-reader-alpha", password: "reader-alpha-secret", perm: auth.PermissionSchemaRead, want: true},
+		// It is still not a wildcard grant, which Allows with no group asks for.
+		{username: "vis-reader-alpha", password: "reader-alpha-secret", perm: auth.PermissionSchemaWrite, want: false},
+		{username: "vis-reader-alpha", password: "reader-alpha-secret", perm: auth.PermissionClusterRead, want: false},
+		{username: "vis-reader-all", password: "reader-all-secret", perm: auth.PermissionSchemaRead, want: true},
+		{username: "vis-reader-all", password: "reader-all-secret", perm: auth.PermissionSchemaWrite, want: false},
+		{username: "vis-writer-alpha", password: "writer-alpha-secret", perm: auth.PermissionSchemaRead, want: true},
+		{username: "vis-writer-alpha", password: "writer-alpha-secret", perm: auth.PermissionSchemaWrite, want: true},
+		{username: "vis-writer-alpha", password: "writer-alpha-secret", perm: auth.PermissionClusterAdmin, want: false},
+		// An authenticated principal with no binding holds nothing anywhere.
+		{username: "vis-unbound", password: "unbound-secret", perm: auth.PermissionSchemaRead, want: false},
+		{username: "vis-unbound", password: "unbound-secret", perm: auth.PermissionDataRead, want: false},
+	} {
+		user := principal(t, snapshot, tc.username, tc.password)
+		if got := snapshot.AllowsAny(user, tc.perm); got != tc.want {
+			t.Errorf("AllowsAny(%s, %q) = %v, want %v", tc.username, tc.perm, got, tc.want)
+		}
+	}
+
+	t.Run("the zero principal holds nothing", func(t *testing.T) {
+		for _, perm := range auth.Permissions() {
+			if snapshot.AllowsAny(auth.Principal{}, perm) {
+				t.Errorf("AllowsAny(zero principal, %q) = true, want false", perm)
+			}
+		}
+	})
+
+	t.Run("an exact grant that Allows one group is reported by both", func(t *testing.T) {
+		reader := principal(t, snapshot, "vis-reader-alpha", "reader-alpha-secret")
+		if !snapshot.Allows(reader, auth.PermissionSchemaRead, "rbac-alpha") {
+			t.Error("Allows(vis-reader-alpha, schema:read, rbac-alpha) = false, want true for its bound group")
+		}
+		if snapshot.Allows(reader, auth.PermissionSchemaRead, "rbac-beta") {
+			t.Error("Allows(vis-reader-alpha, schema:read, rbac-beta) = true, want false outside its bound group")
+		}
+		if !snapshot.AllowsAny(reader, auth.PermissionSchemaRead) {
+			t.Error("AllowsAny(vis-reader-alpha, schema:read) = false, want true because one group is bound")
+		}
+	})
+
+	t.Run("a users-only policy grants nothing anywhere", func(t *testing.T) {
+		usersOnly := compile(t, 2, visibilityUsersOnlyYAML)
+		reader := principal(t, usersOnly, "vis-reader-alpha", "reader-alpha-secret")
+		for _, perm := range auth.Permissions() {
+			if usersOnly.AllowsAny(reader, perm) {
+				t.Errorf("AllowsAny(%q) = true with RBAC disabled, want false", perm)
+			}
+		}
+	})
+}

--- a/test/e2e-v2/cases/rbac/check-rbac-schema.sh
+++ b/test/e2e-v2/cases/rbac/check-rbac-schema.sh
@@ -1,0 +1,270 @@
+#!/usr/bin/env bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The schema stage of the direct standalone RBAC case, owning the schema-bootstrap half of
+# E-DIR-01 and the Group.List/schema half of E-DIR-04 for issue #14015. It provisions the
+# alpha/beta fixture as the administrator, waits for it through the protected SchemaBarrier
+# API rather than by sleeping, and then drives the scoped CRUD/List/Exist matrix over both
+# direct gRPC and the bound grpc-gateway routes against a deployed container.
+#
+# It runs before check-rbac.sh, which finishes by rewriting the mounted policy to a revoked
+# and then a malformed revision.
+
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 <grpc> <http>" >&2
+  exit 2
+fi
+
+grpc_addr=$1
+http_addr=$2
+descriptor_set=${RBAC_DESCRIPTOR_SET:-/tmp/rbac-api.bin}
+work_dir=$(mktemp -d)
+trap 'rm -rf "${work_dir}"' EXIT
+
+alpha=alpha
+beta=beta
+gamma=gamma
+alpha_marker=alpha_marker
+beta_marker=beta_marker
+
+group_get=banyandb.database.v1.GroupRegistryService/Get
+group_exist=banyandb.database.v1.GroupRegistryService/Exist
+group_create=banyandb.database.v1.GroupRegistryService/Create
+group_update=banyandb.database.v1.GroupRegistryService/Update
+group_list=banyandb.database.v1.GroupRegistryService/List
+measure_create=banyandb.database.v1.MeasureRegistryService/Create
+measure_get=banyandb.database.v1.MeasureRegistryService/Get
+measure_exist=banyandb.database.v1.MeasureRegistryService/Exist
+measure_list=banyandb.database.v1.MeasureRegistryService/List
+measure_delete=banyandb.database.v1.MeasureRegistryService/Delete
+await_applied=banyandb.schema.v1.SchemaBarrierService/AwaitSchemaApplied
+await_revision=banyandb.schema.v1.SchemaBarrierService/AwaitRevisionApplied
+measure_query=banyandb.measure.v1.MeasureService/Query
+
+fail() {
+  echo "$*" >&2
+  exit 1
+}
+
+# grpc_call runs one RPC and asserts the status code. The payload is passed on stdin so a
+# JSON body containing spaces or braces survives.
+grpc_call() {
+  local expected_code=$1
+  local username=$2
+  local password=$3
+  local method=$4
+  local payload=${5:-{\}}
+  local output_file="${work_dir}/grpc-$(echo "${method}" | tr '/.' '--')-${expected_code}-$RANDOM.log"
+  local -a auth_args=()
+  local exit_code
+
+  if [[ -n ${username} ]]; then
+    auth_args=(-H "username: ${username}" -H "password: ${password}")
+  fi
+  set +e
+  printf '%s\n' "${payload}" | timeout 30s grpcurl -plaintext -protoset "${descriptor_set}" \
+    "${auth_args[@]}" -d @ "${grpc_addr}" "${method}" >"${output_file}" 2>&1
+  exit_code=$?
+  set -e
+
+  if [[ ${expected_code} == OK ]]; then
+    [[ ${exit_code} -eq 0 ]] || { cat "${output_file}" >&2; fail "${method}: expected OK, grpcurl exited ${exit_code}"; }
+    cat "${output_file}"
+    return
+  fi
+  if [[ ${exit_code} -eq 0 ]] || ! grep -Fq "Code: ${expected_code}" "${output_file}"; then
+    cat "${output_file}" >&2
+    fail "${method}: expected ${expected_code}"
+  fi
+}
+
+http_call() {
+  local expected_status=$1
+  local username=$2
+  local password=$3
+  local method=$4
+  local path=$5
+  local body=${6:-}
+  local response_file="${work_dir}/http-${expected_status}-$(echo "${path}" | tr '/' '-')-$RANDOM.body"
+  local -a auth_args=()
+  local -a body_args=()
+  local actual_status
+
+  if [[ -n ${username} ]]; then
+    auth_args=(--user "${username}:${password}")
+  fi
+  if [[ -n ${body} ]]; then
+    body_args=(--header 'Content-Type: application/json' --data "${body}")
+  fi
+  actual_status=$(curl --silent --show-error --output "${response_file}" --write-out '%{http_code}' \
+    --request "${method}" "${auth_args[@]}" "${body_args[@]}" "http://${http_addr}${path}")
+  [[ ${actual_status} == "${expected_status}" ]] || {
+    cat "${response_file}" >&2
+    fail "${path}: expected HTTP ${expected_status}, got ${actual_status}"
+  }
+  cat "${response_file}"
+}
+
+group_body() {
+  printf '{"group":{"metadata":{"name":"%s"},"catalog":"CATALOG_MEASURE","resourceOpts":{"shardNum":1,' "$1"
+  printf '"segmentInterval":{"unit":"UNIT_DAY","num":1},"ttl":{"unit":"UNIT_DAY","num":7}}}}'
+}
+
+measure_body() {
+  printf '{"measure":{"metadata":{"group":"%s","name":"%s"},"entity":{"tagNames":["id"]},' "$1" "$2"
+  printf '"tagFamilies":[{"name":"default","tags":[{"name":"id","type":"TAG_TYPE_STRING"}]}],'
+  printf '"fields":[{"name":"value","fieldType":"FIELD_TYPE_INT","encodingMethod":"ENCODING_METHOD_GORILLA",'
+  printf '"compressionMethod":"COMPRESSION_METHOD_ZSTD"}]}}'
+}
+
+# ---------------------------------------------------------------------------
+# Bootstrap: the administrator provisions both groups and one measure in each,
+# then waits for them through the protected barrier API. No sleeps.
+# ---------------------------------------------------------------------------
+for group in "${alpha}" "${beta}"; do
+  grpc_call OK bydb-admin admin-secret "${group_create}" "$(group_body "${group}")" >/dev/null
+done
+grpc_call OK bydb-admin admin-secret "${measure_create}" "$(measure_body "${alpha}" "${alpha_marker}")" >/dev/null
+grpc_call OK bydb-admin admin-secret "${measure_create}" "$(measure_body "${beta}" "${beta_marker}")" >/dev/null
+
+barrier_keys=$(printf '{"keys":[{"kind":"group","name":"%s"},{"kind":"group","name":"%s"},' "${alpha}" "${beta}")
+barrier_keys+=$(printf '{"kind":"measure","group":"%s","name":"%s"},' "${alpha}" "${alpha_marker}")
+barrier_keys+=$(printf '{"kind":"measure","group":"%s","name":"%s"}],' "${beta}" "${beta_marker}")
+barrier_keys+='"minRevisions":["0","0","0","0"]}'
+applied=$(grpc_call OK bydb-admin admin-secret "${await_applied}" "${barrier_keys}")
+grep -Fq '"applied": true' <<<"${applied}" || fail "the fixture schema did not converge through AwaitSchemaApplied"
+
+# ---------------------------------------------------------------------------
+# Scoped reads: the exact reader sees alpha and is denied beta; the wildcard
+# reader sees both; an unauthorized Exist is denied rather than answered false.
+# ---------------------------------------------------------------------------
+grpc_call OK bydb-reader reader-secret "${group_get}" "{\"group\":\"${alpha}\"}" >/dev/null
+grpc_call PermissionDenied bydb-reader reader-secret "${group_get}" "{\"group\":\"${beta}\"}"
+grpc_call OK bydb-reader-all reader-all-secret "${group_get}" "{\"group\":\"${beta}\"}" >/dev/null
+grpc_call PermissionDenied bydb-auth-only auth-only-secret "${group_get}" "{\"group\":\"${alpha}\"}"
+
+grpc_call OK bydb-reader reader-secret "${group_exist}" "{\"group\":\"${alpha}\"}" >/dev/null
+grpc_call PermissionDenied bydb-reader reader-secret "${group_exist}" "{\"group\":\"${beta}\"}"
+
+grpc_call OK bydb-reader reader-secret "${measure_list}" "{\"group\":\"${alpha}\"}" >/dev/null
+grpc_call PermissionDenied bydb-reader reader-secret "${measure_list}" "{\"group\":\"${beta}\"}"
+grpc_call OK bydb-reader reader-secret "${measure_get}" \
+  "{\"metadata\":{\"group\":\"${alpha}\",\"name\":\"${alpha_marker}\"}}" >/dev/null
+grpc_call PermissionDenied bydb-reader reader-secret "${measure_exist}" \
+  "{\"metadata\":{\"group\":\"${beta}\",\"name\":\"${beta_marker}\"}}"
+
+# A request carrying no resolvable group is malformed, not unauthorized.
+grpc_call InvalidArgument bydb-admin admin-secret "${group_get}" '{}'
+grpc_call InvalidArgument bydb-admin admin-secret "${measure_create}" '{}'
+
+# ---------------------------------------------------------------------------
+# Scoped writes: the exact writer mutates alpha only, and a denied mutation
+# leaves the preloaded schema exactly as the administrator can still observe it.
+# ---------------------------------------------------------------------------
+grpc_call PermissionDenied bydb-reader reader-secret "${measure_create}" "$(measure_body "${alpha}" "reader_marker")"
+grpc_call PermissionDenied bydb-writer writer-secret "${measure_create}" "$(measure_body "${beta}" "writer_marker")"
+for absent in reader_marker writer_marker; do
+  for group in "${alpha}" "${beta}"; do
+    exists=$(grpc_call OK bydb-admin admin-secret "${measure_exist}" \
+      "{\"metadata\":{\"group\":\"${group}\",\"name\":\"${absent}\"}}")
+    grep -Fq '"hasMeasure": true' <<<"${exists}" && fail "a denied create left ${group}/${absent} behind"
+  done
+done
+grpc_call OK bydb-writer writer-secret "${measure_create}" "$(measure_body "${alpha}" "writer_marker")" >/dev/null
+
+# A dedicated resource proves the delete path so alpha_marker stays available to the read and
+# transport assertions below.
+grpc_call OK bydb-admin admin-secret "${measure_create}" "$(measure_body "${alpha}" "alpha_doomed")" >/dev/null
+grpc_call PermissionDenied bydb-reader reader-secret "${measure_delete}" \
+  "{\"metadata\":{\"group\":\"${alpha}\",\"name\":\"alpha_doomed\"}}"
+still_there=$(grpc_call OK bydb-admin admin-secret "${measure_exist}" \
+  "{\"metadata\":{\"group\":\"${alpha}\",\"name\":\"alpha_doomed\"}}")
+grep -Fq '"hasMeasure": true' <<<"${still_there}" || fail "a denied delete removed ${alpha}/alpha_doomed"
+deleted=$(grpc_call OK bydb-writer writer-secret "${measure_delete}" \
+  "{\"metadata\":{\"group\":\"${alpha}\",\"name\":\"alpha_doomed\"}}")
+grep -Fq '"deleted": true' <<<"${deleted}" || fail "the alpha writer could not delete its own measure"
+
+# Group upserts are scoped by the group body name, so a writer bound to a group that does not
+# exist yet may bootstrap it, and only it.
+grpc_call PermissionDenied bydb-reader reader-secret "${group_create}" "$(group_body "${gamma}")"
+grpc_call PermissionDenied bydb-writer writer-secret "${group_create}" "$(group_body "${gamma}")"
+grpc_call OK bydb-writer-gamma writer-gamma-secret "${group_create}" "$(group_body "${gamma}")" >/dev/null
+grpc_call OK bydb-writer-gamma writer-gamma-secret "${group_update}" "$(group_body "${gamma}")" >/dev/null
+grpc_call PermissionDenied bydb-writer-gamma writer-gamma-secret "${group_update}" "$(group_body "${alpha}")"
+
+# ---------------------------------------------------------------------------
+# Group.List visibility, over gRPC and over the bound gateway route.
+# ---------------------------------------------------------------------------
+reader_list=$(grpc_call OK bydb-reader reader-secret "${group_list}" '{}')
+grep -Fq "\"${alpha}\"" <<<"${reader_list}" || fail "the alpha reader's Group.List omits ${alpha}"
+grep -Fq "\"${beta}\"" <<<"${reader_list}" && fail "the alpha reader's Group.List leaks ${beta}"
+grep -Fq "\"${gamma}\"" <<<"${reader_list}" && fail "the alpha reader's Group.List leaks ${gamma}"
+
+admin_list=$(grpc_call OK bydb-admin admin-secret "${group_list}" '{}')
+for group in "${alpha}" "${beta}" "${gamma}"; do
+  grep -Fq "\"${group}\"" <<<"${admin_list}" || fail "the wildcard administrator's Group.List omits ${group}"
+done
+grpc_call PermissionDenied bydb-auth-only auth-only-secret "${group_list}" '{}'
+
+http_reader_list=$(http_call 200 bydb-reader reader-secret GET /api/v1/group/schema/lists '')
+grep -Fq "\"${alpha}\"" <<<"${http_reader_list}" || fail "the alpha reader's HTTP Group.List omits ${alpha}"
+grep -Fq "\"name\":\"${beta}\"" <<<"${http_reader_list}" && fail "the alpha reader's HTTP Group.List leaks ${beta}"
+http_call 403 bydb-auth-only auth-only-secret GET /api/v1/group/schema/lists ''
+
+# ---------------------------------------------------------------------------
+# Transport parity: every bound gateway route reaches the same decision, and
+# 401, 400 and 403 stay distinguishable.
+# ---------------------------------------------------------------------------
+http_call 200 bydb-reader reader-secret GET "/api/v1/group/schema/${alpha}" '' >/dev/null
+http_call 403 bydb-reader reader-secret GET "/api/v1/group/schema/${beta}" '' >/dev/null
+http_call 401 bydb-reader wrong-password GET "/api/v1/group/schema/${alpha}" '' >/dev/null
+http_call 200 bydb-reader reader-secret GET "/api/v1/measure/schema/lists/${alpha}" '' >/dev/null
+http_call 403 bydb-reader reader-secret GET "/api/v1/measure/schema/lists/${beta}" '' >/dev/null
+http_call 200 bydb-reader reader-secret GET "/api/v1/measure/schema/${alpha}/${alpha_marker}" '' >/dev/null
+http_call 403 bydb-reader reader-secret GET "/api/v1/measure/schema/${beta}/${beta_marker}" '' >/dev/null
+http_call 403 bydb-writer writer-secret POST /api/v1/measure/schema "$(measure_body "${beta}" "http_marker")" >/dev/null
+http_call 200 bydb-writer writer-secret POST /api/v1/measure/schema "$(measure_body "${alpha}" "http_marker")" >/dev/null
+http_call 403 bydb-writer writer-secret DELETE "/api/v1/measure/schema/${beta}/${beta_marker}" '' >/dev/null
+beta_intact=$(grpc_call OK bydb-admin admin-secret "${measure_exist}" \
+  "{\"metadata\":{\"group\":\"${beta}\",\"name\":\"${beta_marker}\"}}")
+grep -Fq '"hasMeasure": true' <<<"${beta_intact}" || fail "a denied HTTP delete removed ${beta}/${beta_marker}"
+
+# ---------------------------------------------------------------------------
+# SchemaBarrier scope: key waits need every resolved group; the cluster-wide
+# revision wait needs a wildcard schema read.
+# ---------------------------------------------------------------------------
+alpha_key=$(printf '{"keys":[{"kind":"group","name":"%s"}],"minRevisions":["0"]}' "${alpha}")
+both_keys=$(printf '{"keys":[{"kind":"group","name":"%s"},{"kind":"group","name":"%s"}],"minRevisions":["0","0"]}' \
+  "${alpha}" "${beta}")
+grpc_call OK bydb-reader reader-secret "${await_applied}" "${alpha_key}" >/dev/null
+grpc_call PermissionDenied bydb-reader reader-secret "${await_applied}" "${both_keys}"
+grpc_call OK bydb-reader-all reader-all-secret "${await_applied}" "${both_keys}" >/dev/null
+grpc_call PermissionDenied bydb-reader reader-secret "${await_revision}" '{"minRevision":"0"}'
+revision=$(grpc_call OK bydb-reader-all reader-all-secret "${await_revision}" '{"minRevision":"0"}')
+grep -Fq '"applied": true' <<<"${revision}" || fail "revision zero must be a real allow case for a wildcard reader"
+
+# ---------------------------------------------------------------------------
+# Activating the schema families must not activate a data one.
+# ---------------------------------------------------------------------------
+grpc_call PermissionDenied bydb-admin admin-secret "${measure_query}" \
+  "{\"groups\":[\"${alpha}\"],\"name\":\"${alpha_marker}\"}"
+http_call 403 bydb-admin admin-secret POST /api/v1/measure/data \
+  "{\"groups\":[\"${alpha}\"],\"name\":\"${alpha_marker}\"}" >/dev/null
+
+printf 'status: success\n'

--- a/test/e2e-v2/cases/rbac/check-rbac-schema.sh
+++ b/test/e2e-v2/cases/rbac/check-rbac-schema.sh
@@ -121,32 +121,6 @@ http_call() {
   cat "${response_file}"
 }
 
-# wait_for_schema_api proves the authenticated schema path is ready before the
-# stateful fixture starts. Retrying the complete verifier would replay mutations
-# and turn the real failure into AlreadyExists on the next attempt.
-wait_for_schema_api() {
-  local output_file="${work_dir}/schema-readiness.log"
-  local deadline=$((SECONDS + 60))
-  local exit_code
-
-  while true; do
-    set +e
-    printf '{}\n' | timeout 5s grpcurl -plaintext -protoset "${descriptor_set}" \
-      -H 'username: bydb-admin' -H 'password: admin-secret' -d @ \
-      "${grpc_addr}" "${group_list}" >"${output_file}" 2>&1
-    exit_code=$?
-    set -e
-    if [[ ${exit_code} -eq 0 ]]; then
-      return
-    fi
-    if ((SECONDS >= deadline)); then
-      cat "${output_file}" >&2
-      fail "${group_list}: schema API did not become ready"
-    fi
-    sleep 1
-  done
-}
-
 group_body() {
   printf '{"group":{"metadata":{"name":"%s"},"catalog":"CATALOG_MEASURE","resourceOpts":{"shardNum":1,' "$1"
   printf '"segmentInterval":{"unit":"UNIT_DAY","num":1},"ttl":{"unit":"UNIT_DAY","num":7}}}}'
@@ -163,7 +137,6 @@ measure_body() {
 # Bootstrap: the administrator provisions both groups and one measure in each,
 # then waits for them through the protected barrier API. No sleeps.
 # ---------------------------------------------------------------------------
-wait_for_schema_api
 for group in "${alpha}" "${beta}"; do
   grpc_call OK bydb-admin admin-secret "${group_create}" "$(group_body "${group}")" >/dev/null
 done
@@ -252,7 +225,7 @@ grpc_call PermissionDenied bydb-auth-only auth-only-secret "${group_list}" '{}'
 http_reader_list=$(http_call 200 bydb-reader reader-secret GET /api/v1/group/schema/lists '')
 grep -Fq "\"${alpha}\"" <<<"${http_reader_list}" || fail "the alpha reader's HTTP Group.List omits ${alpha}"
 grep -Fq "\"name\":\"${beta}\"" <<<"${http_reader_list}" && fail "the alpha reader's HTTP Group.List leaks ${beta}"
-http_call 403 bydb-auth-only auth-only-secret GET /api/v1/group/schema/lists ''
+http_call 403 bydb-auth-only auth-only-secret GET /api/v1/group/schema/lists '' >/dev/null
 
 # ---------------------------------------------------------------------------
 # Transport parity: every bound gateway route reaches the same decision, and

--- a/test/e2e-v2/cases/rbac/check-rbac-schema.sh
+++ b/test/e2e-v2/cases/rbac/check-rbac-schema.sh
@@ -121,6 +121,32 @@ http_call() {
   cat "${response_file}"
 }
 
+# wait_for_schema_api proves the authenticated schema path is ready before the
+# stateful fixture starts. Retrying the complete verifier would replay mutations
+# and turn the real failure into AlreadyExists on the next attempt.
+wait_for_schema_api() {
+  local output_file="${work_dir}/schema-readiness.log"
+  local deadline=$((SECONDS + 60))
+  local exit_code
+
+  while true; do
+    set +e
+    printf '{}\n' | timeout 5s grpcurl -plaintext -protoset "${descriptor_set}" \
+      -H 'username: bydb-admin' -H 'password: admin-secret' -d @ \
+      "${grpc_addr}" "${group_list}" >"${output_file}" 2>&1
+    exit_code=$?
+    set -e
+    if [[ ${exit_code} -eq 0 ]]; then
+      return
+    fi
+    if ((SECONDS >= deadline)); then
+      cat "${output_file}" >&2
+      fail "${group_list}: schema API did not become ready"
+    fi
+    sleep 1
+  done
+}
+
 group_body() {
   printf '{"group":{"metadata":{"name":"%s"},"catalog":"CATALOG_MEASURE","resourceOpts":{"shardNum":1,' "$1"
   printf '"segmentInterval":{"unit":"UNIT_DAY","num":1},"ttl":{"unit":"UNIT_DAY","num":7}}}}'
@@ -137,6 +163,7 @@ measure_body() {
 # Bootstrap: the administrator provisions both groups and one measure in each,
 # then waits for them through the protected barrier API. No sleeps.
 # ---------------------------------------------------------------------------
+wait_for_schema_api
 for group in "${alpha}" "${beta}"; do
   grpc_call OK bydb-admin admin-secret "${group_create}" "$(group_body "${group}")" >/dev/null
 done

--- a/test/e2e-v2/cases/rbac/check-rbac.sh
+++ b/test/e2e-v2/cases/rbac/check-rbac.sh
@@ -186,7 +186,7 @@ assert_bounded_decision_labels() {
       *) fail "unbounded RBAC permission label: ${permission}" ;;
     esac
     case ${reason} in
-      granted|unauthenticated|permission_missing|executor_unavailable|health_exempt) ;;
+      granted|unauthenticated|permission_missing|executor_unavailable|health_exempt|invalid_request) ;;
       *) fail "unbounded RBAC reason label: ${reason}" ;;
     esac
     if grep -Eq '(username|password|principal|role|group)=' <<<"${line}"; then
@@ -244,7 +244,9 @@ expect_http 200 bydb-admin admin-secret POST /api/v1/snapshot '{}'
 after_http_snapshot=$(snapshot_fingerprint "${container_id}")
 [[ ${after_http_snapshot} != "${after_grpc_snapshot}" ]] || fail "allowed HTTP Snapshot created no filesystem artifact"
 
-expect_grpc PermissionDenied bydb-admin admin-secret "${group_list}"
+# Group.List is decided by the schema executor issue #14015 activates: a wildcard
+# administrator is allowed and its response carries every group.
+expect_grpc OK bydb-admin admin-secret "${group_list}"
 expect_grpc PermissionDenied bydb-admin admin-secret "${stream_write}"
 for fallback_method in "${internal_query}" "${stream_delete}" "${measure_delete}" "${trace_delete}"; do
   expect_grpc Unimplemented bydb-admin admin-secret "${fallback_method}"
@@ -256,7 +258,7 @@ expect_http 401 bydb-admin wrong-password GET /api/v1/cluster/state ''
 expect_http 403 bydb-auth-only auth-only-secret GET /api/v1/cluster/state ''
 expect_http 403 bydb-reader reader-secret GET /api/v1/cluster/state ''
 expect_http 200 bydb-admin admin-secret GET /api/v1/cluster/state ''
-expect_http 403 bydb-admin admin-secret GET /api/v1/group/schema/lists ''
+expect_http 200 bydb-admin admin-secret GET /api/v1/group/schema/lists ''
 expect_http 403 bydb-reader reader-secret GET /api/v1/cluster/state '' \
   --header 'Grpc-Metadata-Username: bydb-admin' --header 'Grpc-Metadata-Password: admin-secret'
 
@@ -280,7 +282,7 @@ assert_metric_delta "${before_metrics}" "${after_metrics}" 2 "${decision_metric}
 assert_metric_delta "${before_metrics}" "${after_metrics}" 2 "${decision_metric}" \
   'method="banyandb.database.v1.SnapshotService/Snapshot"' 'decision="allow"' 'reason="granted"'
 assert_metric_delta "${before_metrics}" "${after_metrics}" 2 "${decision_metric}" \
-  'method="banyandb.database.v1.GroupRegistryService/List"' 'decision="deny"' 'reason="executor_unavailable"'
+  'method="banyandb.database.v1.GroupRegistryService/List"' 'decision="allow"' 'reason="granted"'
 assert_metric_delta "${before_metrics}" "${after_metrics}" 1 "${decision_metric}" \
   'method="banyandb.stream.v1.StreamService/Write"' 'decision="deny"' 'reason="executor_unavailable"'
 for fallback_method in "${internal_query}" "${stream_delete}" "${measure_delete}" "${trace_delete}"; do

--- a/test/e2e-v2/cases/rbac/e2e.yaml
+++ b/test/e2e-v2/cases/rbac/e2e.yaml
@@ -39,6 +39,14 @@ verify:
     count: 1
     interval: 5s
   cases:
+    # The schema stage runs first: check-rbac.sh finishes by rewriting the mounted
+    # policy to a revoked and then a malformed revision, which the schema matrix
+    # must not observe.
+    - query: >-
+        bash test/e2e-v2/cases/rbac/check-rbac-schema.sh
+        ${banyandb_host}:${banyandb_17912}
+        ${banyandb_host}:${banyandb_17913}
+      expected: expected/success.yaml
     - query: >-
         bash test/e2e-v2/cases/rbac/check-rbac.sh
         ${banyandb_host}:${banyandb_17912}

--- a/test/e2e-v2/cases/rbac/e2e.yaml
+++ b/test/e2e-v2/cases/rbac/e2e.yaml
@@ -36,8 +36,7 @@ verify:
   retry:
     # This case validates exact metric deltas and live reload state, so it must
     # execute once rather than replay a stateful sequence after an assertion.
-    count: 1
-    interval: 5s
+    count: 0
   cases:
     # The schema stage runs first: check-rbac.sh finishes by rewriting the mounted
     # policy to a revoked and then a malformed revision, which the schema matrix

--- a/test/e2e-v2/cases/rbac/security.yaml
+++ b/test/e2e-v2/cases/rbac/security.yaml
@@ -18,6 +18,12 @@ users:
     password: admin-secret
   - username: bydb-reader
     password: reader-secret
+  - username: bydb-reader-all
+    password: reader-all-secret
+  - username: bydb-writer
+    password: writer-secret
+  - username: bydb-writer-gamma
+    password: writer-gamma-secret
   - username: bydb-auth-only
     password: auth-only-secret
 
@@ -31,3 +37,14 @@ rbac:
     - principal: bydb-reader
       role: reader
       groups: [alpha]
+    - principal: bydb-reader-all
+      role: reader
+      groups: ["*"]
+    - principal: bydb-writer
+      role: writer
+      groups: [alpha]
+    # Bound to a group the fixture does not provision, so the schema stage can prove a
+    # service account bootstrapping the group it needs without cluster administration.
+    - principal: bydb-writer-gamma
+      role: writer
+      groups: [gamma]

--- a/test/integration/standalone/other/rbac/rbac_global_test.go
+++ b/test/integration/standalone/other/rbac/rbac_global_test.go
@@ -287,18 +287,15 @@ var _ = g.Describe("rbac-global authorization through the real liaison", func() 
 			"bydb-reader must be stopped before the InternalQuery fallback")
 	})
 
-	// R6: schema and data permissions have no activated executor in this release, so every
-	// method carrying one fails closed for every actor, admin included.
-	g.It("fails closed on every not-yet-activated schema and data method", func() {
+	// R6: data permissions still have no activated executor in this release, so every
+	// method carrying one fails closed for every actor, admin included. Schema methods
+	// are exercised by the rbac_schema suite now that their executor is active.
+	g.It("fails closed on every not-yet-activated data method", func() {
 		measure := measurev1.NewMeasureServiceClient(conn)
-		groups := databasev1.NewGroupRegistryServiceClient(conn)
 		for _, a := range []actor{adminActor, monitorActor, readerActor, writerActor, unboundActor} {
 			_, err := measure.Query(a.ctx(), &measurev1.QueryRequest{})
 			gm.Expect(status.Code(err)).To(gm.Equal(codes.PermissionDenied),
 				"%s must fail closed on MeasureService/Query", a.name)
-			_, err = groups.List(a.ctx(), &databasev1.GroupRegistryServiceListRequest{})
-			gm.Expect(status.Code(err)).To(gm.Equal(codes.PermissionDenied),
-				"%s must fail closed on GroupRegistryService/List", a.name)
 		}
 	})
 

--- a/test/integration/standalone/other/rbac_schema/rbac_schema_http_impl_test.go
+++ b/test/integration/standalone/other/rbac_schema/rbac_schema_http_impl_test.go
@@ -1,0 +1,63 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with this work for additional
+// information regarding copyright ownership. The ASF licenses this file to You under
+// the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+// ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+
+package rbacschema_test
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+
+	g "github.com/onsi/ginkgo/v2"
+	gm "github.com/onsi/gomega"
+
+	"github.com/apache/skywalking-banyandb/pkg/test"
+	"github.com/apache/skywalking-banyandb/pkg/test/setup"
+)
+
+var _ = g.Describe("rbac-schema HTTP malformed request", func() {
+	var (
+		httpAddr string
+		cleanup  func()
+	)
+
+	g.BeforeEach(func() {
+		dataRoot, releaseSpace, spaceErr := test.NewSpace()
+		gm.Expect(spaceErr).NotTo(gm.HaveOccurred())
+
+		policyFile := filepath.Join(dataRoot, "security.yaml")
+		writeErr := os.WriteFile(policyFile, []byte(schemaPolicy), 0o600)
+		gm.Expect(writeErr).NotTo(gm.HaveOccurred())
+
+		ports, portErr := test.AllocateFreePorts(5)
+		gm.Expect(portErr).NotTo(gm.HaveOccurred())
+
+		_, assignedHTTPAddr, closeServer := setup.EmptyClosableStandalone(nil, dataRoot, ports,
+			"--auth-config-file="+policyFile)
+		httpAddr = assignedHTTPAddr
+		cleanup = func() {
+			closeServer()
+			releaseSpace()
+		}
+	})
+
+	g.AfterEach(func() {
+		cleanup()
+	})
+
+	g.It("returns HTTP 400 for an authenticated malformed schema request", func() {
+		statusCode, responseBody := httpCall(httpAddr, http.MethodPost, "/api/v1/measure/schema", writerAlphaActor, "{}")
+		gm.Expect(statusCode).To(gm.Equal(http.StatusBadRequest),
+			"a nil measure body must stay malformed over HTTP: %s", responseBody)
+	})
+})

--- a/test/integration/standalone/other/rbac_schema/rbac_schema_suite_test.go
+++ b/test/integration/standalone/other/rbac_schema/rbac_schema_suite_test.go
@@ -1,0 +1,39 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package rbacschema holds the standalone integration proof of the liaison's group-scoped
+// schema authorization boundary.
+package rbacschema_test
+
+import (
+	"testing"
+
+	g "github.com/onsi/ginkgo/v2"
+	gm "github.com/onsi/gomega"
+
+	integration_standalone "github.com/apache/skywalking-banyandb/test/integration/standalone"
+)
+
+// TestRBACSchemaWorkflow is the workflow-level gate of issue #14015. It drives the whole
+// group-scoped schema lifecycle — Group point reads and upserts, group deletion, the seven
+// registry families, the filtered Group.List, and both SchemaBarrier scope forms — against a
+// real standalone liaison over generated gRPC clients and the bound grpc-gateway routes, and
+// turns GREEN only once rounds B1-B10 have all landed.
+func TestRBACSchemaWorkflow(t *testing.T) {
+	gm.RegisterFailHandler(g.Fail)
+	g.RunSpecs(t, "RBAC Schema Workflow Suite", g.Label(integration_standalone.Labels...))
+}

--- a/test/integration/standalone/other/rbac_schema/rbac_schema_test.go
+++ b/test/integration/standalone/other/rbac_schema/rbac_schema_test.go
@@ -1,0 +1,544 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package rbacschema_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	g "github.com/onsi/ginkgo/v2"
+	gm "github.com/onsi/gomega"
+	grpclib "google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	commonv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/common/v1"
+	databasev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
+	measurev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/measure/v1"
+	schemav1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/schema/v1"
+	clientauth "github.com/apache/skywalking-banyandb/pkg/auth"
+	"github.com/apache/skywalking-banyandb/pkg/test"
+	"github.com/apache/skywalking-banyandb/pkg/test/setup"
+)
+
+// The canonical fixture family of the #13994 design, narrowed to the actors issue #14015
+// needs: an operator administrator, an exact-scope writer and reader on alpha, a wildcard
+// reader, and an authenticated principal with no binding.
+const schemaPolicy = `
+users:
+  - username: "bydb-admin"
+    password: "admin-secret"
+  - username: "bydb-writer-alpha"
+    password: "writer-alpha-secret"
+  - username: "bydb-writer-gamma"
+    password: "writer-gamma-secret"
+  - username: "bydb-reader-alpha"
+    password: "reader-alpha-secret"
+  - username: "bydb-reader-all"
+    password: "reader-all-secret"
+  - username: "bydb-unbound"
+    password: "unbound-secret"
+rbac:
+  enabled: true
+  bindings:
+    - principal: "bydb-admin"
+      role: "admin"
+      groups: ["*"]
+    - principal: "bydb-writer-alpha"
+      role: "writer"
+      groups: ["alpha"]
+    - principal: "bydb-writer-gamma"
+      role: "writer"
+      groups: ["gamma"]
+    - principal: "bydb-reader-alpha"
+      role: "reader"
+      groups: ["alpha"]
+    - principal: "bydb-reader-all"
+      role: "reader"
+      groups: ["*"]
+`
+
+const (
+	groupAlpha   = "alpha"
+	groupBeta    = "beta"
+	groupGamma   = "gamma"
+	measureAlpha = "alpha_marker"
+	measureBeta  = "beta_marker"
+)
+
+type actor struct {
+	name     string
+	password string
+}
+
+var (
+	adminActor       = actor{name: "bydb-admin", password: "admin-secret"}
+	writerAlphaActor = actor{name: "bydb-writer-alpha", password: "writer-alpha-secret"}
+	writerGammaActor = actor{name: "bydb-writer-gamma", password: "writer-gamma-secret"}
+	readerAlphaActor = actor{name: "bydb-reader-alpha", password: "reader-alpha-secret"}
+	readerAllActor   = actor{name: "bydb-reader-all", password: "reader-all-secret"}
+	unboundActor     = actor{name: "bydb-unbound", password: "unbound-secret"}
+)
+
+func (a actor) ctx() context.Context {
+	return metadata.NewOutgoingContext(context.Background(),
+		metadata.Pairs("username", a.name, "password", a.password))
+}
+
+// measureGroup is the group body the fixture provisions. Both fixture groups are identical
+// apart from their name, so a scope leak shows up as the wrong group answering, not as a
+// resource that happens to be shaped differently.
+func measureGroup(name string) *commonv1.Group {
+	return &commonv1.Group{
+		Metadata: &commonv1.Metadata{Name: name},
+		Catalog:  commonv1.Catalog_CATALOG_MEASURE,
+		ResourceOpts: &commonv1.ResourceOpts{
+			ShardNum:        1,
+			SegmentInterval: &commonv1.IntervalRule{Unit: commonv1.IntervalRule_UNIT_DAY, Num: 1},
+			Ttl:             &commonv1.IntervalRule{Unit: commonv1.IntervalRule_UNIT_DAY, Num: 7},
+		},
+	}
+}
+
+func measureSchema(group, name string) *databasev1.Measure {
+	return &databasev1.Measure{
+		Metadata: &commonv1.Metadata{Group: group, Name: name},
+		Entity:   &databasev1.Entity{TagNames: []string{"id"}},
+		TagFamilies: []*databasev1.TagFamilySpec{{
+			Name: "default",
+			Tags: []*databasev1.TagSpec{{Name: "id", Type: databasev1.TagType_TAG_TYPE_STRING}},
+		}},
+		Fields: []*databasev1.FieldSpec{{
+			Name:              "value",
+			FieldType:         databasev1.FieldType_FIELD_TYPE_INT,
+			EncodingMethod:    databasev1.EncodingMethod_ENCODING_METHOD_GORILLA,
+			CompressionMethod: databasev1.CompressionMethod_COMPRESSION_METHOD_ZSTD,
+		}},
+	}
+}
+
+// httpCall issues one grpc-gateway request with Basic credentials and returns the status code
+// and body. Both are needed: a boolean "did it succeed" assertion cannot tell 401 from 403,
+// and the body is where a leaked group name would show up.
+func httpCall(httpAddr, method, path string, a actor, body string) (int, string) {
+	var reader io.Reader
+	if body != "" {
+		reader = bytes.NewReader([]byte(body))
+	}
+	req, err := http.NewRequestWithContext(context.Background(), method,
+		fmt.Sprintf("http://%s%s", httpAddr, path), reader)
+	gm.ExpectWithOffset(1, err).NotTo(gm.HaveOccurred())
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if a.name != "" {
+		req.Header.Set("Authorization", clientauth.GenerateBasicAuthHeader(a.name, a.password))
+	}
+	resp, doErr := http.DefaultClient.Do(req)
+	gm.ExpectWithOffset(1, doErr).NotTo(gm.HaveOccurred())
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	payload, readErr := io.ReadAll(resp.Body)
+	gm.ExpectWithOffset(1, readErr).NotTo(gm.HaveOccurred())
+	return resp.StatusCode, string(payload)
+}
+
+var _ = g.Describe("rbac-schema group-scoped schema authorization through the real liaison", func() {
+	var (
+		grpcAddr, httpAddr string
+		conn               *grpclib.ClientConn
+		groups             databasev1.GroupRegistryServiceClient
+		measures           databasev1.MeasureRegistryServiceClient
+		barrier            schemav1.SchemaBarrierServiceClient
+		deferFn            func()
+	)
+
+	g.BeforeEach(func() {
+		dataRoot, releaseSpace, spaceErr := test.NewSpace()
+		gm.Expect(spaceErr).NotTo(gm.HaveOccurred())
+
+		policyFile := filepath.Join(dataRoot, "security.yaml")
+		gm.Expect(os.WriteFile(policyFile, []byte(schemaPolicy), 0o600)).To(gm.Succeed())
+
+		ports, portErr := test.AllocateFreePorts(5)
+		gm.Expect(portErr).NotTo(gm.HaveOccurred())
+
+		var closeServer func()
+		grpcAddr, httpAddr, closeServer = setup.EmptyClosableStandalone(nil, dataRoot, ports,
+			"--auth-config-file="+policyFile)
+
+		var dialErr error
+		conn, dialErr = grpclib.NewClient(grpcAddr, grpclib.WithTransportCredentials(insecure.NewCredentials()))
+		gm.Expect(dialErr).NotTo(gm.HaveOccurred())
+		groups = databasev1.NewGroupRegistryServiceClient(conn)
+		measures = databasev1.NewMeasureRegistryServiceClient(conn)
+		barrier = schemav1.NewSchemaBarrierServiceClient(conn)
+
+		deferFn = func() {
+			_ = conn.Close()
+			closeServer()
+			releaseSpace()
+		}
+
+		// The administrator provisions the alpha/beta fixture before any role assertion, and
+		// waits for it through the protected SchemaBarrier API rather than by sleeping. This
+		// is itself part of the contract: a global administrator must be able to bootstrap the
+		// groups and child schemas its deployment needs without holding cluster administration.
+		for _, group := range []string{groupAlpha, groupBeta} {
+			_, createErr := groups.Create(adminActor.ctx(), &databasev1.GroupRegistryServiceCreateRequest{
+				Group: measureGroup(group),
+			})
+			gm.Expect(createErr).NotTo(gm.HaveOccurred(), "the administrator must be allowed to create group %s", group)
+		}
+		for group, name := range map[string]string{groupAlpha: measureAlpha, groupBeta: measureBeta} {
+			_, createErr := measures.Create(adminActor.ctx(), &databasev1.MeasureRegistryServiceCreateRequest{
+				Measure: measureSchema(group, name),
+			})
+			gm.Expect(createErr).NotTo(gm.HaveOccurred(), "the administrator must be allowed to create measure %s/%s", group, name)
+		}
+		_, barrierErr := barrier.AwaitSchemaApplied(adminActor.ctx(), &schemav1.AwaitSchemaAppliedRequest{
+			Keys: []*schemav1.SchemaKey{
+				{Kind: "group", Name: groupAlpha},
+				{Kind: "group", Name: groupBeta},
+				{Kind: "measure", Group: groupAlpha, Name: measureAlpha},
+				{Kind: "measure", Group: groupBeta, Name: measureBeta},
+			},
+			MinRevisions: []int64{0, 0, 0, 0},
+		})
+		gm.Expect(barrierErr).NotTo(gm.HaveOccurred(), "the administrator must be allowed to await the fixture schema")
+	})
+
+	g.AfterEach(func() {
+		deferFn()
+	})
+
+	// R1: an exact grant admits its own group and denies every other, a wildcard grant admits
+	// both, and an unauthorized existence check is denied rather than answered false. The
+	// expected codes are read off issue #14015's R1, not recomputed from the policy.
+	g.It("scopes Group and registry reads to the caller's exact groups", func() {
+		for _, a := range []actor{adminActor, writerAlphaActor, readerAlphaActor, readerAllActor} {
+			resp, err := groups.Get(a.ctx(), &databasev1.GroupRegistryServiceGetRequest{Group: groupAlpha})
+			gm.Expect(err).NotTo(gm.HaveOccurred(), "%s must read the alpha group", a.name)
+			gm.Expect(resp.GetGroup().GetMetadata().GetName()).To(gm.Equal(groupAlpha))
+		}
+		for _, a := range []actor{writerAlphaActor, readerAlphaActor} {
+			_, err := groups.Get(a.ctx(), &databasev1.GroupRegistryServiceGetRequest{Group: groupBeta})
+			gm.Expect(status.Code(err)).To(gm.Equal(codes.PermissionDenied), "%s must be denied the beta group", a.name)
+		}
+		_, unboundErr := groups.Get(unboundActor.ctx(), &databasev1.GroupRegistryServiceGetRequest{Group: groupAlpha})
+		gm.Expect(status.Code(unboundErr)).To(gm.Equal(codes.PermissionDenied), "an unbound principal must be denied")
+
+		// An unauthorized Exist must be denied, never answered false: false would tell the
+		// caller the resource is absent, which is a fact about a group it cannot see.
+		existResp, existErr := groups.Exist(readerAlphaActor.ctx(), &databasev1.GroupRegistryServiceExistRequest{Group: groupBeta})
+		gm.Expect(status.Code(existErr)).To(gm.Equal(codes.PermissionDenied),
+			"Exist on an unauthorized group must be denied, got response %v", existResp)
+
+		measureExist, measureExistErr := measures.Exist(readerAlphaActor.ctx(), &databasev1.MeasureRegistryServiceExistRequest{
+			Metadata: &commonv1.Metadata{Group: groupBeta, Name: measureBeta},
+		})
+		gm.Expect(status.Code(measureExistErr)).To(gm.Equal(codes.PermissionDenied),
+			"Exist on an unauthorized measure must be denied, got response %v", measureExist)
+
+		// R2's three structural families over a real registry: List by direct group, Get by
+		// metadata group, and the alpha reader denied both in beta.
+		listAlpha, listAlphaErr := measures.List(readerAlphaActor.ctx(), &databasev1.MeasureRegistryServiceListRequest{Group: groupAlpha})
+		gm.Expect(listAlphaErr).NotTo(gm.HaveOccurred(), "the alpha reader must list alpha measures")
+		gm.Expect(listAlpha.GetMeasure()).To(gm.HaveLen(1))
+		gm.Expect(listAlpha.GetMeasure()[0].GetMetadata().GetName()).To(gm.Equal(measureAlpha))
+
+		_, listBetaErr := measures.List(readerAlphaActor.ctx(), &databasev1.MeasureRegistryServiceListRequest{Group: groupBeta})
+		gm.Expect(status.Code(listBetaErr)).To(gm.Equal(codes.PermissionDenied), "the alpha reader must be denied beta measures")
+
+		getAlpha, getAlphaErr := measures.Get(readerAlphaActor.ctx(), &databasev1.MeasureRegistryServiceGetRequest{
+			Metadata: &commonv1.Metadata{Group: groupAlpha, Name: measureAlpha},
+		})
+		gm.Expect(getAlphaErr).NotTo(gm.HaveOccurred(), "the alpha reader must get an alpha measure")
+		gm.Expect(getAlpha.GetMeasure().GetMetadata().GetGroup()).To(gm.Equal(groupAlpha))
+	})
+
+	// R2: a request carrying no resolvable group is malformed, and authentication has already
+	// happened, so the caller sees InvalidArgument rather than an authorization outcome.
+	g.It("keeps validation precedence for requests carrying no group", func() {
+		_, emptyGroupErr := groups.Get(adminActor.ctx(), &databasev1.GroupRegistryServiceGetRequest{})
+		gm.Expect(status.Code(emptyGroupErr)).To(gm.Equal(codes.InvalidArgument),
+			"an empty group on a Group point read must be InvalidArgument")
+
+		_, nilBodyErr := measures.Create(adminActor.ctx(), &databasev1.MeasureRegistryServiceCreateRequest{})
+		gm.Expect(status.Code(nilBodyErr)).To(gm.Equal(codes.InvalidArgument),
+			"a create with no resource body must be InvalidArgument")
+
+		_, nilMetadataErr := measures.Get(adminActor.ctx(), &databasev1.MeasureRegistryServiceGetRequest{})
+		gm.Expect(status.Code(nilMetadataErr)).To(gm.Equal(codes.InvalidArgument),
+			"a get with no metadata must be InvalidArgument")
+
+		// The same holds when the caller would not have been allowed either way: a malformed
+		// request must not become a channel for learning what a scope check would have said.
+		_, unboundMalformedErr := groups.Get(unboundActor.ctx(), &databasev1.GroupRegistryServiceGetRequest{})
+		gm.Expect(status.Code(unboundMalformedErr)).To(gm.Equal(codes.InvalidArgument),
+			"an unbound principal's malformed request must be InvalidArgument too")
+	})
+
+	// R2/R3: Group upserts are scoped by Group.Metadata.Name, and a denied write leaves the
+	// preloaded schema exactly as it was. The absence check runs as the administrator, so it
+	// observes storage rather than the denied caller's own view of it.
+	g.It("scopes Group upserts by the group body name and leaves denied writes without effect", func() {
+		_, readerDeniedErr := groups.Create(readerAlphaActor.ctx(), &databasev1.GroupRegistryServiceCreateRequest{
+			Group: measureGroup(groupGamma),
+		})
+		gm.Expect(status.Code(readerDeniedErr)).To(gm.Equal(codes.PermissionDenied), "a reader must not create a group")
+
+		_, wrongScopeErr := groups.Create(writerAlphaActor.ctx(), &databasev1.GroupRegistryServiceCreateRequest{
+			Group: measureGroup(groupGamma),
+		})
+		gm.Expect(status.Code(wrongScopeErr)).To(gm.Equal(codes.PermissionDenied),
+			"the alpha writer must not create a group outside its scope")
+
+		// An exact scope is exact: a name that merely starts with the bound one is a different
+		// group and stays denied.
+		_, prefixErr := groups.Create(writerGammaActor.ctx(), &databasev1.GroupRegistryServiceCreateRequest{
+			Group: measureGroup(groupGamma + "-extra"),
+		})
+		gm.Expect(status.Code(prefixErr)).To(gm.Equal(codes.PermissionDenied),
+			"a group whose name only shares a prefix with the bound scope must be denied")
+
+		for _, absent := range []string{groupGamma, groupGamma + "-extra"} {
+			_, absentErr := groups.Get(adminActor.ctx(), &databasev1.GroupRegistryServiceGetRequest{Group: absent})
+			gm.Expect(absentErr).To(gm.HaveOccurred(), "denied create must leave %s absent", absent)
+			gm.Expect(status.Code(absentErr)).NotTo(gm.Equal(codes.OK))
+		}
+
+		// A writer bound to a group that does not exist yet may bootstrap it, which is what
+		// lets a service account initialize the groups it needs without cluster administration.
+		_, bootstrapErr := groups.Create(writerGammaActor.ctx(), &databasev1.GroupRegistryServiceCreateRequest{
+			Group: measureGroup(groupGamma),
+		})
+		gm.Expect(bootstrapErr).NotTo(gm.HaveOccurred(), "the gamma writer must be allowed to create its bound group")
+
+		// Update is scoped by the same body name, so the gamma writer may update gamma and
+		// nothing else.
+		_, gammaUpdateErr := groups.Update(writerGammaActor.ctx(), &databasev1.GroupRegistryServiceUpdateRequest{
+			Group: measureGroup(groupGamma),
+		})
+		gm.Expect(gammaUpdateErr).NotTo(gm.HaveOccurred(), "the gamma writer must be allowed to update its bound group")
+
+		_, alphaUpdateErr := groups.Update(writerGammaActor.ctx(), &databasev1.GroupRegistryServiceUpdateRequest{
+			Group: measureGroup(groupAlpha),
+		})
+		gm.Expect(status.Code(alphaUpdateErr)).To(gm.Equal(codes.PermissionDenied),
+			"the gamma writer must be denied an update to the alpha group")
+
+		// A denied registry mutation likewise leaves the resource untouched.
+		_, updateDeniedErr := measures.Update(readerAlphaActor.ctx(), &databasev1.MeasureRegistryServiceUpdateRequest{
+			Measure: measureSchema(groupAlpha, measureAlpha),
+		})
+		gm.Expect(status.Code(updateDeniedErr)).To(gm.Equal(codes.PermissionDenied), "a reader must not update a measure")
+
+		_, deleteDeniedErr := measures.Delete(readerAlphaActor.ctx(), &databasev1.MeasureRegistryServiceDeleteRequest{
+			Metadata: &commonv1.Metadata{Group: groupAlpha, Name: measureAlpha},
+		})
+		gm.Expect(status.Code(deleteDeniedErr)).To(gm.Equal(codes.PermissionDenied), "a reader must not delete a measure")
+
+		stillThere, stillThereErr := measures.Get(adminActor.ctx(), &databasev1.MeasureRegistryServiceGetRequest{
+			Metadata: &commonv1.Metadata{Group: groupAlpha, Name: measureAlpha},
+		})
+		gm.Expect(stillThereErr).NotTo(gm.HaveOccurred(), "the denied mutations must have left the measure in place")
+		gm.Expect(stillThere.GetMeasure().GetMetadata().GetName()).To(gm.Equal(measureAlpha))
+
+		// The writer within scope then succeeds on the same resource, which is what proves the
+		// denials above were authorization outcomes and not a broken fixture.
+		deleted, deleteErr := measures.Delete(writerAlphaActor.ctx(), &databasev1.MeasureRegistryServiceDeleteRequest{
+			Metadata: &commonv1.Metadata{Group: groupAlpha, Name: measureAlpha},
+		})
+		gm.Expect(deleteErr).NotTo(gm.HaveOccurred(), "the alpha writer must delete its own measure")
+		gm.Expect(deleted.GetDeleted()).To(gm.BeTrue())
+	})
+
+	// R3: Group.List admits any principal holding schema:read somewhere, rejects one holding
+	// it nowhere, and returns only the groups the caller's scopes cover. The expected lists
+	// are written out from the fixture bindings.
+	g.It("filters Group.List to the caller's visible groups", func() {
+		for _, tc := range []struct {
+			who  actor
+			want []string
+		}{
+			{who: adminActor, want: []string{groupAlpha, groupBeta}},
+			{who: readerAllActor, want: []string{groupAlpha, groupBeta}},
+			{who: readerAlphaActor, want: []string{groupAlpha}},
+			{who: writerAlphaActor, want: []string{groupAlpha}},
+		} {
+			resp, err := groups.List(tc.who.ctx(), &databasev1.GroupRegistryServiceListRequest{})
+			gm.Expect(err).NotTo(gm.HaveOccurred(), "%s must be allowed Group.List", tc.who.name)
+			names := make([]string, 0, len(resp.GetGroup()))
+			for _, group := range resp.GetGroup() {
+				names = append(names, group.GetMetadata().GetName())
+			}
+			for _, want := range tc.want {
+				gm.Expect(names).To(gm.ContainElement(want), "%s must see %s", tc.who.name, want)
+			}
+			if len(tc.want) == 1 {
+				gm.Expect(names).NotTo(gm.ContainElement(groupBeta), "%s must not see the beta group", tc.who.name)
+			}
+		}
+		_, unboundErr := groups.List(unboundActor.ctx(), &databasev1.GroupRegistryServiceListRequest{})
+		gm.Expect(status.Code(unboundErr)).To(gm.Equal(codes.PermissionDenied),
+			"a principal with no schema:read grant anywhere must be denied Group.List")
+	})
+
+	// R4: a key wait needs every resolved group, a group-kind key takes its scope from the
+	// key name, and the cluster-wide revision wait needs a wildcard schema read. Revision
+	// zero is a real allow case, not a degenerate one.
+	g.It("scopes SchemaBarrier key waits and requires a wildcard read for revision waits", func() {
+		alphaKey := []*schemav1.SchemaKey{{Kind: "group", Name: groupAlpha}}
+		bothKeys := []*schemav1.SchemaKey{
+			{Kind: "group", Name: groupAlpha},
+			{Kind: "measure", Group: groupBeta, Name: measureBeta},
+		}
+
+		applied, appliedErr := barrier.AwaitSchemaApplied(readerAlphaActor.ctx(), &schemav1.AwaitSchemaAppliedRequest{
+			Keys: alphaKey, MinRevisions: []int64{0},
+		})
+		gm.Expect(appliedErr).NotTo(gm.HaveOccurred(), "the alpha reader must await an alpha key")
+		gm.Expect(applied.GetApplied()).To(gm.BeTrue())
+
+		_, mixedErr := barrier.AwaitSchemaApplied(readerAlphaActor.ctx(), &schemav1.AwaitSchemaAppliedRequest{
+			Keys: bothKeys, MinRevisions: []int64{0, 0},
+		})
+		gm.Expect(status.Code(mixedErr)).To(gm.Equal(codes.PermissionDenied),
+			"one forbidden key group must deny the whole wait")
+
+		wildcardApplied, wildcardErr := barrier.AwaitSchemaApplied(readerAllActor.ctx(), &schemav1.AwaitSchemaAppliedRequest{
+			Keys: bothKeys, MinRevisions: []int64{0, 0},
+		})
+		gm.Expect(wildcardErr).NotTo(gm.HaveOccurred(), "a wildcard reader must await both key groups")
+		gm.Expect(wildcardApplied.GetApplied()).To(gm.BeTrue())
+
+		_, deletedErr := barrier.AwaitSchemaDeleted(readerAlphaActor.ctx(), &schemav1.AwaitSchemaDeletedRequest{
+			Keys: []*schemav1.SchemaKey{{Kind: "measure", Group: groupBeta, Name: measureBeta}},
+		})
+		gm.Expect(status.Code(deletedErr)).To(gm.Equal(codes.PermissionDenied),
+			"the alpha reader must be denied a beta deletion wait")
+
+		_, exactRevisionErr := barrier.AwaitRevisionApplied(readerAlphaActor.ctx(), &schemav1.AwaitRevisionAppliedRequest{
+			MinRevision: 0,
+		})
+		gm.Expect(status.Code(exactRevisionErr)).To(gm.Equal(codes.PermissionDenied),
+			"an exact-scope reader must be denied a cluster-wide revision wait")
+
+		revisionApplied, revisionErr := barrier.AwaitRevisionApplied(readerAllActor.ctx(), &schemav1.AwaitRevisionAppliedRequest{
+			MinRevision: 0,
+		})
+		gm.Expect(revisionErr).NotTo(gm.HaveOccurred(), "a wildcard reader must be allowed a revision wait")
+		gm.Expect(revisionApplied.GetApplied()).To(gm.BeTrue())
+	})
+
+	// R4: every bound grpc-gateway route reaches the same decision its gRPC method does. The
+	// gateway maps PermissionDenied to 403, InvalidArgument to 400, and the Basic-auth
+	// middleware answers 401 itself, so 401, 400 and 403 must stay distinguishable.
+	g.It("decides the bound HTTP schema routes exactly as direct gRPC does", func() {
+		alphaPath := "/api/v1/group/schema/" + groupAlpha
+		betaPath := "/api/v1/group/schema/" + groupBeta
+
+		for _, a := range []actor{adminActor, readerAllActor, readerAlphaActor, writerAlphaActor} {
+			gotStatus, body := httpCall(httpAddr, http.MethodGet, alphaPath, a, "")
+			gm.Expect(gotStatus).To(gm.Equal(http.StatusOK), "%s must read the alpha group over HTTP: %s", a.name, body)
+		}
+		for _, a := range []actor{readerAlphaActor, writerAlphaActor} {
+			gotStatus, body := httpCall(httpAddr, http.MethodGet, betaPath, a, "")
+			gm.Expect(gotStatus).To(gm.Equal(http.StatusForbidden), "%s must be denied the beta group over HTTP: %s", a.name, body)
+		}
+		wrongPassword := actor{name: adminActor.name, password: "not-the-password"}
+		gotStatus, _ := httpCall(httpAddr, http.MethodGet, alphaPath, wrongPassword, "")
+		gm.Expect(gotStatus).To(gm.Equal(http.StatusUnauthorized), "bad credentials must stay 401, not 403")
+
+		// Group.List over the gateway is filtered exactly as it is over gRPC, and the body is
+		// inspected because that is where a hidden group would leak.
+		listStatus, listBody := httpCall(httpAddr, http.MethodGet, "/api/v1/group/schema/lists", readerAlphaActor, "")
+		gm.Expect(listStatus).To(gm.Equal(http.StatusOK))
+		gm.Expect(listBody).To(gm.ContainSubstring(groupAlpha))
+		gm.Expect(listBody).NotTo(gm.ContainSubstring(`"name":"`+groupBeta+`"`),
+			"the alpha reader's Group.List body must not name the beta group")
+
+		unboundStatus, _ := httpCall(httpAddr, http.MethodGet, "/api/v1/group/schema/lists", unboundActor, "")
+		gm.Expect(unboundStatus).To(gm.Equal(http.StatusForbidden), "an unbound principal must get 403 from Group.List")
+
+		// A registry read, a registry list and a registry write, each over its bound route.
+		measureGetStatus, _ := httpCall(httpAddr, http.MethodGet,
+			fmt.Sprintf("/api/v1/measure/schema/%s/%s", groupAlpha, measureAlpha), readerAlphaActor, "")
+		gm.Expect(measureGetStatus).To(gm.Equal(http.StatusOK), "the alpha reader must get an alpha measure over HTTP")
+
+		measureBetaStatus, _ := httpCall(httpAddr, http.MethodGet,
+			fmt.Sprintf("/api/v1/measure/schema/%s/%s", groupBeta, measureBeta), readerAlphaActor, "")
+		gm.Expect(measureBetaStatus).To(gm.Equal(http.StatusForbidden), "the alpha reader must be denied a beta measure over HTTP")
+
+		measureListStatus, _ := httpCall(httpAddr, http.MethodGet,
+			"/api/v1/measure/schema/lists/"+groupBeta, readerAlphaActor, "")
+		gm.Expect(measureListStatus).To(gm.Equal(http.StatusForbidden), "the alpha reader must be denied a beta measure list over HTTP")
+
+		createBody := fmt.Sprintf(
+			`{"measure":{"metadata":{"group":%q,"name":"http_marker"},"entity":{"tagNames":["id"]},`+
+				`"tagFamilies":[{"name":"default","tags":[{"name":"id","type":"TAG_TYPE_STRING"}]}],`+
+				`"fields":[{"name":"value","fieldType":"FIELD_TYPE_INT",`+
+				`"encodingMethod":"ENCODING_METHOD_GORILLA","compressionMethod":"COMPRESSION_METHOD_ZSTD"}]}}`,
+			groupBeta)
+		createStatus, createBodyOut := httpCall(httpAddr, http.MethodPost, "/api/v1/measure/schema", writerAlphaActor, createBody)
+		gm.Expect(createStatus).To(gm.Equal(http.StatusForbidden),
+			"the alpha writer must be denied a beta measure create over HTTP: %s", createBodyOut)
+
+		absent, absentErr := measures.Exist(adminActor.ctx(), &databasev1.MeasureRegistryServiceExistRequest{
+			Metadata: &commonv1.Metadata{Group: groupBeta, Name: "http_marker"},
+		})
+		gm.Expect(absentErr).NotTo(gm.HaveOccurred())
+		gm.Expect(absent.GetHasMeasure()).To(gm.BeFalse(), "the denied HTTP create must have written nothing")
+
+		deleteStatus, _ := httpCall(httpAddr, http.MethodDelete,
+			fmt.Sprintf("/api/v1/measure/schema/%s/%s", groupBeta, measureBeta), writerAlphaActor, "")
+		gm.Expect(deleteStatus).To(gm.Equal(http.StatusForbidden), "the alpha writer must be denied a beta measure delete over HTTP")
+
+		stillThere, stillThereErr := measures.Exist(adminActor.ctx(), &databasev1.MeasureRegistryServiceExistRequest{
+			Metadata: &commonv1.Metadata{Group: groupBeta, Name: measureBeta},
+		})
+		gm.Expect(stillThereErr).NotTo(gm.HaveOccurred())
+		gm.Expect(stillThere.GetHasMeasure()).To(gm.BeTrue(), "the denied HTTP delete must have left the measure in place")
+	})
+
+	// R6: activating the schema families must not activate a data one. Every data method
+	// stays fail-closed for the global administrator, which is what keeps W-PR3's boundary
+	// intact and provable from outside.
+	g.It("leaves every data method fail-closed", func() {
+		_, queryErr := measurev1.NewMeasureServiceClient(conn).Query(adminActor.ctx(), &measurev1.QueryRequest{
+			Groups: []string{groupAlpha},
+			Name:   measureAlpha,
+		})
+		gm.Expect(status.Code(queryErr)).To(gm.Equal(codes.PermissionDenied),
+			"a data query must stay fail-closed for the administrator until W-PR3")
+
+		queryStatus, _ := httpCall(httpAddr, http.MethodPost, "/api/v1/measure/data", adminActor,
+			fmt.Sprintf(`{"groups":[%q],"name":%q}`, groupAlpha, measureAlpha))
+		gm.Expect(queryStatus).To(gm.Equal(http.StatusForbidden),
+			"a data query must stay fail-closed over the bound HTTP route too")
+	})
+})

--- a/test/integration/standalone/other/rbac_schema/rbac_schema_test.go
+++ b/test/integration/standalone/other/rbac_schema/rbac_schema_test.go
@@ -86,6 +86,12 @@ const (
 	groupGamma   = "gamma"
 	measureAlpha = "alpha_marker"
 	measureBeta  = "beta_marker"
+	// internalTopNResult is provisioned by the measure subsystem itself in every measure
+	// group, exactly as test/cases/schema/clients.go already accounts for. It is not a
+	// resource this fixture created, and authorization is a group decision rather than a
+	// resource filter, so a list assertion names the fixture's own measures instead of
+	// carrying an off-by-one for it.
+	internalTopNResult = "_top_n_result"
 )
 
 type actor struct {
@@ -137,6 +143,19 @@ func measureSchema(group, name string) *databasev1.Measure {
 			CompressionMethod: databasev1.CompressionMethod_COMPRESSION_METHOD_ZSTD,
 		}},
 	}
+}
+
+// userMeasureNames names the measures a caller created, dropping the auto-provisioned TopN
+// result entry.
+func userMeasureNames(listed []*databasev1.Measure) []string {
+	names := make([]string, 0, len(listed))
+	for _, entry := range listed {
+		if entry.GetMetadata().GetName() == internalTopNResult {
+			continue
+		}
+		names = append(names, entry.GetMetadata().GetName())
+	}
+	return names
 }
 
 // httpCall issues one grpc-gateway request with Basic credentials and returns the status code
@@ -267,8 +286,13 @@ var _ = g.Describe("rbac-schema group-scoped schema authorization through the re
 		// metadata group, and the alpha reader denied both in beta.
 		listAlpha, listAlphaErr := measures.List(readerAlphaActor.ctx(), &databasev1.MeasureRegistryServiceListRequest{Group: groupAlpha})
 		gm.Expect(listAlphaErr).NotTo(gm.HaveOccurred(), "the alpha reader must list alpha measures")
-		gm.Expect(listAlpha.GetMeasure()).To(gm.HaveLen(1))
-		gm.Expect(listAlpha.GetMeasure()[0].GetMetadata().GetName()).To(gm.Equal(measureAlpha))
+		for _, listed := range listAlpha.GetMeasure() {
+			gm.Expect(listed.GetMetadata().GetGroup()).To(gm.Equal(groupAlpha),
+				"a group-scoped list must answer from the requested group only, got %s/%s",
+				listed.GetMetadata().GetGroup(), listed.GetMetadata().GetName())
+		}
+		gm.Expect(userMeasureNames(listAlpha.GetMeasure())).To(gm.ConsistOf(measureAlpha),
+			"the alpha reader's list must be the alpha fixture measure and nothing else the fixture created")
 
 		_, listBetaErr := measures.List(readerAlphaActor.ctx(), &databasev1.MeasureRegistryServiceListRequest{Group: groupBeta})
 		gm.Expect(status.Code(listBetaErr)).To(gm.Equal(codes.PermissionDenied), "the alpha reader must be denied beta measures")


### PR DESCRIPTION
## Why

The previous change gave the liaison a security snapshot, a trusted principal and an
exhaustive method policy table, and used them to authorize the twelve cluster-level methods.
Everything else in the table was classified but left deliberately undecidable: any method
carrying a schema or data permission returned `PermissionDenied` for every caller, the global
administrator included. That was the right way to merge an authorization framework without a
bypass, but it also means an operator who turns RBAC on today cannot manage schema at all.

This change makes the schema half of the API usable, and usable *per group*. A tenant reader
bound to `sw_metric` can read that group's measures, streams, traces, properties, index rules,
index-rule bindings and TopN aggregations, and is refused everything in every other group. A
service account bound to one group can create and evolve the schema it owns without being
granted cluster administration. Group scoping is not deferred: it is what makes a single
BanyanDB cluster safe to share, and it changes the semantics of reads, lists and barrier waits
throughout, so it belongs in the same change as the methods it constrains.

## What it does

Each externally served method is paired with exactly one typed extractor that knows where that
method's request carries its group. Group point reads and deletions carry it as a plain field.
Group creates and updates carry it as `Group.Metadata.Name` — deliberately not as that body's
`Metadata.Group`, so a caller cannot smuggle a write into a group it holds by naming that group
in the wrong field. Registry methods use three structural shapes and no more: the request's own
group for `List`, `Metadata.Group` for point reads and deletions, and the resource body's
`Metadata.Group` for creates and updates. Barrier key waits resolve one scope per key, reading
a `group`-kind key from its name and every other kind from its group.

There is no reflective "find a field called group" rule. BanyanDB request shapes differ far too
much for one, and a rule like that lets a newly added RPC inherit a scope nobody chose. A
coverage test pairs every method with its family instead, so an unclassified or mis-paired
method fails the build rather than quietly picking up a policy.

Two request shapes get special treatment. `Group.List` addresses the whole deployment, so
there is no group to check before the handler runs; it admits any caller holding `schema:read`
somewhere, refuses a caller holding it nowhere, and reduces the response afterwards to the
groups that caller can actually see. The filter is handed the same snapshot the decision was
taken from, so a policy reload landing mid-handler cannot pair one revision's decision with
another revision's visibility. The cluster-wide revision barrier likewise names no group and is
satisfied only by a wildcard `schema:read` grant, since it reports convergence across
everything.

Authorization stays a single decision for both transports. The gRPC interceptor and the
grpc-gateway route bound to the same method go through the same function against the same
table, so there is no second policy to drift and no route that can be reached around. A
request whose group cannot be read from it — absent body, absent metadata, an empty name — is
answered `InvalidArgument` rather than being folded into an authorization outcome, so a caller
that sent something malformed learns that, and learns nothing about what it would otherwise
have been permitted to do.

```mermaid
flowchart TD
    H["HTTP :17913<br/>Basic middleware"] -->|verified identity as metadata| GW[grpc-gateway]
    GW --> AZ
    G["gRPC :17912"] --> AZ

    AZ["Authorization interceptor<br/>one decision for both transports"]
    AZ --> AUTHN{"credentials<br/>verified?"}
    AUTHN -->|no| U401["Unauthenticated / 401"]
    AUTHN -->|yes| POL["look up the method's policy"]

    POL --> ACT{"executor<br/>activated?"}
    ACT -->|"no (data methods)"| D403["PermissionDenied / 403<br/>reason: executor_unavailable"]
    ACT -->|yes| EXT["resolve scopes via the method's<br/>typed extractor family"]

    EXT -->|unresolvable| I400["InvalidArgument / 400<br/>reason: invalid_request"]
    EXT -->|"no group: Group.List"| ANY{"holds schema:read<br/>in any scope?"}
    EXT -->|"one or more groups"| ALL{"holds the permission<br/>for every group?"}

    ANY -->|no| D403
    ALL -->|no| D403
    ALL -->|yes| HND
    ANY -->|yes| HND["handler"]

    HND --> FLT{"response filter<br/>for this policy?"}
    FLT -->|"no"| OUT["reply"]
    FLT -->|"yes: Group.List"| RED["reduce to visible groups<br/>using the request's own snapshot"]
    RED --> OUT
```

Because a decision now precedes every schema handler, a refused create, update or delete cannot
leave anything behind — no metadata write, no deletion task, no tombstone — because the handler
never ran. Group deletion in particular is decided before the dry-run, force and deletion-task
paths are consulted, for every combination of those flags. An unauthorized existence check is
refused rather than answered `false`: `false` would be a fact about a group the caller is not
allowed to see, so authorization is settled before existence is disclosed. Conversely an
authorized request for a group that happens not to exist is allowed through, so the handler
still answers `NotFound` and callers keep the status codes they have always seen.

## Compatibility

A deployment with no auth file, a users-only file, or `rbac.enabled: false` is untouched. Group
scope is never consulted, every schema handler still runs, and `Group.List` returns exactly
what the handler produced — an existing bydbctl or OAP client must not quietly start receiving a
shorter list. Nothing persisted or on the wire changes: every scope is read from protobuf
fields that already exist, so there is no new message, field, on-disk layout or internal
protocol, and a liaison built from this table starts unchanged against an older cluster.

Data methods remain fail-closed, with their bounded `executor_unavailable` reason intact, so
the remaining boundary stays observable from outside rather than resting on a comment. The new
`invalid_request` reason joins the existing closed label set, and the decision counter keeps its
two-valued outcome label and its bounded cardinality: no group name, principal or role name
becomes a metric label as a result of decisions becoming group-scoped.

## Testing

Unit coverage proves the family oracle, extraction across all seven registry families, the
malformed-request table, response filtering including snapshot pinning, and the barrier scope
rules. A standalone suite drives the whole schema lifecycle against a real liaison over
generated gRPC clients and the bound gateway routes, provisioning its fixture as the
administrator and waiting through the protected barrier API rather than sleeping, and re-reading
storage as the administrator so a denied mutation's absence is observed rather than inferred.
The direct standalone deployment case gains a schema stage that repeats the matrix against a
container, including the filtered group list and both barrier scope forms.

Fixes apache/skywalking#14015
