### PR TITLE
Pre setting logging level before flags parse

### DIFF
--- a/banyand/metadata/discovery/dns/dns.go
+++ b/banyand/metadata/discovery/dns/dns.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/rs/zerolog"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
@@ -315,13 +316,34 @@ func (s *Service) retryScheduler(ctx context.Context) {
 	}
 }
 
+// consecutiveDNSFailuresBeforeError is how many queries have to fail in a row, once the init
+// phase is over, before the discovery loop reports the failure at error level.
+const consecutiveDNSFailuresBeforeError = 3
+
+// dnsFailureLevel picks the level a failed DNS query is reported at. Nodes come up in no
+// particular order, so misses while the cluster is still forming are expected and stay at warn
+// however many there are; afterwards the query is retried every interval and recovers on its
+// own, so a single miss is still only a warning and error is kept for a run of them.
+func dnsFailureLevel(inInitPhase bool, consecutiveFailures int) zerolog.Level {
+	if inInitPhase || consecutiveFailures < consecutiveDNSFailuresBeforeError {
+		return zerolog.WarnLevel
+	}
+	return zerolog.ErrorLevel
+}
+
 func (s *Service) discoveryLoop(ctx context.Context) {
 	// add the init phase finish time
 	initPhaseEnd := time.Now().Add(s.initDuration)
+	var consecutiveFailures int
 
 	for {
 		if err := s.queryDNSAndUpdateNodes(ctx); err != nil {
-			s.GetLogger().Warn().Err(err).Msg("failed to query DNS and update nodes")
+			consecutiveFailures++
+			level := dnsFailureLevel(time.Now().Before(initPhaseEnd), consecutiveFailures)
+			s.GetLogger().WithLevel(level).Err(err).Int("consecutive_failures", consecutiveFailures).
+				Msg("failed to query DNS and update nodes")
+		} else {
+			consecutiveFailures = 0
 		}
 
 		// wait for next interval

--- a/banyand/metadata/discovery/dns/dns.go
+++ b/banyand/metadata/discovery/dns/dns.go
@@ -321,7 +321,7 @@ func (s *Service) discoveryLoop(ctx context.Context) {
 
 	for {
 		if err := s.queryDNSAndUpdateNodes(ctx); err != nil {
-			s.GetLogger().Err(err).Msg("failed to query DNS and update nodes")
+			s.GetLogger().Warn().Err(err).Msg("failed to query DNS and update nodes")
 		}
 
 		// wait for next interval

--- a/banyand/metadata/discovery/dns/level_test.go
+++ b/banyand/metadata/discovery/dns/level_test.go
@@ -1,0 +1,65 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dns
+
+import (
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+func TestDNSFailureLevel(t *testing.T) {
+	tests := []struct {
+		name        string
+		failures    int
+		want        zerolog.Level
+		inInitPhase bool
+	}{
+		{name: "first failure in the init phase", inInitPhase: true, failures: 1, want: zerolog.WarnLevel},
+		{
+			name:        "a run of failures in the init phase is still expected",
+			inInitPhase: true,
+			failures:    consecutiveDNSFailuresBeforeError,
+			want:        zerolog.WarnLevel,
+		},
+		{name: "the init phase never escalates", inInitPhase: true, failures: 100, want: zerolog.WarnLevel},
+		{name: "first failure after the init phase", failures: 1, want: zerolog.WarnLevel},
+		{
+			name:     "one short of the threshold",
+			failures: consecutiveDNSFailuresBeforeError - 1,
+			want:     zerolog.WarnLevel,
+		},
+		{
+			name:     "the threshold escalates",
+			failures: consecutiveDNSFailuresBeforeError,
+			want:     zerolog.ErrorLevel,
+		},
+		{
+			name:     "past the threshold stays escalated",
+			failures: consecutiveDNSFailuresBeforeError + 1,
+			want:     zerolog.ErrorLevel,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := dnsFailureLevel(tt.inInitPhase, tt.failures); got != tt.want {
+				t.Errorf("dnsFailureLevel(%t, %d) = %v, want %v", tt.inInitPhase, tt.failures, got, tt.want)
+			}
+		})
+	}
+}

--- a/docs/operation/observability/logging.md
+++ b/docs/operation/observability/logging.md
@@ -11,6 +11,15 @@ Every shipped BanyanDB binary accepts the same four logging flags: the server (`
 | `--logging-modules` | `BYDB_LOGGING_MODULES` |
 | `--logging-levels` | `BYDB_LOGGING_LEVELS` |
 
+A process logs a little before the configured logger exists: the command tree registers its
+flags, and `GOMAXPROCS` is resolved. Those early lines honor `--logging-level` / `--logging-env`
+and their environment variables all the same -- the level is read straight from the command line
+and the environment at that point, with the flag winning over the environment, as everywhere else.
+Only `--logging-modules` and `--logging-levels` are not applied that early; they take effect once
+the logger is initialized. Without any of them the early lines stay at `debug`, which is the
+historical behavior. The ASCII banner is printed directly to the console and is not a log line,
+so no level silences it.
+
 `logging-env` is used to set the logging environment. The default value is `prod`. The logging environment can be set to `dev` for development or `prod` for production. The logging environment affects the log format and output. In the `dev` environment, logs are output in a human-readable format, while in the `prod` environment, logs are output in JSON format.
 
 `logging-modules` and `logging-levels` are used to set the log level for specific modules. The `logging-modules` flag is a comma-separated list of module names, and the `logging-levels` flag is a comma-separated list of log levels corresponding to the module names. The log level for a specific module can be set using these flags. Modules on the server include `storage`, `distributed-query`, `liaison-grpc`, `liaison-http`, `measure`, `stream`, `trace`, `metadata`, `property-schema-registry`, `metrics`, `pprof-service`, `query`, `server-queue-sub`, `server-queue-pub`. The other binaries name theirs differently: `migration` in `banyand-migration`, `fodc-proxy` in the FODC proxy, and `fodc`, `server` and `watchdog` in the FODC agent.

--- a/pkg/logger/setting.go
+++ b/pkg/logger/setting.go
@@ -80,45 +80,62 @@ func defaultLogging() Logging {
 // proper error once it runs.
 func earlyLogging(args []string, getenv func(string) string) Logging {
 	cfg := Logging{Env: "prod", Level: "debug"}
+	// An unset variable and one set to an empty string are the same thing to viper, which
+	// ignores both, so only a non-empty value counts here.
 	if env := getenv(envLoggingEnv); env != "" {
 		cfg.Env = env
 	}
-	cfg.Level = acceptLevel(cfg.Level, getenv(envLoggingLevel))
-	flagEnv, flagLevel := loggingFlagsFromArgs(args)
-	if flagEnv != "" {
-		cfg.Env = flagEnv
+	if level := getenv(envLoggingLevel); level != "" {
+		cfg.Level = acceptLevel(cfg.Level, level)
 	}
-	cfg.Level = acceptLevel(cfg.Level, flagLevel)
+	// A flag, on the other hand, is applied whenever it appears, empty value included: that is
+	// what pflag reports as changed and what config.Load hands to Init later on.
+	flags := loggingFlagsFromArgs(args)
+	if flags.envSet {
+		cfg.Env = flags.env
+	}
+	if flags.levelSet {
+		cfg.Level = acceptLevel(cfg.Level, flags.level)
+	}
 	return cfg
 }
 
-// acceptLevel returns candidate when zerolog can parse it, and current otherwise.
+// acceptLevel returns candidate when zerolog can parse it, and current otherwise. An empty
+// candidate parses to NoLevel, the same value Init would end up with.
 func acceptLevel(current, candidate string) string {
-	if candidate == "" {
-		return current
-	}
 	if _, err := zerolog.ParseLevel(candidate); err != nil {
 		return current
 	}
 	return candidate
 }
 
+// earlyFlags carries the two logging flags scanned out of a raw command line. Each value
+// comes with whether the flag was given at all, because an explicit empty value is a value:
+// pflag reports it as changed and config.Load then keeps the environment out of the way.
+type earlyFlags struct {
+	env      string
+	level    string
+	envSet   bool
+	levelSet bool
+}
+
 // loggingFlagsFromArgs reads the two logging flags out of a raw argument list. It reuses
 // pflag so the values match what cobra resolves later, and tolerates everything else in
 // the list: the flags of the real command are not declared here, and the subcommand name
-// is just a positional argument.
-func loggingFlagsFromArgs(args []string) (env, level string) {
+// is just a positional argument. A malformed command line is the real parser's business to
+// report, so whatever was read before the error is kept.
+func loggingFlagsFromArgs(args []string) earlyFlags {
+	var flags earlyFlags
 	fs := pflag.NewFlagSet("early-logging", pflag.ContinueOnError)
 	fs.ParseErrorsAllowlist.UnknownFlags = true
 	fs.SetOutput(io.Discard)
 	fs.Usage = func() {}
-	fs.StringVar(&env, "logging-env", "", "")
-	fs.StringVar(&level, "logging-level", "", "")
-	if err := fs.Parse(args); err != nil {
-		// A malformed command line is the real parser's business to report.
-		return env, level
-	}
-	return env, level
+	fs.StringVar(&flags.env, "logging-env", "", "")
+	fs.StringVar(&flags.level, "logging-level", "", "")
+	_ = fs.Parse(args)
+	flags.envSet = fs.Changed("logging-env")
+	flags.levelSet = fs.Changed("logging-level")
+	return flags
 }
 
 func (rl *rootLogger) set(cfg Logging) error {

--- a/pkg/logger/setting.go
+++ b/pkg/logger/setting.go
@@ -31,7 +31,15 @@ import (
 	"github.com/spf13/pflag"
 )
 
-const rootName = "ROOT"
+const (
+	rootName = "ROOT"
+
+	// Environment variables bound to the --logging-env and --logging-level flags by
+	// pkg/config. They are read directly here because the root logger has to produce
+	// output before the command tree that owns those flags exists.
+	envLoggingEnv   = "BYDB_LOGGING_ENV"
+	envLoggingLevel = "BYDB_LOGGING_LEVEL"
+)
 
 var root = rootLogger{}
 
@@ -53,14 +61,64 @@ func (rl *rootLogger) setDefault() {
 	if rl.done == 0 {
 		defer atomic.StoreUint32(&rl.done, 1)
 		var err error
-		rl.l, err = getLogger(Logging{
-			Env:   "prod",
-			Level: "debug",
-		})
+		rl.l, err = getLogger(defaultLogging())
 		if err != nil {
 			panic(err)
 		}
 	}
+}
+
+// defaultLogging returns the configuration the root logger falls back to until Init runs.
+func defaultLogging() Logging {
+	return earlyLogging(os.Args[1:], os.Getenv)
+}
+
+// earlyLogging resolves the logging configuration from the sources available before the
+// command tree exists, so that the lines emitted while it is built follow the level the
+// operator asked for. Flags win over the environment, the order config.Load applies later.
+// An unusable level is ignored rather than fatal here, because Init reports it with a
+// proper error once it runs.
+func earlyLogging(args []string, getenv func(string) string) Logging {
+	cfg := Logging{Env: "prod", Level: "debug"}
+	if env := getenv(envLoggingEnv); env != "" {
+		cfg.Env = env
+	}
+	cfg.Level = acceptLevel(cfg.Level, getenv(envLoggingLevel))
+	flagEnv, flagLevel := loggingFlagsFromArgs(args)
+	if flagEnv != "" {
+		cfg.Env = flagEnv
+	}
+	cfg.Level = acceptLevel(cfg.Level, flagLevel)
+	return cfg
+}
+
+// acceptLevel returns candidate when zerolog can parse it, and current otherwise.
+func acceptLevel(current, candidate string) string {
+	if candidate == "" {
+		return current
+	}
+	if _, err := zerolog.ParseLevel(candidate); err != nil {
+		return current
+	}
+	return candidate
+}
+
+// loggingFlagsFromArgs reads the two logging flags out of a raw argument list. It reuses
+// pflag so the values match what cobra resolves later, and tolerates everything else in
+// the list: the flags of the real command are not declared here, and the subcommand name
+// is just a positional argument.
+func loggingFlagsFromArgs(args []string) (env, level string) {
+	fs := pflag.NewFlagSet("early-logging", pflag.ContinueOnError)
+	fs.ParseErrorsAllowlist.UnknownFlags = true
+	fs.SetOutput(io.Discard)
+	fs.Usage = func() {}
+	fs.StringVar(&env, "logging-env", "", "")
+	fs.StringVar(&level, "logging-level", "", "")
+	if err := fs.Parse(args); err != nil {
+		// A malformed command line is the real parser's business to report.
+		return env, level
+	}
+	return env, level
 }
 
 func (rl *rootLogger) set(cfg Logging) error {

--- a/pkg/logger/setting_test.go
+++ b/pkg/logger/setting_test.go
@@ -107,6 +107,26 @@ func TestEarlyLogging(t *testing.T) {
 			wantEnv:   "prod",
 			wantLevel: "debug",
 		},
+		{
+			name:      "an explicitly empty env flag wins over the environment",
+			env:       map[string]string{envLoggingEnv: "dev"},
+			args:      []string{"liaison", "--logging-env="},
+			wantEnv:   "",
+			wantLevel: "debug",
+		},
+		{
+			name:      "an explicitly empty level flag wins over the environment",
+			env:       map[string]string{envLoggingLevel: "error"},
+			args:      []string{"liaison", "--logging-level="},
+			wantEnv:   "prod",
+			wantLevel: "",
+		},
+		{
+			name:      "an empty environment value does not override the default",
+			env:       map[string]string{envLoggingEnv: "", envLoggingLevel: ""},
+			wantEnv:   "prod",
+			wantLevel: "debug",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/logger/setting_test.go
+++ b/pkg/logger/setting_test.go
@@ -1,0 +1,123 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package logger
+
+import "testing"
+
+func TestEarlyLogging(t *testing.T) {
+	tests := []struct {
+		env       map[string]string
+		name      string
+		wantEnv   string
+		wantLevel string
+		args      []string
+	}{
+		{
+			name:      "nothing set keeps the built-in defaults",
+			wantEnv:   "prod",
+			wantLevel: "debug",
+		},
+		{
+			name:      "level from the environment",
+			env:       map[string]string{envLoggingLevel: "error"},
+			wantEnv:   "prod",
+			wantLevel: "error",
+		},
+		{
+			name:      "env from the environment",
+			env:       map[string]string{envLoggingEnv: "dev"},
+			wantEnv:   "dev",
+			wantLevel: "debug",
+		},
+		{
+			name:      "level from a flag joined by an equals sign",
+			args:      []string{"liaison", "--logging-level=error"},
+			wantEnv:   "prod",
+			wantLevel: "error",
+		},
+		{
+			name:      "level from a flag separated by a space",
+			args:      []string{"liaison", "--logging-level", "error"},
+			wantEnv:   "prod",
+			wantLevel: "error",
+		},
+		{
+			name:      "both flags at once",
+			args:      []string{"data", "--logging-env", "dev", "--logging-level", "warn"},
+			wantEnv:   "dev",
+			wantLevel: "warn",
+		},
+		{
+			name:      "a flag wins over the environment",
+			env:       map[string]string{envLoggingLevel: "info", envLoggingEnv: "prod"},
+			args:      []string{"standalone", "--logging-level=error", "--logging-env=dev"},
+			wantEnv:   "dev",
+			wantLevel: "error",
+		},
+		{
+			name:      "the environment still applies to what the flags leave out",
+			env:       map[string]string{envLoggingEnv: "dev"},
+			args:      []string{"standalone", "--logging-level=error"},
+			wantEnv:   "dev",
+			wantLevel: "error",
+		},
+		{
+			name:      "flags of the real command do not disturb the scan",
+			args:      []string{"data", "--grpc-port", "17912", "--logging-level=error", "--node-labels", "type=hot"},
+			wantEnv:   "prod",
+			wantLevel: "error",
+		},
+		{
+			name:      "an unparsable level from a flag falls back",
+			args:      []string{"liaison", "--logging-level=bogus"},
+			wantEnv:   "prod",
+			wantLevel: "debug",
+		},
+		{
+			name:      "an unparsable level from the environment falls back",
+			env:       map[string]string{envLoggingLevel: "bogus"},
+			wantEnv:   "prod",
+			wantLevel: "debug",
+		},
+		{
+			name:      "an unparsable flag does not discard a usable environment value",
+			env:       map[string]string{envLoggingLevel: "error"},
+			args:      []string{"liaison", "--logging-level=bogus"},
+			wantEnv:   "prod",
+			wantLevel: "error",
+		},
+		{
+			name:      "a trailing flag with no value is tolerated",
+			args:      []string{"liaison", "--logging-level"},
+			wantEnv:   "prod",
+			wantLevel: "debug",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			getenv := func(key string) string { return tt.env[key] }
+			cfg := earlyLogging(tt.args, getenv)
+			if cfg.Env != tt.wantEnv {
+				t.Errorf("Env = %q, want %q", cfg.Env, tt.wantEnv)
+			}
+			if cfg.Level != tt.wantLevel {
+				t.Errorf("Level = %q, want %q", cfg.Level, tt.wantLevel)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Current behavior

A deployment that asks for `error` still gets a burst of `debug`, `info` and `warn` on every start. On a cluster running with `BYDB_LOGGING_LEVEL=error` correctly set on all 17 containers, every BanyanDB container still emitted low-level lines, and all of them landed inside the very first second of the process:

```
container              all levels seen                       within the first second
liaison                info 1, debug 33, warn 2, error 22    info 1, debug 33, warn 2
data                   info 1, debug 33, warn 2, error 1     info 1, debug 33, warn 2
fodc-agent             info 1, error 12                      info 1
lifecycle              info 1, debug 3, error 1              info 1, debug 3
backup                 info 1                                info 1
fodc-proxy             info 1, error 121                     info 1
```

After that first second only `error` came through, so the level was in fact applied -- just not to anything logged before it took effect. The 33 `register flags` lines and the `maxprocs` line are the bulk of it, and no combination of flags or environment variables could silence them.

## Why it happens

`logger.Init` runs in the root command's `PersistentPreRunE`, i.e. when the command *executes*. Two things log earlier than that:

- `pkg/run/run.go:150` takes a logger with `logger.GetLogger(g.name)` and `run.go:244` writes `register flags` while the command tree is being *built*, which happens in `NewRoot` before any `PreRun` hook.
- `pkg/cgroups` resolves `GOMAXPROCS` in a package-level `init()`, so it logs before `main` even starts.

`GetLogger` on an uninitialized root falls through to `rootLogger.setDefault()`, and that function hard-coded `Level: "debug"`. Everything above therefore logged at `debug` unconditionally.

## The fix

`setDefault` now resolves its configuration from the two sources that *do* exist that early: the raw command line and the environment.

- `--logging-level` / `--logging-env` are read straight out of `os.Args` with a throwaway `pflag.FlagSet` that has `ParseErrorsAllowlist.UnknownFlags` set, so the real command's flags and the subcommand name are ignored while the parsing of the two flags stays identical to what cobra does later. No hand-rolled string matching, and both `--logging-level=error` and `--logging-level error` work.
- `BYDB_LOGGING_LEVEL` / `BYDB_LOGGING_ENV` are read directly, since `pkg/config` has not run yet.
- A flag wins over the environment, matching the order `config.Load` applies afterwards.
- An unparsable level is ignored and the fallback stays `debug`, rather than being fatal: `setDefault` panics on a logger error, and a typo in a level should not kill the process at its earliest moment with no usable message. `Init` still reports it properly a moment later.
- With nothing set, the configuration is unchanged (`prod` / `debug`).

`--logging-modules` and `--logging-levels` are deliberately *not* applied this early. They must have equal lengths or `getLogger` fails, and a failure here reaches the `panic` in `setDefault`; trading a crash-on-typo for filtering a few dozen startup lines is not worth it. They keep working normally once `Init` runs.

## Verification

Unit tests (`pkg/logger/setting_test.go`, 13 cases) cover both flag spellings, flag-over-environment precedence, unknown flags mixed in, unparsable and empty values, and a trailing flag with no value.

Running `banyand standalone` for 12s on its own ports and data directory:

| configuration | total output | log lines |
|---|---|---|
| nothing set | 137 | **130** (info 66 / debug 33 / warn 30) |
| `--logging-level=error` | 7 | **0** |
| `BYDB_LOGGING_LEVEL=error` | 7 | **0** |

All three runs wrote the same number of files into their data directories, confirming the service started normally rather than failing silently.

The 7 remaining lines are the ASCII banner (`fmt.Print` in `pkg/cmdsetup/root.go`) and the `terminated signal received` line (`fmt.Fprintf` in `pkg/signal/handler.go:62`). Neither goes through the logger, so no level affects them; both are printed once.

- [ ] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Fixes apache/skywalking#<issue number>.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking-banyandb/blob/main/CHANGES.md).
