### PR TITLE
Fix native metrics logging level

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Release Notes.
 
 ### Bug Fixes
 
+- Honor the configured logging level in native observability metrics instead of retaining the pre-initialization debug logger.
 - Fix FODC proxy `/metrics` returning partial data or timing out when concurrent scrapes overlap.
 
 ### Document

--- a/pkg/meter/native/collection.go
+++ b/pkg/meter/native/collection.go
@@ -72,23 +72,23 @@ func (m *MetricCollection) FlushMetrics(ctx context.Context) {
 	m.mu.RLock()
 	if len(m.collectors) == 0 {
 		m.mu.RUnlock()
-		log.Debug().Msg("native metric collection skipped: no collectors registered")
+		nativeLogger().Debug().Msg("native metric collection skipped: no collectors registered")
 		return
 	}
 	collectorsCopy := append([]collector(nil), m.collectors...)
 	m.mu.RUnlock()
 
-	log.Debug().Int("collector_count", len(collectorsCopy)).Msg("native metric collection started")
+	nativeLogger().Debug().Int("collector_count", len(collectorsCopy)).Msg("native metric collection started")
 	publisher := m.pipeline.NewBatchPublisher(writeTimeout)
 	defer publisher.Close()
 	var messages []bus.Message
 	for _, collector := range collectorsCopy {
 		name, metrics := collector.Collect()
 		if len(metrics) == 0 {
-			log.Debug().Str("metric_name", name).Msg("native metric collector returned no metrics")
+			nativeLogger().Debug().Str("metric_name", name).Msg("native metric collector returned no metrics")
 			continue
 		}
-		log.Debug().Str("metric_name", name).Int("metric_count", len(metrics)).Msg("native metric collector collected metrics")
+		nativeLogger().Debug().Str("metric_name", name).Int("metric_count", len(metrics)).Msg("native metric collector collected metrics")
 		for _, metric := range metrics {
 			iwr := m.buildIWR(name, metric)
 			nodeID := ""
@@ -97,7 +97,7 @@ func (m *MetricCollection) FlushMetrics(ctx context.Context) {
 			if m.nodeSelector != nil {
 				nodeID, err = m.nodeSelector.Locate(iwr.GetRequest().GetMetadata().GetGroup(), iwr.GetRequest().GetMetadata().GetName(), uint32(0), uint32(0))
 				if err != nil {
-					log.Error().Err(err).Msg("Failed to locate nodeID")
+					nativeLogger().Error().Err(err).Msg("Failed to locate nodeID")
 				}
 			}
 			messages = append(messages, bus.NewBatchMessageWithNode(bus.MessageID(time.Now().UnixNano()), nodeID, iwr))
@@ -105,10 +105,10 @@ func (m *MetricCollection) FlushMetrics(ctx context.Context) {
 	}
 	_, err := publisher.Publish(ctx, data.TopicMeasureWrite, messages...)
 	if err != nil {
-		log.Error().Err(err).Msg("Failed to publish messages")
+		nativeLogger().Error().Err(err).Msg("Failed to publish messages")
 		return
 	}
-	log.Debug().Int("message_count", len(messages)).Msg("native metric collection published messages")
+	nativeLogger().Debug().Int("message_count", len(messages)).Msg("native metric collection published messages")
 }
 
 func (m *MetricCollection) buildIWR(metricName string, metric metricWithLabelValues) *measurev1.InternalWriteRequest {

--- a/pkg/meter/native/provider.go
+++ b/pkg/meter/native/provider.go
@@ -45,7 +45,9 @@ const (
 	tagHTTPAddress         = "http_address"
 )
 
-var log = logger.GetLogger("observability", "metrics", "system")
+func nativeLogger() *logger.Logger {
+	return logger.GetLogger("observability", "metrics", "system")
+}
 
 // NodeInfo is the struct that contains information used in native observability mode.
 type NodeInfo struct {
@@ -88,7 +90,7 @@ func InitSchema(ctx context.Context, p meter.Provider) {
 	np.initialized.Store(true)
 	groupErr := np.createNativeObservabilityGroup(ctx)
 	if groupErr != nil && !errors.Is(groupErr, schema.ErrGRPCAlreadyExists) {
-		log.Error().Err(groupErr).Msg("Failed to create native observability group")
+		nativeLogger().Error().Err(groupErr).Msg("Failed to create native observability group")
 	}
 	np.mu.Lock()
 	pending := np.pendingMeasures
@@ -97,7 +99,7 @@ func InitSchema(ctx context.Context, p meter.Provider) {
 	for _, pm := range pending {
 		_, measureErr := np.createMeasure(ctx, pm.name, pm.labels...)
 		if measureErr != nil && !errors.Is(measureErr, schema.ErrGRPCAlreadyExists) {
-			log.Error().Err(measureErr).Msgf("Failed to create measure %s", pm.name)
+			nativeLogger().Error().Err(measureErr).Msgf("Failed to create measure %s", pm.name)
 		}
 	}
 }
@@ -135,7 +137,7 @@ func (p *provider) registerOrDefer(name string, labels []string) {
 		defer cancel()
 		_, measureErr := p.createMeasure(ctx, name, labels...)
 		if measureErr != nil && !errors.Is(measureErr, schema.ErrGRPCAlreadyExists) {
-			log.Error().Err(measureErr).Msgf("Failed to create measure %s", name)
+			nativeLogger().Error().Err(measureErr).Msgf("Failed to create measure %s", name)
 		}
 		return
 	}

--- a/pkg/meter/native/provider_test.go
+++ b/pkg/meter/native/provider_test.go
@@ -1,0 +1,33 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package native
+
+import (
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/apache/skywalking-banyandb/pkg/logger"
+)
+
+func TestNativeLoggerHonorsConfiguredLevel(t *testing.T) {
+	t.Cleanup(func() {
+		require.NoError(t, logger.Init(logger.Logging{Env: "prod", Level: "debug"}))
+	})
+	require.NoError(t, logger.Init(logger.Logging{Env: "prod", Level: "info"}))
+	require.Equal(t, zerolog.InfoLevel, nativeLogger().GetLevel())
+}

--- a/pkg/meter/native/vec.go
+++ b/pkg/meter/native/vec.go
@@ -91,7 +91,7 @@ func (n *metricVec) Collect() (string, []metricWithLabelValues) {
 func seriesHash(tagValues []*modelv1.TagValue) []byte {
 	entities, err := pbv1.EntityValues(tagValues).ToEntity()
 	if err != nil {
-		log.Error().Err(err).Msg("Failed to convert tagValues to Entity")
+		nativeLogger().Error().Err(err).Msg("Failed to convert tagValues to Entity")
 	}
 	return pbv1.HashEntity(entities)
 }


### PR DESCRIPTION
### Fix native observability metrics ignoring the configured logging level

- [x] Add a unit test to verify that the fix works.
- [x] Explain briefly why the bug exists and how to fix it.

`pkg/meter/native` created a scoped logger in a package-level variable. That initialization runs before the command persistent pre-run calls `logger.Init`, so the scoped logger permanently retained the fallback DEBUG level. Resolving the scoped logger when emitting a message makes it use the active root configuration and allows `--logging-level=info` to suppress native metrics DEBUG messages.

- [x] Fixes apache/skywalking#14065.
- [x] Update the `CHANGES` log.

Validation:

```text
go test ./pkg/meter/native -count=1
go test -race ./pkg/meter/native -run TestNativeLoggerHonorsConfiguredLevel -count=1
```
