### PR TITLE
fix(bydbql): reject deeply nested WHERE parentheses to prevent stack overflow

### DIFF
--- a/pkg/bydbql/bydbql_test.go
+++ b/pkg/bydbql/bydbql_test.go
@@ -790,6 +790,22 @@ var _ = Describe("Parser", func() {
 					Expect(err).ToNot(BeNil())
 					Expect(grammar).To(BeNil())
 				})
+
+				It("rejects deeply nested WHERE parentheses instead of crashing", func() {
+					nested := "SELECT * FROM STREAM sw IN default WHERE " +
+						strings.Repeat("(", 500000) + "x=1" + strings.Repeat(")", 500000)
+					grammar, err := ParseQuery(nested)
+					Expect(err).ToNot(BeNil())
+					Expect(grammar).To(BeNil())
+				})
+
+				It("still parses WHERE parentheses nested within the accepted limit", func() {
+					nested := "SELECT * FROM STREAM sw IN default WHERE " +
+						strings.Repeat("(", 10) + "x=1" + strings.Repeat(")", 10)
+					grammar, err := ParseQuery(nested)
+					Expect(err).To(BeNil())
+					Expect(grammar).NotTo(BeNil())
+				})
 			})
 		})
 

--- a/pkg/bydbql/parser.go
+++ b/pkg/bydbql/parser.go
@@ -76,8 +76,20 @@ func init() {
 	}
 }
 
+// maxParenDepth bounds the parenthesis nesting ParseQuery accepts. Participle's
+// recursive-descent parser calls back into GrammarOrExpr once per nesting level
+// with no built-in recursion limit, so a query with enough nested parentheses
+// can exhaust the goroutine stack and crash the process via runtime.throw — a
+// fatal error recover() cannot catch. Rejecting excess nesting with a flat,
+// non-recursive scan before the query ever reaches the parser keeps the fix
+// itself immune to the same failure mode.
+const maxParenDepth = 64
+
 // ParseQuery parses a BydbQL query string into a Grammar struct.
 func ParseQuery(query string) (*Grammar, error) {
+	if err := checkParenDepth(query); err != nil {
+		return nil, err
+	}
 	// Parse using Participle
 	grammar, err := particpleParser.ParseString("", query)
 	if err != nil {
@@ -85,4 +97,39 @@ func ParseQuery(query string) (*Grammar, error) {
 	}
 
 	return grammar, nil
+}
+
+// checkParenDepth rejects queries whose parenthesis nesting exceeds maxParenDepth.
+// It skips over quoted string content — which may contain unbalanced or
+// backslash-escaped quote characters, per the String lexer rule — so literal
+// values never distort the depth count.
+func checkParenDepth(query string) error {
+	depth := 0
+	var quote byte
+	for i := 0; i < len(query); i++ {
+		c := query[i]
+		if quote != 0 {
+			switch c {
+			case '\\':
+				i++
+			case quote:
+				quote = 0
+			}
+			continue
+		}
+		switch c {
+		case '\'', '"':
+			quote = c
+		case '(':
+			depth++
+			if depth > maxParenDepth {
+				return fmt.Errorf("syntax error: parenthesis nesting exceeds maximum depth of %d", maxParenDepth)
+			}
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary
- BydbQL's WHERE-clause grammar is mutually recursive through parentheses (`GrammarOrExpr -> GrammarAndExpr -> GrammarPredicate.Paren -> GrammarOrExpr`), and Participle's recursive-descent parser recurses once per `(` with no depth limit.
- A query with enough nested parentheses (well under the 16 MiB message-size cap) exhausts the goroutine stack and crashes the whole process via `runtime.throw`, which `recover()`/the gRPC recovery interceptor cannot catch.
- `ParseQuery` now runs a flat, non-recursive scan over the raw query string (skipping parens inside quoted string literals) and rejects nesting past 64 levels before the query ever reaches the parser. `ParseQuery` is the single choke point every caller goes through (`Prepare`, bydbctl TUI, MCP tool), so one guard covers the gRPC `BydbQLService.Query` path and also bounds the downstream prepare/bind/transform tree-walks, since they only ever see an already depth-capped AST.

## Test plan
- [x] Added regression tests in `pkg/bydbql/bydbql_test.go`: a 500,000-deep nested WHERE clause is rejected; a 10-deep one still parses.
- [x] Reproduced the reporter's original PoC (`cmd/vuln004/main.go`, 500,000 nesting levels, ~1MB payload) against the patched code: process no longer crashes, `ParseQuery` returns an ordinary syntax error instead.
- [x] `go test ./pkg/bydbql/...` passes.
- [x] `make pre-push` passes (generate, lint, license/format check, vuln-check).