### PR TITLE
fix(measure): make syncer error retry cancellable on shutdown with jittered backoff

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Release Notes.
 - Fix FODC proxy `/metrics` returning partial data or timing out when concurrent scrapes overlap.
 - Enforce trace query time ranges independently of the sort index, skipping row timestamp checks when the query fully covers a part.
 - Retry property schema registry initialization indefinitely, logging an error every 10 attempts.
+- Fix un-interruptible sleep on shutdown during measure snapshot sync retry and add jittered backoff.
 
 ### Document
 

--- a/banyand/measure/syncer.go
+++ b/banyand/measure/syncer.go
@@ -20,6 +20,7 @@ package measure
 import (
 	"context"
 	"fmt"
+	"math/rand/v2"
 	"path/filepath"
 	"strconv"
 	"time"
@@ -35,6 +36,25 @@ import (
 
 // PartTypeCore is the type of the core part.
 const PartTypeCore = "core"
+
+const (
+	snapshotSyncRetryDelay  = 2 * time.Second
+	snapshotSyncRetryJitter = 500 * time.Millisecond
+)
+
+func syncRetryDelay() time.Duration {
+	// #nosec G404 -- not security-critical, just for retry jitter
+	return snapshotSyncRetryDelay + time.Duration(rand.Int64N(int64(snapshotSyncRetryJitter)))
+}
+
+func waitSyncRetry(closeNotify <-chan struct{}) bool {
+	select {
+	case <-closeNotify:
+		return true
+	case <-time.After(syncRetryDelay()):
+		return false
+	}
+}
 
 type syncIntroduction struct {
 	synced  map[uint64]struct{}
@@ -98,8 +118,7 @@ func (tst *tsTable) syncLoop(syncCh chan *syncIntroduction, flusherNotifier watc
 				}
 				tst.l.Error().Err(err).Msgf("cannot sync snapshot: %d", curSnapshot.epoch)
 				tst.incTotalSyncLoopErr(1)
-				time.Sleep(2 * time.Second)
-				return false
+				return waitSyncRetry(tst.loopCloser.CloseNotify())
 			}
 			epoch = curSnapshot.epoch
 			lastTriggerTime = triggerTime

--- a/banyand/measure/syncer_test.go
+++ b/banyand/measure/syncer_test.go
@@ -1,0 +1,63 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package measure
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSyncRetryDelay_BoundedJitter(t *testing.T) {
+	seen := make(map[time.Duration]bool)
+	for i := 0; i < 100; i++ {
+		d := syncRetryDelay()
+		require.GreaterOrEqual(t, d, snapshotSyncRetryDelay, "delay must be >= base delay (2s)")
+		require.Less(t, d, snapshotSyncRetryDelay+snapshotSyncRetryJitter, "delay must be < 2.5s")
+		seen[d] = true
+	}
+	require.Greater(t, len(seen), 1, "jitter must produce variable delays")
+}
+
+func TestWaitSyncRetry_CanceledOnShutdown(t *testing.T) {
+	closeCh := make(chan struct{})
+	// Simulate shutdown signal received
+	close(closeCh)
+
+	start := time.Now()
+	exited := waitSyncRetry(closeCh)
+	elapsed := time.Since(start)
+
+	require.True(t, exited, "waitSyncRetry must return true when closeNotify is closed")
+	// Proves it exits immediately instead of hanging for 2+ seconds
+	require.Less(t, elapsed, 100*time.Millisecond, "waitSyncRetry must return immediately on shutdown")
+}
+
+func TestWaitSyncRetry_Timeout(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping 2s timeout test in short mode")
+	}
+	closeCh := make(chan struct{})
+	start := time.Now()
+	exited := waitSyncRetry(closeCh)
+	elapsed := time.Since(start)
+
+	require.False(t, exited, "waitSyncRetry must return false on timeout")
+	require.GreaterOrEqual(t, elapsed, snapshotSyncRetryDelay, "must wait at least base delay")
+}


### PR DESCRIPTION
Follow-up to #1347 for the `measure` syncer:

- **Cancellable Shutdown**: Replaces blocking `time.Sleep(2s)` in `measure/syncer.go` with `waitSyncRetry` on `closeNotify` so shutdown unblocks immediately.
- **Jittered Backoff**: Adds uniform jitter (`[2.0s, 2.5s)`) to avoid thundering herds.
- **Tests**: Adds unit tests verifying immediate exit on shutdown, timeout path, and jitter bounds.

- [x] Add a unit test to verify that the fix works.
- [x] Update the `CHANGES` log.