### PR TITLE
fix(metadata): re-fetch discovery nodes before Start during PreRun

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Release Notes.
 - Fix FODC proxy `/metrics` returning partial data or timing out when concurrent scrapes overlap.
 - Enforce trace query time ranges independently of the sort index, skipping row timestamp checks when the query fully covers a part.
 - Retry property schema registry initialization indefinitely, logging an error every 10 attempts.
+- Re-fetch file/DNS discovery nodes that are parked in the retry queue while discovery has not Start()-ed yet, so unbounded PreRun schema-registry retries can recover once peers become reachable without restarting liaison.
 
 ### Document
 

--- a/banyand/metadata/discovery/dns/dns.go
+++ b/banyand/metadata/discovery/dns/dns.go
@@ -59,6 +59,7 @@ type Service struct {
 	lastQueryMutex    sync.RWMutex
 	addressMutex      sync.RWMutex
 	tlsEnabled        bool
+	started           bool
 }
 
 // Config holds configuration for DNS discovery service.
@@ -292,6 +293,10 @@ func (s *Service) Start(ctx context.Context) error {
 		}
 	}
 
+	// mark as started so updateNodeCache can defer unchanged retry-queue
+	// addresses to retryScheduler instead of re-fetching on every list.
+	s.started = true
+
 	go s.discoveryLoop(ctx)
 	go s.retryScheduler(ctx)
 
