### PR TITLE
fix(stream): make syncer error retry cancellable on shutdown with jittered backoff

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Release Notes.
 - Fix FODC proxy `/metrics` returning partial data or timing out when concurrent scrapes overlap.
 - Enforce trace query time ranges independently of the sort index, skipping row timestamp checks when the query fully covers a part.
 - Retry property schema registry initialization indefinitely, logging an error every 10 attempts.
+- Fix un-interruptible sleep on shutdown during stream snapshot sync retry and add jittered backoff.
 
 ### Document
 

--- a/banyand/stream/syncer.go
+++ b/banyand/stream/syncer.go
@@ -20,6 +20,7 @@ package stream
 import (
 	"context"
 	"fmt"
+	"math/rand/v2"
 	"path/filepath"
 	"strconv"
 	"time"
@@ -34,6 +35,25 @@ import (
 
 // PartTypeCore is the type of the core part.
 const PartTypeCore = "core"
+
+const (
+	snapshotSyncRetryDelay  = 2 * time.Second
+	snapshotSyncRetryJitter = 500 * time.Millisecond
+)
+
+func syncRetryDelay() time.Duration {
+	// #nosec G404 -- not security-critical, just for retry jitter
+	return snapshotSyncRetryDelay + time.Duration(rand.Int64N(int64(snapshotSyncRetryJitter)))
+}
+
+func waitSyncRetry(closeNotify <-chan struct{}) bool {
+	select {
+	case <-closeNotify:
+		return true
+	case <-time.After(syncRetryDelay()):
+		return false
+	}
+}
 
 func (tst *tsTable) syncLoop(syncCh chan *syncIntroduction, flusherNotifier watcher.Channel) {
 	defer tst.loopCloser.Done()
@@ -67,8 +87,7 @@ func (tst *tsTable) syncLoop(syncCh chan *syncIntroduction, flusherNotifier watc
 				}
 				tst.l.Logger.Warn().Err(err).Msgf("cannot sync snapshot: %d", curSnapshot.epoch)
 				tst.incTotalSyncLoopErr(1)
-				time.Sleep(2 * time.Second)
-				return false
+				return waitSyncRetry(tst.loopCloser.CloseNotify())
 			}
 			epoch = curSnapshot.epoch
 			firstSync = false

--- a/banyand/stream/syncer_test.go
+++ b/banyand/stream/syncer_test.go
@@ -1,0 +1,50 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package stream
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSyncRetryDelay_BoundedJitter(t *testing.T) {
+	seen := make(map[time.Duration]bool)
+	for i := 0; i < 100; i++ {
+		d := syncRetryDelay()
+		require.GreaterOrEqual(t, d, snapshotSyncRetryDelay, "delay must be >= base delay (2s)")
+		require.Less(t, d, snapshotSyncRetryDelay+snapshotSyncRetryJitter, "delay must be < 2.5s")
+		seen[d] = true
+	}
+	require.Greater(t, len(seen), 1, "jitter must produce variable delays")
+}
+
+func TestWaitSyncRetry_CanceledOnShutdown(t *testing.T) {
+	closeCh := make(chan struct{})
+	// Simulate shutdown signal received
+	close(closeCh)
+
+	start := time.Now()
+	exited := waitSyncRetry(closeCh)
+	elapsed := time.Since(start)
+
+	require.True(t, exited, "waitSyncRetry must return true when closeNotify is closed")
+	// Proves it exits immediately instead of hanging for 2+ seconds
+	require.Less(t, elapsed, 100*time.Millisecond, "waitSyncRetry must return immediately on shutdown")
+}


### PR DESCRIPTION
### What this PR does

1. **Cancellable Shutdown**: Replaces un-interruptible `time.Sleep(2 * time.Second)` in `stream/syncer.go` with a cancellable wait on `closeNotify <-chan struct{}` so process shutdown (SIGTERM / closer) exits immediately instead of hanging for 2 seconds.
2. **Jittered Backoff**: Adds uniform random jitter (`500ms` window via `rand.Int64N`) to the 2s base retry delay to avoid thundering herds across replicas.
3. **Unit Tests**:
   - `TestWaitSyncRetry_CanceledOnShutdown`: Verifies immediate unblocking (< 100ms) upon shutdown signal.
   - `TestSyncRetryDelay_BoundedJitter`: Verifies delay bounds `[2.0s, 2.5s)` and delay variance across 100 iterations in microseconds (zero CI delay).

### Maintainer Feedback & Scope
- **Other Engines**: Note that `banyand/measure` and `banyand/trace` also have the exact same un-cancellable `time.Sleep(2 * time.Second)` in their respective syncer error paths. If this design is approved, I will submit two separate PRs to update `measure` and `trace` as well.
- **Testing Approach**: Currently, `TestSyncRetryDelay_BoundedJitter` tests the bounded jitter math in microseconds to keep CI fast. Would you prefer a real-scenario test that waits for the actual timer (taking 2+ seconds), or is this fast bounded unit test preferred?

- [x] Add a unit test to verify that the fix works.
- [x] Update the `CHANGES` log.