### PR TITLE
fix(canopy): enforce readonly role on /monitoring/* proxy

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,4 +13,10 @@ Release Notes.
 
 - Bump canopy and mcp npm dependencies to clear Dependabot CVEs (fast-uri, fastify, qs).
 
+## 0.11.1
+
+### Bug Fixes
+
+- Enforce the Canopy readonly role on the `/monitoring/*` proxy the same way as `/api/*`.
+
 ## 0.11.0

--- a/canopy/server/src/plugins/proxy.ts
+++ b/canopy/server/src/plugins/proxy.ts
@@ -166,8 +166,9 @@ export async function registerProxy(app: FastifyInstance, config: Config): Promi
     await forwardRequest(upstreamBase, upstreamPath, request, reply, config, upstreamAuth);
   });
 
-  // /monitoring/* — forwarded to MONITOR_TARGET with /monitoring prefix STRIPPED
-  app.all('/monitoring/*', { preHandler: [requireAuth] }, async (request, reply) => {
+  // /monitoring/* — forwarded to MONITOR_TARGET with /monitoring prefix STRIPPED.
+  // Same role gate as /api/*: readonly sessions may only use GET/HEAD/OPTIONS.
+  app.all('/monitoring/*', { preHandler: [requireAuth, enforceRole] }, async (request, reply) => {
     const scopedPath = stripBasePath(request.url, config.basePath);
     const stripped = scopedPath.replace(/^\/monitoring/, '');
     await forwardRequest(config.monitorTarget, stripped, request, reply, config, undefined);

--- a/canopy/server/test/bff.test.ts
+++ b/canopy/server/test/bff.test.ts
@@ -505,4 +505,29 @@ describe('/monitoring proxy', () => {
     // Strip /monitoring prefix → sent to monitor.test:2121/metrics → 200
     expect(res.statusCode).toBe(200);
   });
+
+  it('readonly user: POST /monitoring/* returns 403', async () => {
+    const cookie = await loginAs(app, 'reader', 'readpass');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/monitoring/debug/panic',
+      headers: { cookie },
+      payload: {},
+    });
+    expect(res.statusCode).toBe(403);
+    expect(res.json()).toMatchObject({ error: 'forbidden' });
+  });
+
+  it('admin user: POST /monitoring/* is allowed through', async () => {
+    const pool = mockAgent.get('http://monitor.test:2121');
+    pool.intercept({ path: '/debug/panic', method: 'POST' }).reply(200, 'ok');
+    const cookie = await loginAs(app, 'admin', 'adminpass');
+    const res = await app.inject({
+      method: 'POST',
+      url: '/monitoring/debug/panic',
+      headers: { cookie },
+      payload: {},
+    });
+    expect(res.statusCode).toBe(200);
+  });
 });


### PR DESCRIPTION
## Summary
- Apply the same Canopy readonly role gate on `/monitoring/*` that `/api/*` already uses, so readonly sessions can only use GET/HEAD/OPTIONS on the monitoring proxy.
- Add BFF regression coverage for readonly POST rejection and admin POST forwarding.
- Note the fix under 0.11.1 in `CHANGES.md`.

## Test plan
- [x] `npm test --workspace=canopy-server -- --run test/bff.test.ts`
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)