### PR TITLE
canopy: Fix flaky DocList admin action test

### DIFF
--- a/canopy/web/src/query/results/DocList.test.tsx
+++ b/canopy/web/src/query/results/DocList.test.tsx
@@ -116,8 +116,8 @@ describe('DocList', () => {
 
   it('shows Edit/Delete actions for an admin session', async () => {
     await renderDocList(ADMIN);
-    expect(screen.getByTitle('Edit document')).toBeInTheDocument();
-    expect(screen.getByTitle('Delete document')).toBeInTheDocument();
+    expect(await screen.findByTitle('Edit document')).toBeInTheDocument();
+    expect(await screen.findByTitle('Delete document')).toBeInTheDocument();
   });
 
   it('hides Edit/Delete actions for a readonly session', async () => {


### PR DESCRIPTION
## Summary

- Await the role-gated admin actions before asserting that they are rendered in `DocList`.

## Testing

- `cd canopy && npm run -w web test -- src/query/results/DocList.test.tsx` (50 runs)
- `cd canopy && npm run -w web test`
- `make lint`

Flaky-Test: canopy/web/src/query/results/DocList.test.tsx.DocList > shows Edit/Delete actions for an admin session