@@ -507,7 +512,13 @@ func (s *Service) updateNodeCache(ctx context.Context, srvToAddresses map[string
 
 			if !exists {
 				if s.RetryManager.IsInRetry(addr) {
-					continue
+					// After Start, retryScheduler owns recovery. Before Start
+					// (schema-registry init in PreRun), re-fetch synchronously so
+					// unbounded PreRun retries can succeed once peers come up.
+					if s.started {
+						continue
+					}
+					s.RetryManager.RemoveFromRetry(addr)
 				}
 
 				// fetch node metadata from gRPC

--- a/banyand/metadata/discovery/dns/dns_test.go
+++ b/banyand/metadata/discovery/dns/dns_test.go
@@ -449,10 +449,13 @@ var _ = Describe("DNS Discovery Service", func() {
 			// Verify DNS was queried successfully
 			Expect(mockResolver.getCallCount("_grpc._tcp.test.local")).To(Equal(1))
 
-			// Verify no nodes were added to the cache
-			nodes, err := svc.ListNode(ctx, databasev1.Role_ROLE_UNSPECIFIED)
-			Expect(err).NotTo(HaveOccurred())
+			// Verify no nodes were added to the cache. Before Start, ListNode
+			// re-fetches retry-queued addresses and surfaces the same failure.
+			nodes, listErr := svc.ListNode(ctx, databasev1.Role_ROLE_UNSPECIFIED)
+			Expect(listErr).To(HaveOccurred())
+			Expect(listErr.Error()).To(ContainSubstring("failed to get current node"))
 			Expect(nodes).To(BeEmpty())
+			Expect(svc.GetCacheSize()).To(Equal(0))
 		})
 
 		It("should use fallback cache after DNS failure (🎯 critical scenario)", func() {
@@ -515,10 +518,11 @@ var _ = Describe("DNS Discovery Service", func() {
 			mockResolver.setError("_grpc._tcp.zone2.local", fmt.Errorf("zone2 DNS server down"))
 
 			// Call queryDNSAndUpdateNodes again
-			// One DNS fails, so it should fallback to cached addresses (all 4 nodes)
-			// With retry mechanism, nodes already in retry queue are skipped, so no errors returned
+			// One DNS fails, so it should fallback to cached addresses (all 4 nodes).
+			// Before Start, retry-queued addresses are re-fetched synchronously (PreRun
+			// recovery); those gRPC failures surface again as joined errors.
 			queryErr2 := svc.QueryDNSAndUpdateNodes(ctx)
-			Expect(queryErr2).NotTo(HaveOccurred())
+			Expect(queryErr2).To(HaveOccurred())
 
 			// Verify fallback happened - cache still has all 4 nodes from first success
 			cachedAfterFailure := svc.GetLastSuccessfulDNS()

--- a/banyand/metadata/discovery/file/file.go
+++ b/banyand/metadata/discovery/file/file.go
@@ -270,19 +270,23 @@ func (s *Service) updateNodeCache(ctx context.Context, newNodes []NodeConfig) {
 			continue
 		}
 
-		// node in retry queue - check if config changed
+		// node in retry queue - check if config changed or PreRun still owns recovery
 		if s.RetryManager.IsInRetry(nodeConfig.Address) {
 			oldConfig, hasOldConfig := oldAddressToNodeConfig[nodeConfig.Address]
-
-			if hasOldConfig && nodeConfigChanged(oldConfig, nodeConfig) {
+			configChanged := hasOldConfig && nodeConfigChanged(oldConfig, nodeConfig)
+			// After Start, the retry scheduler owns unchanged addresses. Before Start
+			// (schema-registry init in PreRun), that scheduler is not running yet, so
+			// each ListNode must re-fetch synchronously or unbounded PreRun retries
+			// never observe a peer that becomes reachable later.
+			if s.started && !configChanged {
+				continue
+			}
+			if configChanged {
 				s.GetLogger().Info().
 					Str("address", nodeConfig.Address).
 					Msg("Node configuration changed, resetting retry state")
-				s.RetryManager.RemoveFromRetry(nodeConfig.Address)
-			} else {
-				// config unchanged, let retry scheduler handle it
-				continue
 			}
+			s.RetryManager.RemoveFromRetry(nodeConfig.Address)
 		}
 
 		// try to fetch metadata for new node

--- a/banyand/metadata/discovery/file/file_test.go
+++ b/banyand/metadata/discovery/file/file_test.go
@@ -434,6 +434,51 @@ func startMockGRPCServer(t *testing.T) (net.Listener, *grpc.Server, *mockNodeQue
 	return listener, grpcServer, mockServer
 }
 
+func TestListNodeRefetchesBeforeStart(t *testing.T) {
+	ctx := context.Background()
+
+	listener, grpcServer, mockServer := startMockGRPCServer(t)
+	defer grpcServer.Stop()
+	defer listener.Close()
+
+	// Peer is unreachable on the first PreRun-style ListNode (schema registry init).
+	mockServer.setNode(nil)
+
+	address := listener.Addr().String()
+	configFile := createTempConfigFile(t, fmt.Sprintf(`
+nodes:
+  - name: prerun-node
+    grpc_address: %s
+`, address))
+	defer os.Remove(configFile)
+
+	svc, err := NewService(Config{
+		FilePath:             configFile,
+		GRPCTimeout:          testGRPCTimeout,
+		FetchInterval:        testFetchInterval,
+		RetryInitialInterval: 100 * time.Millisecond,
+		RetryMaxInterval:     1 * time.Second,
+		RetryMultiplier:      2.0,
+	})
+	require.NoError(t, err)
+	defer svc.Close()
+
+	// Do not Start — retryScheduler is not running, matching metadata PreRun.
+	nodes, listErr := svc.ListNode(ctx, databasev1.Role_ROLE_UNSPECIFIED)
+	require.NoError(t, listErr)
+	require.Empty(t, nodes)
+	require.True(t, svc.RetryManager.IsInRetry(address), "failed fetch should park the address")
+
+	// Peer becomes reachable while PreRun is still retrying schema-registry init.
+	mockServer.setNode(newTestNode("prerun-node", address))
+
+	nodes, listErr = svc.ListNode(ctx, databasev1.Role_ROLE_UNSPECIFIED)
+	require.NoError(t, listErr)
+	require.Len(t, nodes, 1)
+	assert.Equal(t, "prerun-node", nodes[0].GetMetadata().GetName())
+	require.False(t, svc.RetryManager.IsInRetry(address), "successful pre-Start re-fetch must clear retry state")
+}
+
 func TestBackoffRetryMechanism(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
## Summary
- While file/DNS node discovery has not `Start()`-ed yet, re-fetch retry-queued peer addresses on each `ListNode`/cache update instead of deferring to `retryScheduler`.
- Keeps unbounded property schema-registry init retries (#1344) so liaison does not restart, but allows PreRun to recover once data becomes reachable (fixes FODC Kind liaison Ready hangs after #1344).
- Covers the same PreRun path for DNS discovery; after `Start()`, unchanged retry-queue deferral is unchanged.

## Test plan
- [x] `go test ./banyand/metadata/discovery/file/ ./banyand/metadata/discovery/dns/`
- [x] `make pre-push`
- [ ] Re-run FODC Dashboard Metrics E2E (Kind) on a PR that previously hung on `banyandb-liaison` rollout (e.g. #1334 after merge)


Made with [Cursor](https://cursor.com)