### PR TITLE
fix(observability): stop liaison gauge from stealing memory_state schema

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Release Notes.
 - Honor the configured logging level in native observability metrics instead of retaining the pre-initialization debug logger.
 - Fix FODC proxy `/metrics` returning partial data or timing out when concurrent scrapes overlap.
 - Enforce trace query time ranges independently of the sort index, skipping row timestamp checks when the query fully covers a part.
+- Keep system native `memory_state` (with `kind` labels) from being overwritten by the liaison load-shedding gauge so self-observability dashboard queries succeed.
 
 ### Document
 

--- a/banyand/liaison/grpc/metrics.go
+++ b/banyand/liaison/grpc/metrics.go
@@ -49,7 +49,7 @@ type metrics struct {
 
 	memoryLoadSheddingRejections meter.Counter
 	grpcBufferSize               meter.Gauge // Shared gauge for both conn and stream buffer sizes
-	memoryState                  meter.Gauge
+	memoryLoadSheddingState      meter.Gauge
 
 	// Step 2.7 — schema-barrier observability. The three Await* RPCs each
 	// emit one histogram observation per call labeled by `result`
@@ -105,7 +105,7 @@ func newMetrics(factory observability.Factory, rbacFactories ...observability.Fa
 		totalRegistryLatency:               factory.NewCounter("total_registry_latency", "group", "service", "method"),
 		memoryLoadSheddingRejections:       factory.NewCounter("memory_load_shedding_rejections_total", "service"),
 		grpcBufferSize:                     factory.NewGauge("grpc_buffer_size_bytes", "type"),
-		memoryState:                        factory.NewGauge("memory_state"),
+		memoryLoadSheddingState:            factory.NewGauge("memory_load_shedding_state"),
 		schemaAwaitRevisionAppliedDuration: factory.NewHistogram("schema_await_revision_applied_duration_seconds", meter.DefBuckets, "result"),
 		schemaAwaitSchemaAppliedDuration:   factory.NewHistogram("schema_await_schema_applied_duration_seconds", meter.DefBuckets, "result"),
 		schemaAwaitSchemaDeletedDuration:   factory.NewHistogram("schema_await_schema_deleted_duration_seconds", meter.DefBuckets, "result"),
@@ -160,7 +160,9 @@ func (m *metrics) updateBufferSizeMetrics(connSize, streamSize int32) {
 	}
 }
 
-// updateMemoryState updates the memory state metric.
+// updateMemoryState updates the memory load-shedding state metric.
+// Named distinctly from the system host gauge "memory_state" so native
+// self-observability does not collide on the _monitoring measure schema.
 func (m *metrics) updateMemoryState(state int) {
-	m.memoryState.Set(float64(state))
+	m.memoryLoadSheddingState.Set(float64(state))
 }

--- a/test/integration/standalone/observability/measure_helper.go
+++ b/test/integration/standalone/observability/measure_helper.go
@@ -24,6 +24,8 @@ import (
 
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	commonv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/common/v1"
+	databasev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
 	measurev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/measure/v1"
 	modelv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/model/v1"
 	"github.com/apache/skywalking-banyandb/pkg/meter/native"
@@ -33,6 +35,39 @@ import (
 type Point struct {
 	Tags  map[string]string
 	Value float64
+}
+
+var baseEntityTags = []string{"node_type", "node_id", "grpc_address", "http_address"}
+
+// GetObservabilityMeasureTags returns the tag names declared on a _monitoring measure schema.
+func GetObservabilityMeasureTags(metricName string) ([]string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	client := databasev1.NewMeasureRegistryServiceClient(sharedContext.Connection)
+	resp, err := client.Get(ctx, &databasev1.MeasureRegistryServiceGetRequest{
+		Metadata: &commonv1.Metadata{
+			Group: native.ObservabilityGroupName,
+			Name:  metricName,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("get measure schema %s failed: %w", metricName, err)
+	}
+	measure := resp.GetMeasure()
+	if measure == nil {
+		return nil, fmt.Errorf("get measure schema %s returned nil measure", metricName)
+	}
+	var tags []string
+	for _, family := range measure.GetTagFamilies() {
+		for _, tag := range family.GetTags() {
+			if tag.GetName() == "" {
+				continue
+			}
+			tags = append(tags, tag.GetName())
+		}
+	}
+	return tags, nil
 }
 
 // QueryObservabilityMeasure queries a measure from the _monitoring group and returns flattened datapoints.
@@ -56,7 +91,7 @@ func QueryObservabilityMeasure(metricName string, tagNames ...string) ([]Point, 
 			TagFamilies: []*modelv1.TagProjection_TagFamily{
 				{
 					Name: "default",
-					Tags: append([]string{"node_type", "node_id", "grpc_address", "http_address"}, tagNames...),
+					Tags: append(append([]string{}, baseEntityTags...), tagNames...),
 				},
 			},
 		},

--- a/test/integration/standalone/observability/native_metrics_test.go
+++ b/test/integration/standalone/observability/native_metrics_test.go
@@ -18,13 +18,114 @@
 package observability
 
 import (
+	"fmt"
+	"slices"
 	"time"
 
 	g "github.com/onsi/ginkgo/v2"
 	gm "github.com/onsi/gomega"
 )
 
+// System host metrics that native self-observability must publish into _monitoring.
+// Extra tags beyond the shared entity tags must match the dashboard query shape.
+var systemNativeMetrics = []struct {
+	name      string
+	extraTags []string
+}{
+	{name: "up_time"},
+	{name: "cpu_num"},
+	{name: "cpu_state", extraTags: []string{"kind"}},
+	{name: "memory_state", extraTags: []string{"kind"}},
+	{name: "disk", extraTags: []string{"path", "kind"}},
+	{name: "net_state", extraTags: []string{"kind", "name"}},
+}
+
+var (
+	cpuStateKinds    = []string{"user", "system", "idle", "nice", "iowait", "irq", "softirq", "steal"}
+	memoryStateKinds = []string{"used", "total", "used_percent"}
+	diskStateKinds   = []string{"used", "total", "used_percent"}
+)
+
 var _ = g.Describe("Native self-observability metrics in _monitoring group", func() {
+	g.It("declares the expected system measure schemas and label tags", func() {
+		for _, metric := range systemNativeMetrics {
+			expected := append(append([]string{}, baseEntityTags...), metric.extraTags...)
+			gm.Eventually(func() error {
+				tags, err := GetObservabilityMeasureTags(metric.name)
+				if err != nil {
+					return err
+				}
+				for _, want := range expected {
+					if !slices.Contains(tags, want) {
+						return fmt.Errorf("measure %s missing tag %q; have %v", metric.name, want, tags)
+					}
+				}
+				return nil
+			}, 90*time.Second, 2*time.Second).Should(gm.Succeed(),
+				"measure %s must keep entity tags plus %v", metric.name, metric.extraTags)
+		}
+	})
+
+	g.It("keeps liaison load-shedding memory pressure off the system memory_state measure", func() {
+		// The liaison gauge used to register as "memory_state" and stole the
+		// system schema (no kind tag), breaking dashboard queries that project kind.
+		gm.Eventually(func() error {
+			tags, err := GetObservabilityMeasureTags("memory_load_shedding_state")
+			if err != nil {
+				return err
+			}
+			for _, want := range baseEntityTags {
+				if !slices.Contains(tags, want) {
+					return fmt.Errorf("memory_load_shedding_state missing tag %q; have %v", want, tags)
+				}
+			}
+			return nil
+		}, 90*time.Second, 2*time.Second).Should(gm.Succeed(),
+			"liaison load-shedding must use a distinct measure name")
+
+		tags, err := GetObservabilityMeasureTags("memory_state")
+		gm.Expect(err).NotTo(gm.HaveOccurred())
+		gm.Expect(tags).To(gm.ContainElement("kind"),
+			"system memory_state must retain the kind tag after liaison metrics register")
+	})
+
+	g.It("serves dashboard-shaped queries with well-formed label values", func() {
+		gm.Eventually(func() error {
+			if _, err := QueryObservabilityMeasure("up_time"); err != nil {
+				return err
+			}
+			cpuPoints, err := QueryObservabilityMeasure("cpu_state", "kind")
+			if err != nil {
+				return err
+			}
+			if err := requireLabeledSeries(cpuPoints, "kind", cpuStateKinds, true); err != nil {
+				return err
+			}
+			memoryPoints, err := QueryObservabilityMeasure("memory_state", "kind")
+			if err != nil {
+				return err
+			}
+			if err := requireLabeledSeries(memoryPoints, "kind", memoryStateKinds, true); err != nil {
+				return err
+			}
+			diskPoints, err := QueryObservabilityMeasure("disk", "path", "kind")
+			if err != nil {
+				return err
+			}
+			if err := requireLabeledSeries(diskPoints, "kind", diskStateKinds, false); err != nil {
+				return err
+			}
+			if _, err := QueryObservabilityMeasure("cpu_num"); err != nil {
+				return err
+			}
+			// net_state may be empty when the host has no eth*/en* interfaces; schema+query must still succeed.
+			if _, err := QueryObservabilityMeasure("net_state", "kind", "name"); err != nil {
+				return err
+			}
+			return nil
+		}, 90*time.Second, 2*time.Second).Should(gm.Succeed())
+	})
+
 	g.It("collects up_time metric", func() {
 		gm.Eventually(func() (float64, error) {
 			points, err := QueryObservabilityMeasure("up_time")
@@ -70,23 +171,55 @@ var _ = g.Describe("Native self-observability metrics in _monitoring group", fun
 		}, 90*time.Second, 5*time.Second).Should(gm.BeTrue())
 	})
 
-	g.It("collects memory_state metric with basic sanity", func() {
-		// Note: memory_state may be created by liaison without "kind" tag, so we query with base tags only.
-		// Validate that we get at least one datapoint with a positive value (total/used bytes or used_percent).
+	g.It("collects memory_state metric with kind labels", func() {
 		gm.Eventually(func() (bool, error) {
-			points, err := QueryObservabilityMeasure("memory_state")
+			points, err := QueryObservabilityMeasure("memory_state", "kind")
 			if err != nil {
 				return false, err
 			}
 			if len(points) == 0 {
 				return false, nil
 			}
+			seen := map[string]bool{}
 			for _, p := range points {
-				if p.Value > 0 {
-					return true, nil
+				kind, ok := p.Tags["kind"]
+				if !ok || !slices.Contains(memoryStateKinds, kind) {
+					return false, nil
 				}
+				if kind == "used" || kind == "total" {
+					if p.Value <= 0 {
+						return false, nil
+					}
+				}
+				if kind == "used_percent" {
+					if p.Value < 0.0 || p.Value > 1.0 {
+						return false, nil
+					}
+				}
+				seen[kind] = true
 			}
-			return false, nil
+			return seen["used"] && seen["total"] && seen["used_percent"], nil
 		}, 90*time.Second, 5*time.Second).Should(gm.BeTrue())
 	})
 })
+
+func requireLabeledSeries(points []Point, label string, allowed []string, requireData bool) error {
+	if requireData && len(points) == 0 {
+		return fmt.Errorf("expected datapoints with label %q", label)
+	}
+	for _, p := range points {
+		value, ok := p.Tags[label]
+		if !ok || value == "" {
+			return fmt.Errorf("datapoint missing non-empty %q label: tags=%v", label, p.Tags)
+		}
+		if !slices.Contains(allowed, value) {
+			return fmt.Errorf("unexpected %q=%q; allowed=%v tags=%v", label, value, allowed, p.Tags)
+		}
+		for _, entityTag := range baseEntityTags {
+			if p.Tags[entityTag] == "" {
+				return fmt.Errorf("datapoint missing entity tag %q: tags=%v", entityTag, p.Tags)
+			}
+		}
+	}
+	return nil
+}

--- a/test/integration/standalone/observability/native_metrics_test.go
+++ b/test/integration/standalone/observability/native_metrics_test.go
@@ -91,36 +91,36 @@ var _ = g.Describe("Native self-observability metrics in _monitoring group", fun
 
 	g.It("serves dashboard-shaped queries with well-formed label values", func() {
 		gm.Eventually(func() error {
-			if _, err := QueryObservabilityMeasure("up_time"); err != nil {
-				return err
+			if _, upTimeErr := QueryObservabilityMeasure("up_time"); upTimeErr != nil {
+				return upTimeErr
 			}
-			cpuPoints, err := QueryObservabilityMeasure("cpu_state", "kind")
-			if err != nil {
-				return err
+			cpuPoints, cpuErr := QueryObservabilityMeasure("cpu_state", "kind")
+			if cpuErr != nil {
+				return cpuErr
 			}
-			if err := requireLabeledSeries(cpuPoints, "kind", cpuStateKinds, true); err != nil {
-				return err
+			if labelErr := requireLabeledSeries(cpuPoints, "kind", cpuStateKinds, true); labelErr != nil {
+				return labelErr
 			}
-			memoryPoints, err := QueryObservabilityMeasure("memory_state", "kind")
-			if err != nil {
-				return err
+			memoryPoints, memoryErr := QueryObservabilityMeasure("memory_state", "kind")
+			if memoryErr != nil {
+				return memoryErr
 			}
-			if err := requireLabeledSeries(memoryPoints, "kind", memoryStateKinds, true); err != nil {
-				return err
+			if labelErr := requireLabeledSeries(memoryPoints, "kind", memoryStateKinds, true); labelErr != nil {
+				return labelErr
 			}
-			diskPoints, err := QueryObservabilityMeasure("disk", "path", "kind")
-			if err != nil {
-				return err
+			diskPoints, diskErr := QueryObservabilityMeasure("disk", "path", "kind")
+			if diskErr != nil {
+				return diskErr
 			}
-			if err := requireLabeledSeries(diskPoints, "kind", diskStateKinds, false); err != nil {
-				return err
+			if labelErr := requireLabeledSeries(diskPoints, "kind", diskStateKinds, false); labelErr != nil {
+				return labelErr
 			}
-			if _, err := QueryObservabilityMeasure("cpu_num"); err != nil {
-				return err
+			if _, cpuNumErr := QueryObservabilityMeasure("cpu_num"); cpuNumErr != nil {
+				return cpuNumErr
 			}
 			// net_state may be empty when the host has no eth*/en* interfaces; schema+query must still succeed.
-			if _, err := QueryObservabilityMeasure("net_state", "kind", "name"); err != nil {
-				return err
+			if _, netErr := QueryObservabilityMeasure("net_state", "kind", "name"); netErr != nil {
+				return netErr
 			}
 			return nil
 		}, 90*time.Second, 2*time.Second).Should(gm.Succeed())


### PR DESCRIPTION
## Summary
- Rename the liaison load-shedding gauge from `memory_state` to `memory_load_shedding_state` so it no longer collides with the system host `memory_state` measure (which needs the `kind` tag).
- Expand native `_monitoring` integration tests to assert system measure schemas/labels and dashboard-shaped queries (including `memory_state` with `kind`), removing the prior workaround that hid this failure.
- Fixes empty Monitoring dashboard in the old UI when `--observability-modes=native` (see apache/skywalking#14077).

## Test plan
- [x] `make pre-push`
- [x] Integration coverage in `test/integration/standalone/observability`
- [x] Manual old-UI Monitoring screenshot with native mode: node row shows uptime/CPU/memory/disk (not “No data yet”)


Made with [Cursor](https://cursor.com)